### PR TITLE
Add certs back to dockerfile. Fixes #5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,15 @@ WORKDIR /app
 COPY go.mod .
 COPY go.sum .
 
-# Get dependancies - will also be cached if we won't change mod/sum
+# Get dependencies - will also be cached if we won't change mod/sum
 RUN go mod download
 # COPY the source code as the last step
 COPY . .
-
 # Build the binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/app
-FROM scratch
+
+FROM alpine:3.4
+RUN apk add --update --no-cache ca-certificates git
 COPY --from=build-env /go/bin/app /go/bin/app
 ADD ./cloud/default.json /models/default.json
 ADD ./cloud/azure.json /models/azure.json


### PR DESCRIPTION
* When slimming down the container, I got too aggressive and wasn't building with certs.
* It's simpler to just build Alpine and add the certs. It's not an appreciable slowdown in build times/container size vs. building from scratch.