### PR TITLE
Spot feed record version fix

### DIFF
--- a/cloud/awsprovider.go
+++ b/cloud/awsprovider.go
@@ -232,6 +232,9 @@ func (aws *AWS) DownloadPricingData() error {
 	aws.ServiceKeyName = c.ServiceKeyName
 	aws.ServiceKeySecret = c.ServiceKeySecret
 
+	if len(aws.SpotDataBucket) != 0 && len(aws.ProjectID) == 0 {
+		return fmt.Errorf("using SpotDataBucket \"%s\" without ProjectID will not end well", aws.SpotDataBucket)
+	}
 	nodeList, err := aws.Clientset.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes two bugs, the first is that the spot feed TSV column `Version` is not in fact the version of the feed but is rather a counter of the number of files created by the spot feed for that hour. The actual feed version shows up as a comment in the first line of the TSV, which we now ingest and check the major version (we can absolutely discuss whether we should be checking the _entire_ version)

The second bug is more-or-less related to the first one: previously the `csvutil` package was not parsing the TSV into the `spotInfo{}` struct due to a misconfiguration of the underlying `encoding/csv` package. By correcting the configuration of `csvReader`, `csvutil` now correctly parses the record into the struct and it removes the need to manually deserialize the `[]string` into the struct which is a lot less painful on the eyes

---

I was also bitten by [a config field change](https://github.com/kubecost/cost-model/commit/ca5c4fbd93e266ade030b4ea91e0b758d432dc6f#diff-3add504165e480da330d29b49e92282fR15) so I took this opportunity to bake in some "hey, watch out" behavior