### PR TITLE
ClusterCosts improvements

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -207,7 +207,7 @@ var regionToBillingRegionCode = map[string]string{
 	"us-gov-west-1":  "UGW1",
 }
 
-func (aws *AWS) GetLocalStorageQuery(window, offset string, rate bool) string {
+func (aws *AWS) GetLocalStorageQuery(window, offset string, rate bool, used bool) string {
 	return ""
 }
 

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -686,6 +686,6 @@ func (az *Azure) PVPricing(pvk PVKey) (*PV, error) {
 	return pricing.PV, nil
 }
 
-func (az *Azure) GetLocalStorageQuery(window, offset string, rate bool) string {
+func (az *Azure) GetLocalStorageQuery(window, offset string, rate bool, used bool) string {
 	return ""
 }

--- a/pkg/cloud/customprovider.go
+++ b/pkg/cloud/customprovider.go
@@ -37,7 +37,7 @@ type customProviderKey struct {
 	Labels         map[string]string
 }
 
-func (*CustomProvider) GetLocalStorageQuery(window, offset string, rate bool) string {
+func (*CustomProvider) GetLocalStorageQuery(window, offset string, rate bool, used bool) string {
 	return ""
 }
 

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -124,7 +124,7 @@ func (gcp *GCP) GetLocalStorageQuery(window, offset string, rate bool, used bool
 
 	baseMetric := "container_fs_limit_bytes"
 	if used {
-		baseMetric = "container_fs_used_bytes"
+		baseMetric = "container_fs_usage_bytes"
 	}
 
 	fmtOffset := ""

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -174,7 +174,7 @@ type Provider interface {
 	UpdateConfigFromConfigMap(map[string]string) (*CustomPricing, error)
 	GetConfig() (*CustomPricing, error)
 	GetManagementPlatform() (string, error)
-	GetLocalStorageQuery(string, string, bool) string
+	GetLocalStorageQuery(string, string, bool, bool) string
 	ExternalAllocations(string, string, []string, string, string, bool) ([]*OutOfClusterAllocation, error)
 	ApplyReservedInstancePricing(map[string]*Node)
 }

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -94,8 +94,6 @@ func NewClusterCostsFromCumulative(cpu, gpu, ram, storage float64, window, offse
 		return nil, err
 	}
 
-	klog.Infof("[Debug] ComputeClusterCosts: dataHours=%f; range dataHours=%f", dataHours, end.Sub(*start).Hours())
-
 	// If the number of hours is not given (i.e. is zero) compute one from the window and offset
 	if dataHours == 0 {
 		dataHours = end.Sub(*start).Hours()
@@ -160,7 +158,6 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	const fmtQueryRAMSystemPct = `sum(sum_over_time(container_memory_usage_bytes{container_name!="",namespace="kube-system"}[%s:1m]%s)) by (cluster_id)
 	/ sum(sum_over_time(kube_node_status_capacity_memory_bytes[%s:1m]%s)) by (cluster_id)`
 
-	// TODO niko/clustercost should we subtract System from this? i.e. does working set include system?
 	const fmtQueryRAMUserPct = `sum(sum_over_time(kubecost_cluster_memory_working_set_bytes[%s:1m]%s)) by (cluster_id)
 	/ sum(sum_over_time(kube_node_status_capacity_memory_bytes[%s:1m]%s)) by (cluster_id)`
 

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -133,7 +133,7 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	}
 	mins := end.Sub(*start).Minutes()
 
-	const fmtQueryDataCount = `max(sum(count_over_time(kube_node_status_capacity_cpu_cores[%s:1m]%s)) by (node, cluster_id))`
+	const fmtQueryDataCount = `count_over_time(sum(kube_node_status_capacity_cpu_cores)[%s:1m]%s)`
 
 	const fmtQueryTotalGPU = `sum(
 		sum_over_time(node_gpu_hourly_cost[%s:1m]%s) / 60


### PR DESCRIPTION
* Fix ClusterCosts being too high when nodes come up and down (problem with `fmtQueryDataCount`)
* Apply discount to ClusterCosts on back-end
* Include percentage breakdown in ClusterCosts