### PR TITLE
Flush cache when custom pricing changes

### DIFF
--- a/costmodel/router.go
+++ b/costmodel/router.go
@@ -336,8 +336,8 @@ func (a *Accesses) CustomPricingHasChanged() bool {
 	// describe parameters by which we determine whether or not custom
 	// pricing settings have changed
 	encodeCustomPricing := func(cp *costAnalyzerCloud.CustomPricing) string {
-		return fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s", cp.CustomPricesEnabled, cp.CPU, cp.SpotCPU,
-			cp.RAM, cp.SpotRAM, cp.GPU, cp.Storage)
+		return fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s:%s", cp.CustomPricesEnabled, cp.CPU, cp.SpotCPU,
+			cp.RAM, cp.SpotRAM, cp.GPU, cp.Storage, cp.CurrencyCode)
 	}
 
 	// compare cached custom pricing parameters with current values


### PR DESCRIPTION
This includes turning custom pricing on/off and changing any of the following settings:
- CPU
- SpotCPU
- RAM
- SpotRAM
- GPU
- Storage