### PR TITLE
Performance Improvements

### DIFF
--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -1335,83 +1335,127 @@ func (cm *CostModel) ComputeCostDataRange(cli prometheusClient.Client, clientset
 	var promErr error
 	var resultRAMRequests interface{}
 	go func() {
-		resultRAMRequests, promErr = QueryRange(cli, queryRAMRequests, start, end, window)
+		defer measureTime(time.Now(), queryRAMRequests)
 		defer wg.Done()
+
+		resultRAMRequests, promErr = QueryRange(cli, queryRAMRequests, start, end, window)
 	}()
 	var resultRAMUsage interface{}
 	go func() {
-		resultRAMUsage, promErr = QueryRange(cli, queryRAMUsage, start, end, window)
+		defer measureTime(time.Now(), queryRAMUsage)
 		defer wg.Done()
+
+		resultRAMUsage, promErr = QueryRange(cli, queryRAMUsage, start, end, window)
 	}()
 	var resultCPURequests interface{}
 	go func() {
-		resultCPURequests, promErr = QueryRange(cli, queryCPURequests, start, end, window)
+		defer measureTime(time.Now(), queryCPURequests)
 		defer wg.Done()
+
+		resultCPURequests, promErr = QueryRange(cli, queryCPURequests, start, end, window)
 	}()
 	var resultCPUUsage interface{}
 	go func() {
-		resultCPUUsage, promErr = QueryRange(cli, queryCPUUsage, start, end, window)
+		defer measureTime(time.Now(), queryCPUUsage)
 		defer wg.Done()
+
+		resultCPUUsage, promErr = QueryRange(cli, queryCPUUsage, start, end, window)
 	}()
 	var resultGPURequests interface{}
 	go func() {
-		resultGPURequests, promErr = QueryRange(cli, queryGPURequests, start, end, window)
+		defer measureTime(time.Now(), queryGPURequests)
 		defer wg.Done()
+
+		resultGPURequests, promErr = QueryRange(cli, queryGPURequests, start, end, window)
 	}()
 	var resultPVRequests interface{}
 	go func() {
-		resultPVRequests, promErr = QueryRange(cli, queryPVRequests, start, end, window)
+		defer measureTime(time.Now(), queryPVRequests)
 		defer wg.Done()
+
+		resultPVRequests, promErr = QueryRange(cli, queryPVRequests, start, end, window)
 	}()
 	var resultNetZoneRequests interface{}
 	go func() {
-		resultNetZoneRequests, promErr = QueryRange(cli, queryNetZoneRequests, start, end, window)
+		defer measureTime(time.Now(), queryNetZoneRequests)
 		defer wg.Done()
+
+		resultNetZoneRequests, promErr = QueryRange(cli, queryNetZoneRequests, start, end, window)
 	}()
 	var resultNetRegionRequests interface{}
 	go func() {
-		resultNetRegionRequests, promErr = QueryRange(cli, queryNetRegionRequests, start, end, window)
+		defer measureTime(time.Now(), queryNetRegionRequests)
 		defer wg.Done()
+
+		resultNetRegionRequests, promErr = QueryRange(cli, queryNetRegionRequests, start, end, window)
 	}()
 	var resultNetInternetRequests interface{}
 	go func() {
-		resultNetInternetRequests, promErr = QueryRange(cli, queryNetInternetRequests, start, end, window)
+		defer measureTime(time.Now(), queryNetInternetRequests)
 		defer wg.Done()
+
+		resultNetInternetRequests, promErr = QueryRange(cli, queryNetInternetRequests, start, end, window)
 	}()
 	var pvPodAllocationResults interface{}
 	go func() {
-		pvPodAllocationResults, promErr = QueryRange(cli, fmt.Sprintf(queryPVCAllocation, windowString), start, end, window)
+		pvAllocQuery := fmt.Sprintf(queryPVCAllocation, windowString)
+
+		defer measureTime(time.Now(), pvAllocQuery)
 		defer wg.Done()
+
+		pvPodAllocationResults, promErr = QueryRange(cli, pvAllocQuery, start, end, window)
 	}()
 	var pvCostResults interface{}
 	go func() {
-		pvCostResults, promErr = QueryRange(cli, fmt.Sprintf(queryPVHourlyCost, windowString), start, end, window)
+		pvHourlyCostQuery := fmt.Sprintf(queryPVHourlyCost, windowString)
+
+		defer measureTime(time.Now(), pvHourlyCostQuery)
 		defer wg.Done()
+
+		pvCostResults, promErr = QueryRange(cli, pvHourlyCostQuery, start, end, window)
 	}()
 	var nsLabelsResults interface{}
 	go func() {
-		nsLabelsResults, promErr = QueryRange(cli, fmt.Sprintf(queryNSLabels, windowString), start, end, window)
+		nsLabelQuery := fmt.Sprintf(queryNSLabels, windowString)
+
+		defer measureTime(time.Now(), nsLabelQuery)
 		defer wg.Done()
+
+		nsLabelsResults, promErr = QueryRange(cli, nsLabelQuery, start, end, window)
 	}()
 	var podLabelsResults interface{}
 	go func() {
-		podLabelsResults, promErr = QueryRange(cli, fmt.Sprintf(queryPodLabels, windowString), start, end, window)
+		podLabelQuery := fmt.Sprintf(queryPodLabels, windowString)
+
+		defer measureTime(time.Now(), podLabelQuery)
 		defer wg.Done()
+
+		podLabelsResults, promErr = QueryRange(cli, podLabelQuery, start, end, window)
 	}()
 	var serviceLabelsResults interface{}
 	go func() {
-		serviceLabelsResults, promErr = QueryRange(cli, fmt.Sprintf(queryServiceLabels, windowString), start, end, window)
+		serviceLabelQuery := fmt.Sprintf(queryServiceLabels, windowString)
+
+		defer measureTime(time.Now(), serviceLabelQuery)
 		defer wg.Done()
+
+		serviceLabelsResults, promErr = QueryRange(cli, serviceLabelQuery, start, end, window)
 	}()
 	var deploymentLabelsResults interface{}
 	go func() {
-		deploymentLabelsResults, promErr = QueryRange(cli, fmt.Sprintf(queryDeploymentLabels, windowString), start, end, window)
+		depLabelQuery := fmt.Sprintf(queryDeploymentLabels, windowString)
+
+		defer measureTime(time.Now(), depLabelQuery)
 		defer wg.Done()
+
+		deploymentLabelsResults, promErr = QueryRange(cli, depLabelQuery, start, end, window)
 	}()
 	var normalizationResults interface{}
 	go func() {
-		normalizationResults, promErr = QueryRange(cli, normalization, start, end, window)
+		defer measureTime(time.Now(), normalization)
 		defer wg.Done()
+
+		normalizationResults, promErr = QueryRange(cli, normalization, start, end, window)
 	}()
 
 	podDeploymentsMapping := make(map[string]map[string][]string)
@@ -1438,6 +1482,8 @@ func (cm *CostModel) ComputeCostDataRange(cli prometheusClient.Client, clientset
 	}()
 
 	wg.Wait()
+
+	defer measureTime(time.Now(), "Processing Query Data")
 
 	if promErr != nil {
 		return nil, fmt.Errorf("Error querying prometheus: %s", promErr.Error())
@@ -2560,4 +2606,9 @@ func wrapPrometheusError(qr interface{}) (string, error) {
 	}
 	eStr, ok := e.(string)
 	return eStr, nil
+}
+
+func measureTime(start time.Time, name string) {
+	elapsed := time.Since(start)
+	klog.V(1).Infof("[Profile][%s] %s", elapsed, name)
 }

--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -1333,7 +1333,11 @@ func (cm *CostModel) ComputeCostDataRange(cli prometheusClient.Client, clientset
 		return cm.costDataRange(cli, clientset, cp, startString, endString, windowString, filterNamespace, filterCluster, remoteEnabled)
 	})
 
-	data := result.(map[string]*CostData)
+	data, ok := result.(map[string]*CostData)
+	if !ok {
+		return nil, fmt.Errorf("Failed to cast result as map[string]*CostData")
+	}
+
 	return data, err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/golang/mock v1.2.0
 	github.com/google/martian v2.1.0+incompatible // indirect
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
 	github.com/gophercloud/gophercloud v0.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
@@ -28,7 +29,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529 // indirect
 	golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	google.golang.org/api v0.4.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.0.0-20190913080256-21721929cffa

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPg
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/uuid v0.0.0-20171113160352-8c31c18f31ed/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=


### PR DESCRIPTION
* Remove `findDeletedPodInfo` from ComputeCostDataRange as we are already cleanly processing pod labels, service labels, and deployment labels for "missing" pods. 
* For ComputeCostDataRange, add a singleflight implementation which allows any requests made with similar inputs to rely on a single call rather than multiple concurrent calls. 