### PR TITLE
Add AWS Glue/Athena Column Name Formatter

### DIFF
--- a/cloud/awsprovider.go
+++ b/cloud/awsprovider.go
@@ -741,7 +741,7 @@ func (*AWS) GetDisks() ([]byte, error) {
 // https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/run-athena-sql.html
 // It returns a string containing the column name in proper column name format and length.
 func ConvertToGlueColumnFormat(column_name string) string {
-	klog.V(2).Infof("Converting string \"%s\" to proper AWS Glue column name.", column_name)
+	klog.V(5).Infof("Converting string \"%s\" to proper AWS Glue column name.", column_name)
 
 	// An underscore is added in front of uppercase letters
 	capital_underscore := regexp.MustCompile(`[A-Z]`)
@@ -775,7 +775,7 @@ func ConvertToGlueColumnFormat(column_name string) string {
 		final = final[:allowed_col_len]
 	}
 
-	klog.V(2).Infof("Column name being returned: \"%s\". Length: \"%d\".", final, len(final))
+	klog.V(5).Infof("Column name being returned: \"%s\". Length: \"%d\".", final, len(final))
 
 	return final
 }


### PR DESCRIPTION
Added `ConvertToGlueColumnFormat` to `cloud/awsprovider.go` which will convert any arbitrary string into a Glue/Athena compatible format by following the guidelines outlined here: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/run-athena-sql.html.

This change was prompted by invalid column headings being sent to Athena for aggregator "label" as part of the out of cluster cost data being pulled. For users who have labels in the Kubernetes fqdn format, such as `app.kubernetes.io/name`, these are not valid for Athena column headings. When AWS provides billing data to Athena, it modifies column names based on the guidelines outlined in the AWS docs link above, so that the actual column name would appear as `resource_tags_user_kubernetes_label_app_kubernetes_io_name`.

**Previous Query:**
```sql
SELECT   
	CAST(line_item_usage_start_date AS DATE) as start_date,
	resource_tags_user_kubernetes_label_app.kubernetes.io/name,
	line_item_product_code,
	SUM(line_item_blended_cost) as blended_cost
FROM cost_usage_report_new_tags as cost_data
WHERE line_item_usage_start_date BETWEEN date '2019-5-18' AND date '2019-5-19'
GROUP BY 1,2,3
```

**Modified Query:**
```sql
SELECT   
	CAST(line_item_usage_start_date AS DATE) as start_date,
	resource_tags_user_kubernetes_label_app_kubernetes_io_name,
	line_item_product_code,
	SUM(line_item_blended_cost) as blended_cost
FROM cost_usage_report_new_tags as cost_data
WHERE line_item_usage_start_date BETWEEN date '2019-5-18' AND date '2019-5-19'
GROUP BY 1,2,3
```

Tested in `v1.23.0` running on AWS cluster and validated correct queries are being sent to Athena - queries above are taken from test executions before and after change.