### PR TITLE
add out of cluster filtering on AWS

### DIFF
--- a/cloud/azureprovider.go
+++ b/cloud/azureprovider.go
@@ -585,7 +585,7 @@ func (az *Azure) GetConfig() (*CustomPricing, error) {
 	return c, nil
 }
 
-func (az *Azure) ExternalAllocations(string, string, string) ([]*OutOfClusterAllocation, error) {
+func (az *Azure) ExternalAllocations(string, string, string, string, string) ([]*OutOfClusterAllocation, error) {
 	return nil, nil
 }
 

--- a/cloud/customprovider.go
+++ b/cloud/customprovider.go
@@ -196,7 +196,7 @@ func (cp *CustomProvider) GetKey(labels map[string]string) Key {
 // ExternalAllocations represents tagged assets outside the scope of kubernetes.
 // "start" and "end" are dates of the format YYYY-MM-DD
 // "aggregator" is the tag used to determine how to allocate those assets, ie namespace, pod, etc.
-func (*CustomProvider) ExternalAllocations(start string, end string, aggregator string) ([]*OutOfClusterAllocation, error) {
+func (*CustomProvider) ExternalAllocations(start string, end string, aggregator string, filterType string, filterValue string) ([]*OutOfClusterAllocation, error) {
 	return nil, nil // TODO: transform the QuerySQL lines into the new OutOfClusterAllocation Struct
 }
 

--- a/cloud/gcpprovider.go
+++ b/cloud/gcpprovider.go
@@ -196,7 +196,7 @@ func (gcp *GCP) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, er
 // ExternalAllocations represents tagged assets outside the scope of kubernetes.
 // "start" and "end" are dates of the format YYYY-MM-DD
 // "aggregator" is the tag used to determine how to allocate those assets, ie namespace, pod, etc.
-func (gcp *GCP) ExternalAllocations(start string, end string, aggregator string) ([]*OutOfClusterAllocation, error) {
+func (gcp *GCP) ExternalAllocations(start string, end string, aggregator string, filterType string, filterValue string) ([]*OutOfClusterAllocation, error) {
 	c, err := GetDefaultPricingData("gcp.json")
 	if err != nil {
 		return nil, err

--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -166,7 +166,7 @@ type Provider interface {
 	GetConfig() (*CustomPricing, error)
 	GetManagementPlatform() (string, error)
 	GetLocalStorageQuery(offset string) (string, error)
-	ExternalAllocations(string, string, string) ([]*OutOfClusterAllocation, error)
+	ExternalAllocations(string, string, string, string, string) ([]*OutOfClusterAllocation, error)
 	ApplyReservedInstancePricing(map[string]*Node)
 }
 


### PR DESCRIPTION
Support secondary level of filtering on out of cluster costs. Empty values in the secondary filter are not filtered out.

eg:
filter by cluster=cluster-one returns clusterID=cluster-one || clusterID=“”

Currently only supported on AWS

