### PR TITLE
Add AWS PV Pricing

### DIFF
--- a/cloud/awsprovider.go
+++ b/cloud/awsprovider.go
@@ -140,8 +140,7 @@ const HourlyRateCode = ".6YS6EN2CT7"
 var volTypes = map[string]string{
 	"EBS:VolumeUsage.gp2":     "gp2",
 	"EBS:VolumeUsage":         "standard",
-	"EBS:VolumeUsage.sc1":     "sc1", 
-	"EBS:VolumeP-IOPS.piops":  "io1",
+	"EBS:VolumeUsage.sc1":     "sc1",
 	"EBS:VolumeUsage.st1":     "st1",
 	"EBS:VolumeUsage.piops":   "io1",
 	"gp2":                     "EBS:VolumeUsage.gp2",
@@ -517,9 +516,14 @@ func (aws *AWS) DownloadPricingData() error {
 					aws.ValidPricingKeys[spotKey] = true
 				} else if strings.Contains(product.Attributes.UsageType, "EBS:Volume") {
 					key := locationToRegion[product.Attributes.Location] + "," + product.Attributes.UsageType
+					// UsageTypes may be prefixed with a region code - we're removing this when using
+					// volTypes to keep lookups generic
+					usageTypeRegx := regexp.MustCompile(".*(-|^)(EBS.+)")
+					usageTypeMatch := usageTypeRegx.FindStringSubmatch(product.Attributes.UsageType)
+					usageTypeNoRegion := usageTypeMatch[len(usageTypeMatch)-1]
 					spotKey := key + ",preemptible"
 					pv := &PV{
-						Class:      volTypes[product.Attributes.UsageType],
+						Class:      volTypes[usageTypeNoRegion],
 						Region:     locationToRegion[product.Attributes.Location],
 					}
 					productTerms := &AWSProductTerms{

--- a/cloud/awsprovider.go
+++ b/cloud/awsprovider.go
@@ -575,25 +575,25 @@ func (aws *AWS) DownloadPricingData() error {
 							if strings.Contains(key, "EBS:VolumeP-IOPS.piops") {
 								// If the specific UsageType is the per IO cost used on io1 volumes
 								// we need to add the per IO cost to the io1 PV cost
-								curr_region := strings.Split(key, ",")[0]
+								currRegion := strings.Split(key, ",")[0]
 								cost := offerTerm.PriceDimensions[sku.(string)+OnDemandRateCode+HourlyRateCode].PricePerUnit.USD
 								// UsageType in most regions starts with a region identifier
 								// Here we get that region identifier and then use it as part of
 								// the key for looking up and storing the per IO cost with the io1 price
-								billing_region_code := regionToBillingRegionCode[curr_region]
-								piops_key := ""
-								if billing_region_code != "" {
-									piops_key = curr_region + "," + billing_region_code + "-EBS:VolumeUsage.piops"
+								billingRegionCode := regionToBillingRegionCode[currRegion]
+								piopsKey := ""
+								if billingRegionCode != "" {
+									piopsKey = currRegion + "," + billingRegionCode + "-EBS:VolumeUsage.piops"
 								} else {
-									piops_key = curr_region + "," + "EBS:VolumeUsage.piops"
+									piopsKey = currRegion + "," + "EBS:VolumeUsage.piops"
 								}
 								// Add the per IO cost to the PV object for the io1 volume type
-								aws.Pricing[piops_key].PV.CostPerIO = cost
+								aws.Pricing[piopsKey].PV.CostPerIO = cost
 							} else if strings.Contains(key, "EBS:Volume") {
 								// If volume, we need to get hourly cost and add it to the PV object
 								cost := offerTerm.PriceDimensions[sku.(string)+OnDemandRateCode+HourlyRateCode].PricePerUnit.USD
-								cost_F, _ := strconv.ParseFloat(cost, 64)
-								hourlyPrice := (cost_F * math.Pow10(-9)) / 730
+								costFloat, _ := strconv.ParseFloat(cost, 64)
+								hourlyPrice := (costFloat * math.Pow10(-9)) / 730
 								aws.Pricing[key].PV.Cost = strconv.FormatFloat(hourlyPrice, 'f', -1, 64)
 							}
 						}

--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -44,6 +44,7 @@ type Node struct {
 // The provider will best-effort try to fill out this struct.
 type PV struct {
 	Cost       string            `json:"hourlyCost"`
+	CostPerIO  string            `json:"costPerIOOperation"`
 	Class      string            `json:"storageClass"`
 	Size       string            `json:"size"`
 	Region     string            `json:"region"`


### PR DESCRIPTION
* Pull in cost data from AWS cost json for EBS volume types
* Added a `CostPerIO` field in the `PV` object to handle `io1` volumes which have a per GB price + a per provisioned IO price

Tested in live AWS EKS environment and everything looked good. I am noticing certain cases where the `CostPerIO` field for `io1` volume types is not being filled out - let me know if you have any ideas on that.