### PR TITLE
Comment discount application in ComputeClusterCosts

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -312,9 +312,11 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 			}
 		}
 	}
-	setCostsFromResults(costData, resultsTotalGPU, "gpu", 0.0, customDiscount)
+	// Apply both sustained use and custom discounts to RAM and CPU
 	setCostsFromResults(costData, resultsTotalCPU, "cpu", discount, customDiscount)
 	setCostsFromResults(costData, resultsTotalRAM, "ram", discount, customDiscount)
+	// Apply only custom discount to GPU and storage
+	setCostsFromResults(costData, resultsTotalGPU, "gpu", 0.0, customDiscount)
 	setCostsFromResults(costData, resultsTotalStorage, "storage", 0.0, customDiscount)
 
 	cpuBreakdownMap := map[string]*ClusterCostsBreakdown{}


### PR DESCRIPTION
Comment to clarify how discounts are being applied in ComputeClusterCosts. Goes with https://github.com/kubecost/kubecost-cost-model/pull/88