### PR TITLE
Azure PV Pricing Adjustment

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -408,8 +408,8 @@ func (az *Azure) DownloadPricingData() error {
 						for _, rate := range v.MeterRates {
 							priceInUsd += *rate
 						}
-						// rate is in GB per month, resolve to GB per hour
-						pricePerHour := priceInUsd / 730.0
+						// rate is in disk per month, resolve price per hour, then GB per hour
+						pricePerHour := priceInUsd / 730.0 / 32.0
 						priceStr := fmt.Sprintf("%f", pricePerHour)
 
 						key := region + "," + storageClass


### PR DESCRIPTION
Pricing for Azure PVs uses various units. S4 and P4 disks specifically use a `1/month` unit, which corresponds to disk price per month. Since we normalize storage costs to 1GB/month, we need to adjust Azure PVs accordingly. 