### PR TITLE
ClusterCosts: better query for counting data points

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -155,7 +155,7 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	}
 	mins := end.Sub(*start).Minutes()
 
-	const fmtQueryDataCount = `count_over_time(sum(kube_node_status_capacity_cpu_cores)[%s:1m]%s)`
+	const fmtQueryDataCount = `count_over_time(sum(kube_node_status_capacity_cpu_cores) by (cluster_id)[%s:1m]%s)`
 
 	const fmtQueryTotalGPU = `sum(
 		sum_over_time(node_gpu_hourly_cost[%s:1m]%s) / 60
@@ -238,16 +238,25 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	resultsTotalStorage := <-chTotalStorage
 	close(chTotalStorage)
 
-	dataMins := mins
-	if len(resultsDataCount) > 0 && len(resultsDataCount[0].Values) > 0 {
-		dataMins = resultsDataCount[0].Values[0].Value
-	} else {
-		klog.V(3).Infof("[Warning] cluster cost data count returned no results")
+	defaultClusterID := os.Getenv(clusterIDKey)
+
+	dataMinsByCluster := map[string]float64{}
+	for _, result := range resultsDataCount {
+		clusterID, _ := result.GetString("cluster_id")
+		if clusterID == "" {
+			clusterID = defaultClusterID
+		}
+		dataMins := mins
+		if len(result.Values) > 0 {
+			dataMins = result.Values[0].Value
+		} else {
+			klog.V(3).Infof("[Warning] cluster cost data count returned no results for cluster %s", clusterID)
+		}
+		dataMinsByCluster[clusterID] = dataMins
 	}
 
 	// Intermediate structure storing mapping of [clusterID][type ∈ {cpu, ram, storage, total}]=cost
 	costData := make(map[string]map[string]float64)
-	defaultClusterID := os.Getenv(clusterIDKey)
 
 	// Helper function to iterate over Prom query results, parsing the raw values into
 	// the intermediate costData structure.
@@ -274,6 +283,11 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	// Convert intermediate structure to Costs instances
 	costsByCluster := map[string]*ClusterCosts{}
 	for id, cd := range costData {
+		dataMins, ok := dataMinsByCluster[id]
+		if !ok {
+			dataMins = mins
+			klog.V(3).Infof("[Warning] cluster cost data count not found for cluster %s", id)
+		}
 		costs, err := NewClusterCostsFromCumulative(cd["cpu"], cd["gpu"], cd["ram"], cd["storage"], window, offset, dataMins/util.MinsPerHour)
 		if err != nil {
 			klog.V(3).Infof("[Warning] Failed to parse cluster costs on %s (%s) from cumulative data: %+v", window, offset, cd)

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -155,7 +155,7 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	}
 	mins := end.Sub(*start).Minutes()
 
-	const fmtQueryDataCount = `max(sum(count_over_time(kube_node_status_capacity_cpu_cores[%s:1m]%s)) by (node, cluster_id))`
+	const fmtQueryDataCount = `count_over_time(sum(kube_node_status_capacity_cpu_cores)[%s:1m]%s)`
 
 	const fmtQueryTotalGPU = `sum(
 		sum_over_time(node_gpu_hourly_cost[%s:1m]%s) / 60


### PR DESCRIPTION
* Safer querying for data points in ComputeClusterCosts
* Query by cluster_id for cases where one cluster is older than another

e.g. here cluster-two was made after cluster-one
![Screenshot from 2020-02-27 14-09-52](https://user-images.githubusercontent.com/8070055/75487075-f9c40500-596a-11ea-9069-e2ce7f3b2dc1.png)
