### PR TITLE
Refresh Provider data every week

### DIFF
--- a/costmodel/jobs.go
+++ b/costmodel/jobs.go
@@ -1,0 +1,48 @@
+package costmodel
+
+import (
+	"time"
+)
+
+// Basic job that executes on condition checked on Update(). Condition resettable.
+type Job interface {
+	Update() (bool, error)
+	Reset()
+}
+
+// Repeatable job based on time conditions that requires manual updating
+type TimedJob struct {
+	jobFunc  func() error
+	interval time.Duration
+	lastRun  time.Time
+	nextRun  time.Time
+}
+
+// Creates a new timed job to be executed on a specific interval
+func NewTimedJob(interval time.Duration, jobFunc func() error) Job {
+	now := time.Now()
+
+	return &TimedJob{
+		interval: interval,
+		lastRun:  now,
+		nextRun:  now.Add(interval),
+		jobFunc:  jobFunc,
+	}
+}
+
+func (tj *TimedJob) Update() (bool, error) {
+	current := time.Now()
+	if current.After(tj.nextRun) {
+		tj.Reset()
+
+		err := tj.jobFunc()
+		return true, err
+	}
+
+	return false, nil
+}
+
+func (tj *TimedJob) Reset() {
+	tj.lastRun = time.Now()
+	tj.nextRun = tj.lastRun.Add(tj.interval)
+}

--- a/test/historical_pod_test.go
+++ b/test/historical_pod_test.go
@@ -180,7 +180,7 @@ func TestPodUpDown(t *testing.T) {
 		panic(err)
 	}
 
-	vectors, err := costModel.GetContainerMetricVectors(res, false, 0, "cluster-one")
+	vectors, err := costModel.GetContainerMetricVectors(res, false, []*costModel.Vector{&costModel.Vector{Value: 0, Timestamp: 0}}, "cluster-one")
 	if err != nil {
 		panic(err)
 	}

--- a/test/jobs_test.go
+++ b/test/jobs_test.go
@@ -1,0 +1,64 @@
+package costmodel_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubecost/cost-model/costmodel"
+)
+
+func TryWait(wg *sync.WaitGroup, t time.Duration) bool {
+	done := make(chan bool)
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		return true
+	case <-time.After(t):
+		return false
+	}
+}
+
+func TestTimedJob(t *testing.T) {
+	done := make(chan bool)
+	wg := new(sync.WaitGroup)
+	wg.Add(2)
+
+	fiveSecondJob := costmodel.NewTimedJob(5*time.Second, func() error {
+		t.Logf("Completed Five Second Job\n")
+		wg.Done()
+		return nil
+	})
+
+	sevenSecondJob := costmodel.NewTimedJob(7*time.Second, func() error {
+		t.Logf("Completed Seven Second Job\n")
+		wg.Done()
+		return nil
+	})
+
+	// Emulate Run Loop
+	go func() {
+		for {
+			fiveSecondJob.Update()
+			sevenSecondJob.Update()
+
+			select {
+			case <-done:
+				return
+			default:
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}()
+
+	if !TryWait(wg, 10*time.Second) {
+		t.Errorf("Failed to trigger wait group within 10 seconds. Test failed")
+		return
+	}
+
+	close(done)
+}


### PR DESCRIPTION
This is somewhat over architected for what I ended up with, but due to some inconsistencies with lack of etags on GCP responses, I've punted for now and just added this directly to the run loop. 

* Does it make sense to add a private reference to Accesses so we can call `Reset()` if the data is force reloaded?
* Should we expose a configuration value? 