### PR TITLE
Gpu query fix

### DIFF
--- a/cloud/customprovider.go
+++ b/cloud/customprovider.go
@@ -218,7 +218,7 @@ func (*CustomProvider) QuerySQL(query string) ([]byte, error) {
 }
 
 func (*CustomProvider) PVPricing(pvk PVKey) (*PV, error) {
-	cpricing, err := GetDefaultPricingData("default")
+	cpricing, err := GetDefaultPricingData("default.json")
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (*CustomProvider) PVPricing(pvk PVKey) (*PV, error) {
 }
 
 func (*CustomProvider) NetworkPricing() (*Network, error) {
-	cpricing, err := GetDefaultPricingData("default")
+	cpricing, err := GetDefaultPricingData("default.json")
 	if err != nil {
 		return nil, err
 	}

--- a/costmodel/costmodel.go
+++ b/costmodel/costmodel.go
@@ -178,7 +178,7 @@ const (
 			), "pod_name","$1","pod","(.+)"
 		) 
 	) by (namespace,container_name,pod_name,node,cluster_id) 
-	* on (pod_name, namespace, cluster_id) group_left(container) label_replace(max(avg_over_time(kube_pod_status_phase{phase="Running"}[%s] %s)) by (pod,namespace,cluster_id), "pod_name","$1","pod","(.+)")`
+	* on (pod_name, namespace, cluster_id) group_left(container) label_replace(avg(avg_over_time(kube_pod_status_phase{phase="Running"}[%s] %s)) by (pod,namespace,cluster_id), "pod_name","$1","pod","(.+)")`
 	queryPVRequestsStr = `avg(kube_persistentvolumeclaim_info) by (persistentvolumeclaim, storageclass, namespace, volumename, cluster_id) 
 						* 
 						on (persistentvolumeclaim, namespace, cluster_id) group_right(storageclass, volumename) 


### PR DESCRIPTION
* Swap to group_left over group_right and delete *node* from the group_by. A pod can be on many nodes, but the pod running status isn't accounted for there. Accordingly, the "many" side is changed to the gpu_requests and the "one" side is the pod runtime
* Then you have to use container instead of container_name (or do a really annoying label replace) to get it to show up in the final metric
* But I ran into an issue where duplicate metric series would break this. So we max() the avg_over_time to remove duplicate labels. Compare:
<img width="1440" alt="Screen Shot 2020-01-24 at 4 55 46 PM" src="https://user-images.githubusercontent.com/453512/73113769-8e4dca00-3eca-11ea-8c72-f2551c6fa599.png">
<img width="1440" alt="Screen Shot 2020-01-24 at 4 56 08 PM" src="https://user-images.githubusercontent.com/453512/73113773-93ab1480-3eca-11ea-800b-9c6fa6512f1c.png">


