### PR TITLE
panic/crashbackoffloop on misconfigured prometheus

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               memory: "55M"
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
-              value:  #The endpoint should have the form http://<service-name>.<namespace-name>.svc.cluster.local 
+              value: "{{prometheusEndpoint}}"  #The endpoint should have the form http://<service-name>.<namespace-name>.svc.cluster.local 
             - name: CLOUD_PROVIDER_API_KEY
               value: "AIzaSyD29bGxmHAVEOBYtgd8sYM2gM2ekfxQX4U" # The GCP Pricing API requires a key.
           imagePullPolicy: Always

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -12,6 +13,8 @@ import (
 	costAnalyzerCloud "github.com/kubecost/cost-model/cloud"
 	costModel "github.com/kubecost/cost-model/costmodel"
 	prometheusClient "github.com/prometheus/client_golang/api"
+	prometheusAPI "github.com/prometheus/client_golang/api/prometheus/v1"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -121,10 +124,18 @@ func main() {
 	if address == "" {
 		log.Fatal("No address for prometheus set. Aborting.")
 	}
+
 	pc := prometheusClient.Config{
 		Address: address,
 	}
 	promCli, _ := prometheusClient.NewClient(pc)
+
+	api := prometheusAPI.NewAPI(promCli)
+	_, err := api.Config(context.Background())
+	if err != nil {
+		log.Fatal("Failed to use Prometheus at " + address + " Error: " + err.Error())
+	}
+	log.Printf("Checked prometheus endpoint: " + address)
 
 	// Kubernetes API setup
 	kc, err := rest.InClusterConfig()


### PR DESCRIPTION
Fixes #11 

The server will panic when prometheus is misconfigured/doesn't have a valid endpoint. While it doesn't return a nice error to the frontend, it's ok to fail fast in this situation.