### PR TITLE
Fix ParseDuration bug and improve error messaging

### DIFF
--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -1526,7 +1526,8 @@ func (cm *CostModel) costDataRange(cli prometheusClient.Client, clientset kubern
 
 	normalizationValue, err := getNormalizations(normalizationResults)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing normalization values: " + err.Error())
+		return nil, fmt.Errorf("error computing normalization for start=%s, end=%s, window=%s: %s",
+			start, end, window, err.Error())
 	}
 
 	nodes, err := getNodeCost(cm.Cache, cp)
@@ -2327,7 +2328,7 @@ func getNormalizations(qr interface{}) ([]*Vector, error) {
 		}
 		return vectors, nil
 	}
-	return nil, fmt.Errorf("Normalization data is empty, kube-state-metrics or node-exporter may not be running")
+	return nil, fmt.Errorf("normalization data is empty: time window may be invalid or kube-state-metrics or node-exporter may not be running")
 }
 
 //todo: don't cast, implement unmarshaler interface

--- a/costmodel/router.go
+++ b/costmodel/router.go
@@ -182,11 +182,11 @@ func ParseTimeRange(duration, offset string) (*time.Time, *time.Time, error) {
 	// in which case it shifts endTime back by given duration
 	endTime := time.Now()
 	if offset != "" {
-		o, err := time.ParseDuration(offset)
+		o, err := ParseDuration(offset)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error parsing offset (%s): %s", offset, err)
 		}
-		endTime = endTime.Add(-1 * o)
+		endTime = endTime.Add(-1 * *o)
 	}
 
 	// if duration is defined in terms of days, convert to hours


### PR DESCRIPTION
- use intended local function instead of `time` package function
- improve error reporting for `getNormalizations` by appending time range (addresses some concerns of https://github.com/kubecost/cost-analyzer-helm-chart/issues/150) 