### PR TITLE
ClusterCache Refactor to Provider + Reserved Instances GCP

### DIFF
--- a/cloud/awsprovider.go
+++ b/cloud/awsprovider.go
@@ -19,6 +19,8 @@ import (
 
 	"k8s.io/klog"
 
+	"github.com/kubecost/cost-model/clustercache"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -29,8 +31,6 @@ import (
 	"github.com/jszwec/csvutil"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 const awsAccessKeyIDEnvVar = "AWS_ACCESS_KEY_ID"
@@ -44,7 +44,7 @@ type AWS struct {
 	Pricing                 map[string]*AWSProductTerms
 	SpotPricingByInstanceID map[string]*spotInfo
 	ValidPricingKeys        map[string]bool
-	Clientset               *kubernetes.Clientset
+	Clientset               clustercache.ClusterCache
 	BaseCPUPrice            string
 	BaseRAMPrice            string
 	BaseGPUPrice            string
@@ -238,12 +238,10 @@ type AwsAthenaInfo struct {
 }
 
 func (aws *AWS) GetManagementPlatform() (string, error) {
-	nodes, err := aws.Clientset.CoreV1().Nodes().List(metav1.ListOptions{})
-	if err != nil {
-		return "", err
-	}
-	if len(nodes.Items) > 0 {
-		n := nodes.Items[0]
+	nodes := aws.Clientset.GetAllNodes()
+
+	if len(nodes) > 0 {
+		n := nodes[0]
 		version := n.Status.NodeInfo.KubeletVersion
 		if strings.Contains(version, "eks") {
 			return "eks", nil
@@ -475,25 +473,20 @@ func (aws *AWS) DownloadPricingData() error {
 	if len(aws.SpotDataBucket) != 0 && len(aws.ProjectID) == 0 {
 		klog.V(1).Infof("using SpotDataBucket \"%s\" without ProjectID will not end well", aws.SpotDataBucket)
 	}
-	nodeList, err := aws.Clientset.CoreV1().Nodes().List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
+	nodeList := aws.Clientset.GetAllNodes()
+
 	inputkeys := make(map[string]bool)
-	for _, n := range nodeList.Items {
+	for _, n := range nodeList {
 		labels := n.GetObjectMeta().GetLabels()
 		key := aws.GetKey(labels)
 		inputkeys[key.Features()] = true
 	}
 
-	pvList, err := aws.Clientset.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
+	pvList := aws.Clientset.GetAllPersistentVolumes()
 
-	storageClasses, err := aws.Clientset.StorageV1().StorageClasses().List(metav1.ListOptions{})
+	storageClasses := aws.Clientset.GetAllStorageClasses()
 	storageClassMap := make(map[string]map[string]string)
-	for _, storageClass := range storageClasses.Items {
+	for _, storageClass := range storageClasses {
 		params := storageClass.Parameters
 		storageClassMap[storageClass.ObjectMeta.Name] = params
 		if storageClass.GetAnnotations()["storageclass.kubernetes.io/is-default-class"] == "true" || storageClass.GetAnnotations()["storageclass.beta.kubernetes.io/is-default-class"] == "true" {
@@ -503,13 +496,13 @@ func (aws *AWS) DownloadPricingData() error {
 	}
 
 	pvkeys := make(map[string]PVKey)
-	for _, pv := range pvList.Items {
+	for _, pv := range pvList {
 		params, ok := storageClassMap[pv.Spec.StorageClassName]
 		if !ok {
 			klog.V(2).Infof("Unable to find params for storageClassName %s, falling back to default pricing", pv.Spec.StorageClassName)
 			continue
 		}
-		key := aws.GetPVKey(&pv, params)
+		key := aws.GetPVKey(pv, params)
 		pvkeys[key.Features()] = key
 	}
 
@@ -815,6 +808,10 @@ func (aws *AWS) NodePricing(k Key) (*Node, error) {
 func (awsProvider *AWS) ClusterInfo() (map[string]string, error) {
 	defaultClusterName := "AWS Cluster #1"
 	c, err := awsProvider.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
 	remote := os.Getenv(remoteEnabled)
 	remoteEnabled := false
 	if os.Getenv(remote) == "true" {
@@ -845,11 +842,8 @@ func (awsProvider *AWS) ClusterInfo() (map[string]string, error) {
 	}
 	provIdRx := regexp.MustCompile("aws:///([^/]+)/([^/]+)")
 	clusterIdRx := regexp.MustCompile("^kubernetes\\.io/cluster/([^/]+)")
-	nodeList, err := awsProvider.Clientset.CoreV1().Nodes().List(metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	for _, n := range nodeList.Items {
+	nodeList := awsProvider.Clientset.GetAllNodes()
+	for _, n := range nodeList {
 		region := ""
 		instanceId := ""
 		providerId := n.Spec.ProviderID
@@ -1400,6 +1394,10 @@ func parseSpotData(bucket string, prefix string, projectID string, region string
 		gr.Close()
 	}
 	return spots, nil
+}
+
+func (aws *AWS) ApplyReservedInstancePricing(nodes map[string]*Node) {
+
 }
 
 /*

--- a/cloud/customprovider.go
+++ b/cloud/customprovider.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/kubecost/cost-model/clustercache"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 type NodePrice struct {
@@ -21,7 +21,7 @@ type NodePrice struct {
 }
 
 type CustomProvider struct {
-	Clientset               *kubernetes.Clientset
+	Clientset               clustercache.ClusterCache
 	Pricing                 map[string]*NodePrice
 	SpotLabel               string
 	SpotLabelValue          string
@@ -48,6 +48,10 @@ func (*CustomProvider) GetConfig() (*CustomPricing, error) {
 
 func (*CustomProvider) GetManagementPlatform() (string, error) {
 	return "", nil
+}
+
+func (*CustomProvider) ApplyReservedInstancePricing(nodes map[string]*Node) {
+
 }
 
 func (cp *CustomProvider) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, error) {

--- a/cloud/gcpprovider.go
+++ b/cloud/gcpprovider.go
@@ -841,6 +841,9 @@ func (gcp *GCP) ApplyReservedInstancePricing(nodes map[string]*Node) {
 
 	// go through all provider nodes using k8s nodes for region
 	for nodeName, node := range nodes {
+		// Reset reserved allocation to prevent double allocation
+		node.Reserved = nil
+
 		kNode, ok := gcpNodes[nodeName]
 		if !ok {
 			klog.V(1).Infof("[Reserved] Could not find K8s Node with name: %s", nodeName)
@@ -856,9 +859,6 @@ func (gcp *GCP) ApplyReservedInstancePricing(nodes map[string]*Node) {
 		reservedCounters, ok := counters[nodeRegion]
 		if !ok {
 			klog.V(1).Infof("[Reserved] Could not find counters for region: %s", nodeRegion)
-			continue
-		}
-		if node.Reserved != nil {
 			continue
 		}
 

--- a/clustercache/watchcontroller.go
+++ b/clustercache/watchcontroller.go
@@ -1,4 +1,4 @@
-package costmodel
+package clustercache
 
 import (
 	"fmt"

--- a/costmodel/router.go
+++ b/costmodel/router.go
@@ -15,9 +15,9 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/kubecost/cost-model/clustercache"
 	"github.com/julienschmidt/httprouter"
 	costAnalyzerCloud "github.com/kubecost/cost-model/cloud"
+	"github.com/kubecost/cost-model/clustercache"
 	"github.com/patrickmn/go-cache"
 	prometheusClient "github.com/prometheus/client_golang/api"
 	prometheusAPI "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -904,7 +904,6 @@ func Initialize() {
 		NetworkInternetEgressRecorder: NetworkInternetEgressRecorder,
 		PersistentVolumePriceRecorder: pvGv,
 		Model:                         NewCostModel(k8sCache),
-		CostDataCache:                 costDataCache,
 		OutOfClusterCache:             outOfClusterCache,
 	}
 


### PR DESCRIPTION
* Moved ClusterCache utility into a separate package to prevent cross dependency between costmodel and provider packages.
* ClusterCache is now created and initialized after Kubernetes client initialization and passed into costmodel as well as provider
* Pulling in GCP committed use, applying to costs _after_ node VCPU and RAM is set. 

----
Note: I will remove aggressive logging of Reserved Instance data before merge. 