### PR TITLE
Resolution-related improvements

### DIFF
--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -338,7 +338,6 @@ func (cm *CostModel) ComputeCostData(cli prometheusClient.Client, clientset kube
 	queryNetZoneRequests := fmt.Sprintf(queryZoneNetworkUsage, window, "")
 	queryNetRegionRequests := fmt.Sprintf(queryRegionNetworkUsage, window, "")
 	queryNetInternetRequests := fmt.Sprintf(queryInternetNetworkUsage, window, "")
-	//normalization := fmt.Sprintf(normalizationStr, window, offset, 1.0)
 	normalization := fmt.Sprintf(normalizationStr, window, offset)
 
 	// Cluster ID is specific to the source cluster

--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -1837,8 +1837,8 @@ func (cm *CostModel) costDataRange(cli prometheusClient.Client, clientset kubern
 
 	normalizationValue, err := getNormalizations(normalizationResults)
 	if err != nil {
-		return nil, fmt.Errorf("error computing normalization for start=%s, end=%s, window=%s: %s",
-			start, end, window, err.Error())
+		return nil, fmt.Errorf("error computing normalization for start=%s, end=%s, window=%s, res=%f: %s",
+			start, end, window, resolutionHours*60*60, err.Error())
 	}
 
 	measureTime(profileStart, fmt.Sprintf("costDataRange(%fh): compute normalizations", durHrs))

--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -1540,8 +1540,6 @@ func (cm *CostModel) ComputeCostDataRange(cli prometheusClient.Client, clientset
 func (cm *CostModel) costDataRange(cli prometheusClient.Client, clientset kubernetes.Interface, cp costAnalyzerCloud.Provider,
 	startString, endString, windowString string, resolutionHours float64, filterNamespace string, filterCluster string, remoteEnabled bool) (map[string]*CostData, error) {
 
-	klog.Infof("[Debug] costDataRange(window=%s, res=%d)", windowString, int(resolutionHours*60*60))
-
 	queryRAMRequests := fmt.Sprintf(queryRAMRequestsStr, windowString, "", windowString, "")
 	queryRAMUsage := fmt.Sprintf(queryRAMUsageStr, windowString, "", windowString, "")
 	queryCPURequests := fmt.Sprintf(queryCPURequestsStr, windowString, "", windowString, "")

--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -2011,7 +2011,7 @@ func (cm *CostModel) costDataRange(cli prometheusClient.Client, clientset kubern
 
 	// No need to normalize here, as this comes from a counter
 	// CPUUsedMap, err := GetContainerMetricVectors(resultCPUUsage, clusterID)
-	// TODO Is that ^ true?? We were normalizing before, so I'm normalizing now.
+	// TODO Is that ^ true? We were normalizing before (in spite of the comment) so I'm keeping it.
 	CPUUsedMap, err := GetNormalizedContainerMetricVectors(resultCPUUsage, normalizationValue, clusterID)
 	if err != nil {
 		return nil, err

--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -1983,10 +1983,9 @@ func (cm *CostModel) costDataRange(cli prometheusClient.Client, clientset kubern
 		containers[key] = true
 	}
 
-	// No need to normalize here, as this comes from a counter
+	// No need to normalize here, as this comes from a counter, namely:
+	// rate(container_cpu_usage_seconds_total) which properly accounts for normalized rates
 	CPUUsedMap, err := GetContainerMetricVectors(resultCPUUsage, clusterID)
-	// TODO Is that ^ true? We were normalizing before (in spite of the comment) so I'm keeping it.
-	// CPUUsedMap, err := GetNormalizedContainerMetricVectors(resultCPUUsage, normalizationValue, clusterID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Supports https://github.com/kubecost/kubecost-cost-model/pull/52

Changes here aim to fix accuracy problems related to decreased-resolution Prometheus queries:
* Reverted the scalar modification of the normalization query in favor of the following.
* RAM and CPU allocation queries now return the total (resource*hour) amounts over the given windows, rather than normalized hourly rate data. This vastly improves the accuracy of cumulative results.
* Correcting for scrape-misses has become slightly more complicated, but seems to do a good job within a reasonable percentage of scrape misses. If anything, this is the part that could use review and improvement.