### PR TITLE
Fix data count query for ComputeClusterCosts

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -155,7 +155,7 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	}
 	mins := end.Sub(*start).Minutes()
 
-	const fmtQueryDataCount = `max(count_over_time(kube_node_status_capacity_cpu_cores[%s:1m]%s))`
+	const fmtQueryDataCount = `max(sum(count_over_time(kube_node_status_capacity_cpu_cores[%s:1m]%s)) by (node, cluster_id))`
 
 	const fmtQueryTotalGPU = `sum(
 		sum_over_time(node_gpu_hourly_cost[%s:1m]%s) / 60


### PR DESCRIPTION
Corrects the "minutes per window" query to account for nodes coming up and down.