### PR TITLE
support custom tag aggregation

### DIFF
--- a/cloud/awsprovider.go
+++ b/cloud/awsprovider.go
@@ -1030,7 +1030,7 @@ func (a *AWS) ExternalAllocations(start string, end string, aggregator string) (
 	if err != nil {
 		return nil, err
 	}
-	aggregator_column_name := "resource_tags_user_kubernetes_" + aggregator
+	aggregator_column_name := "resource_tags_user_" + aggregator
 	aggregator_column_name = ConvertToGlueColumnFormat(aggregator_column_name)
 	query := fmt.Sprintf(`SELECT   
 		CAST(line_item_usage_start_date AS DATE) as start_date,

--- a/cloud/gcpprovider.go
+++ b/cloud/gcpprovider.go
@@ -202,8 +202,8 @@ func (gcp *GCP) ExternalAllocations(start string, end string, aggregator string)
 						FROM %s
 						WHERE usage_start_time >= "%s" AND usage_start_time < "%s")
 						LEFT JOIN UNNEST(labels) as labels
-						ON labels.key = "kubernetes_namespace" OR labels.key = "kubernetes_container" OR labels.key = "kubernetes_deployment" OR labels.key = "kubernetes_pod" OR labels.key = "kubernetes_daemonset"
-				GROUP BY aggregator, environment, service;`, c.BillingDataDataset, start, end) // For example, "billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2"
+						ON labels.key = "%s"
+				GROUP BY aggregator, environment, service;`, c.BillingDataDataset, start, end, aggregator) // For example, "billing_data.gcp_billing_export_v1_01AC9F_74CF1D_5565A2"
 	klog.V(4).Infof("Querying \"%s\" with : %s", c.ProjectID, queryString)
 	return gcp.QuerySQL(queryString)
 }

--- a/costmodel/router.go
+++ b/costmodel/router.go
@@ -466,8 +466,14 @@ func (a *Accesses) OutofClusterCosts(w http.ResponseWriter, r *http.Request, ps 
 	start := r.URL.Query().Get("start")
 	end := r.URL.Query().Get("end")
 	aggregator := r.URL.Query().Get("aggregator")
-
-	data, err := a.Cloud.ExternalAllocations(start, end, aggregator)
+	customAggregation := r.URL.Query().Get("customAggregation")
+	var data []*costAnalyzerCloud.OutOfClusterAllocation
+	var err error
+	if customAggregation != "" {
+		data, err = a.Cloud.ExternalAllocations(start, end, customAggregation)
+	} else {
+		data, err = a.Cloud.ExternalAllocations(start, end, "kubernetes_"+aggregator)
+	}
 	w.Write(wrapData(data, err))
 }
 


### PR DESCRIPTION
This change allows the out of cluster costs to support aggregation over a custom tag at the API level.