### PR TITLE
run image as non-root user to comply with PSP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,5 @@ ADD ./cloud/default.json /models/default.json
 ADD ./cloud/azure.json /models/azure.json
 ADD ./cloud/aws.json /models/aws.json
 ADD ./cloud/gcp.json /models/gcp.json
+USER 1001
 ENTRYPOINT ["/go/bin/app"]


### PR DESCRIPTION
We are using the cost-model deployment along with our own custom PodSecurityPolicies that require images to run as non-root.