### PR TITLE
Add efficiency scores to aggregate API

### DIFF
--- a/costmodel/aggregations.go
+++ b/costmodel/aggregations.go
@@ -220,7 +220,12 @@ func AggregateCostData(costData map[string]*CostData, field string, subfields []
 			// It is possible to score > 100% efficiency, which is meant to be interpreted as a red flag.
 			// It is not possible to score < 0% efficiency.
 
-			agg.CPUEfficiency = 100.0
+			klog.V(1).Infof("\n\tlen(CPU allocation): %d\n\tlen(CPU requested): %d\n\tlen(CPU used): %d",
+				len(agg.CPUAllocationVectors),
+				len(agg.CPURequestedVectors),
+				len(agg.CPUUsedVectors))
+
+			agg.CPUEfficiency = 1.0
 			CPUIdle := 0.0
 			avgCPUAllocation := totalVectors(agg.CPUAllocationVectors) / float64(len(agg.CPUAllocationVectors))
 			if avgCPUAllocation > 0.0 {
@@ -230,7 +235,12 @@ func AggregateCostData(costData map[string]*CostData, field string, subfields []
 				agg.CPUEfficiency = 1.0 - CPUIdle
 			}
 
-			agg.RAMEfficiency = 100.0
+			klog.V(1).Infof("\n\tlen(RAM allocation): %d\n\tlen(RAM requested): %d\n\tlen(RAM used): %d",
+				len(agg.RAMAllocationVectors),
+				len(agg.RAMRequestedVectors),
+				len(agg.RAMUsedVectors))
+
+			agg.RAMEfficiency = 1.0
 			RAMIdle := 0.0
 			avgRAMAllocation := totalVectors(agg.RAMAllocationVectors) / float64(len(agg.RAMAllocationVectors))
 			if avgRAMAllocation > 0.0 {
@@ -272,6 +282,8 @@ func aggregateDatum(cp cloud.Provider, aggregations map[string]*Aggregation, cos
 		agg.Environment = key
 		aggregations[key] = agg
 	}
+
+	klog.V(1).Infoln(costDatum)
 
 	mergeVectors(cp, costDatum, aggregations[key], rate, discount, idleCoefficient)
 }

--- a/costmodel/aggregations.go
+++ b/costmodel/aggregations.go
@@ -13,7 +13,7 @@ import (
 
 type Aggregation struct {
 	Aggregator          string    `json:"aggregation"`
-	Subfields           []string  `json:"subfields"`
+	Subfields           []string  `json:"subfields,omitempty"`
 	Environment         string    `json:"environment"`
 	Cluster             string    `json:"cluster,omitempty"`
 	CPUAllocationVector []*Vector `json:"-"`
@@ -259,7 +259,9 @@ func aggregateDatum(cp cloud.Provider, aggregations map[string]*Aggregation, cos
 	if _, ok := aggregations[key]; !ok {
 		agg := &Aggregation{}
 		agg.Aggregator = field
-		agg.Subfields = subfields
+		if len(subfields) > 0 {
+			agg.Subfields = subfields
+		}
 		agg.Environment = key
 		aggregations[key] = agg
 	}

--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -74,9 +74,9 @@ type CostData struct {
 	Jobs            []string                     `json:"jobs,omitempty"`
 	RAMReq          []*Vector                    `json:"ramreq,omitempty"`
 	RAMUsed         []*Vector                    `json:"ramused,omitempty"`
+	RAMAllocation   []*Vector                    `json:"ramallocated,omitempty"`
 	CPUReq          []*Vector                    `json:"cpureq,omitempty"`
 	CPUUsed         []*Vector                    `json:"cpuused,omitempty"`
-	RAMAllocation   []*Vector                    `json:"ramallocated,omitempty"`
 	CPUAllocation   []*Vector                    `json:"cpuallocated,omitempty"`
 	GPUReq          []*Vector                    `json:"gpureq,omitempty"`
 	PVCData         []*PersistentVolumeClaimData `json:"pvcData,omitempty"`
@@ -1873,7 +1873,7 @@ func QueryRange(cli prometheusClient.Client, query string, start, end time.Time,
 		klog.V(3).Infof("%s", w)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("%s Error %s fetching query %s", resp.StatusCode, err.Error(), query)
+		return nil, fmt.Errorf("%d Error %s fetching query %s", resp.StatusCode, err.Error(), query)
 	}
 	var toReturn interface{}
 	err = json.Unmarshal(body, &toReturn)
@@ -1903,7 +1903,7 @@ func Query(cli prometheusClient.Client, query string) (interface{}, error) {
 			return nil, fmt.Errorf("Error %s fetching query %s", err.Error(), query)
 		}
 
-		return nil, fmt.Errorf("%s Error %s fetching query %s", resp.StatusCode, err.Error(), query)
+		return nil, fmt.Errorf("%d Error %s fetching query %s", resp.StatusCode, err.Error(), query)
 	}
 	var toReturn interface{}
 	err = json.Unmarshal(body, &toReturn)

--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -86,6 +86,13 @@ type CostData struct {
 	ClusterID       string                       `json:"clusterId"`
 }
 
+func (cd *CostData) String() string {
+	return fmt.Sprintf("\n\tName: %s; PodName: %s, NodeName: %s\n\tNamespace: %s\n\tDeployments: %s\n\tServices: %s\n\tCPU (req, used, alloc): %d, %d, %d\n\tRAM (req, used, alloc): %d, %d, %d",
+		cd.Name, cd.PodName, cd.NodeName, cd.Namespace, strings.Join(cd.Deployments, ", "), strings.Join(cd.Services, ", "),
+		len(cd.CPUReq), len(cd.CPUUsed), len(cd.CPUAllocation),
+		len(cd.RAMReq), len(cd.RAMUsed), len(cd.RAMAllocation))
+}
+
 type Vector struct {
 	Timestamp float64 `json:"timestamp"`
 	Value     float64 `json:"value"`

--- a/costmodel/router.go
+++ b/costmodel/router.go
@@ -275,7 +275,10 @@ func (a *Accesses) AggregateCostModel(w http.ResponseWriter, r *http.Request, ps
 
 	// timeSeries == true maintains the time series dimension of the data,
 	// which by default gets summed over the entire interval
-	timeSeries := r.URL.Query().Get("timeSeries") == "true"
+	includeTimeSeries := r.URL.Query().Get("timeSeries") == "true"
+
+	// efficiency == true aggregates and returns usage and efficiency data
+	includeEfficiency := r.URL.Query().Get("efficiency") == "true"
 
 	// disableCache, if set to "true", tells this function to recompute and
 	// cache the requested data
@@ -380,7 +383,7 @@ func (a *Accesses) AggregateCostModel(w http.ResponseWriter, r *http.Request, ps
 
 	// parametrize cache key by all request parameters
 	aggKey := fmt.Sprintf("aggregate:%s:%s:%s:%s:%s:%s:%s:%t:%t",
-		window, offset, namespace, cluster, field, strings.Join(subfields, ","), rate, timeSeries, allocateIdle)
+		window, offset, namespace, cluster, field, strings.Join(subfields, ","), rate, includeTimeSeries, allocateIdle)
 
 	// check the cache for aggregated response; if cache is hit and not disabled, return response
 	if result, found := a.Cache.Get(aggKey); found && !disableCache {
@@ -457,7 +460,8 @@ func (a *Accesses) AggregateCostModel(w http.ResponseWriter, r *http.Request, ps
 		DataCount:          dataCount,
 		Discount:           discount,
 		IdleCoefficient:    idleCoefficient,
-		IncludeTimeSeries:  timeSeries,
+		IncludeEfficiency:  includeEfficiency,
+		IncludeTimeSeries:  includeTimeSeries,
 		Rate:               rate,
 		SharedResourceInfo: sr,
 	}

--- a/costmodel/router.go
+++ b/costmodel/router.go
@@ -382,8 +382,8 @@ func (a *Accesses) AggregateCostModel(w http.ResponseWriter, r *http.Request, ps
 	}
 
 	// parametrize cache key by all request parameters
-	aggKey := fmt.Sprintf("aggregate:%s:%s:%s:%s:%s:%s:%s:%t:%t",
-		window, offset, namespace, cluster, field, strings.Join(subfields, ","), rate, includeTimeSeries, allocateIdle)
+	aggKey := fmt.Sprintf("aggregate:%s:%s:%s:%s:%s:%s:%s:%t:%t:%t",
+		window, offset, namespace, cluster, field, strings.Join(subfields, ","), rate, allocateIdle, includeTimeSeries, includeEfficiency)
 
 	// check the cache for aggregated response; if cache is hit and not disabled, return response
 	if result, found := a.Cache.Get(aggKey); found && !disableCache {

--- a/costmodel/router.go
+++ b/costmodel/router.go
@@ -265,13 +265,18 @@ func (a *Accesses) AggregateCostModel(w http.ResponseWriter, r *http.Request, ps
 	namespace := r.URL.Query().Get("namespace")
 	cluster := r.URL.Query().Get("cluster")
 	field := r.URL.Query().Get("aggregation")
-	subfields := strings.Split(r.URL.Query().Get("aggregationSubfield"), ",")
+	subfieldStr := r.URL.Query().Get("aggregationSubfield")
 	rate := r.URL.Query().Get("rate")
 	allocateIdle := r.URL.Query().Get("allocateIdle") == "true"
 	sharedNamespaces := r.URL.Query().Get("sharedNamespaces")
 	sharedLabelNames := r.URL.Query().Get("sharedLabelNames")
 	sharedLabelValues := r.URL.Query().Get("sharedLabelValues")
 	remote := r.URL.Query().Get("remote")
+
+	subfields := []string{}
+	if len(subfieldStr) > 0 {
+		subfields = strings.Split(r.URL.Query().Get("aggregationSubfield"), ",")
+	}
 
 	// timeSeries == true maintains the time series dimension of the data,
 	// which by default gets summed over the entire interval

--- a/test/aggregation_test.go
+++ b/test/aggregation_test.go
@@ -104,13 +104,10 @@ func TestAggregation(t *testing.T) {
 	costData["test1,foo,nginx,testnode"] = cd1
 	costData["test1,bar,nginx,testnode"] = cd2
 
-	dataCount := int64(1)
-
 	field := "namespace"
 	subfields := []string{""}
-	rate := ""
 
-	agg := costModel.AggregateCostData(cp, costData, dataCount, field, subfields, rate, false, 0.0, 1.0, nil)
+	agg := costModel.AggregateCostData(costData, field, subfields, cp, nil)
 	log.Printf("agg: %+v", agg["test1"])
 	assert.Equal(t, agg["test1"].TotalCost, 8.0)
 }

--- a/test/historical_pod_test.go
+++ b/test/historical_pod_test.go
@@ -232,7 +232,7 @@ func TestPodUpDown(t *testing.T) {
 		panic(err)
 	}
 
-	agg := costModel.AggregateCostData(provider, data, 1, "namespace", []string{""}, "", false, 0.0, 1.0, nil)
+	agg := costModel.AggregateCostData(data, "namespace", []string{""}, provider, nil)
 	_, ok := agg["test"]
 	assert.Assert(t, ok)
 
@@ -241,11 +241,11 @@ func TestPodUpDown(t *testing.T) {
 		panic(err)
 	}
 
-	agg2 := costModel.AggregateCostData(provider, data2, 1, "namespace", []string{""}, "", false, 0.0, 1.0, nil)
+	agg2 := costModel.AggregateCostData(data2, "namespace", []string{""}, provider, nil)
 	_, ok2 := agg2["test"]
 	assert.Assert(t, ok2)
 
-	agg3 := costModel.AggregateCostData(provider, data, 1, "label", []string{"testaggregation"}, "", false, 0.0, 1.0, nil)
+	agg3 := costModel.AggregateCostData(data, "label", []string{"testaggregation"}, provider, nil)
 	_, ok3 := agg3["foo"]
 	assert.Assert(t, ok3)
 }

--- a/test/remote_cluster_test.go
+++ b/test/remote_cluster_test.go
@@ -68,8 +68,8 @@ func TestClusterConvergence(t *testing.T) {
 		panic(err)
 	}
 
-	agg := costModel.AggregateCostData(provider, data, 1, "namespace", []string{""}, "", false, 0.0, 1.0, nil)
-	agg2 := costModel.AggregateCostData(provider, data2, 1, "namespace", []string{""}, "", false, 0.0, 1.0, nil)
+	agg := costModel.AggregateCostData(data, "namespace", []string{""}, provider, nil)
+	agg2 := costModel.AggregateCostData(data2, "namespace", []string{""}, provider, nil)
 
 	assert.Equal(t, agg["kubecost"].TotalCost, agg2["kubecost"].TotalCost)
 


### PR DESCRIPTION
If the `efficiency=true` flag is set, add three efficiency scores to aggregated cost data:
- CPU efficiency
- RAM efficiency
- Total efficiency

Also, two small(ish) refactors:
- modify the `AggregateCostData` API to be more friendly to default use, but customizable with a well-documented options struct
- consolidate repeat code, rename vars, and comment code in the `addVectors` helper function so that it's clear it can be used for any two slices of Vectors (not just `req` and `used`)
