### PR TITLE
Kubernetes Secret for Service Account

### DIFF
--- a/pkg/cloud/customprovider.go
+++ b/pkg/cloud/customprovider.go
@@ -3,7 +3,6 @@ package cloud
 import (
 	"encoding/json"
 	"io"
-	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -107,10 +106,6 @@ func (cp *CustomProvider) ClusterInfo() (map[string]string, error) {
 	}
 	m["provider"] = "custom"
 	return m, nil
-}
-
-func (*CustomProvider) AddServiceKey(url.Values) error {
-	return nil
 }
 
 func (*CustomProvider) GetDisks() ([]byte, error) {

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"strings"
 
@@ -21,6 +20,7 @@ const clusterIDKey = "CLUSTER_ID"
 const remoteEnabled = "REMOTE_WRITE_ENABLED"
 const remotePW = "REMOTE_WRITE_PASSWORD"
 const sqlAddress = "SQL_ADDRESS"
+const authSecretPath = "/var/secrets/service-key.json"
 
 var createTableStatements = []string{
 	`CREATE TABLE IF NOT EXISTS names (
@@ -162,7 +162,6 @@ type CustomPricing struct {
 // Provider represents a k8s provider.
 type Provider interface {
 	ClusterInfo() (map[string]string, error)
-	AddServiceKey(url.Values) error
 	GetDisks() ([]byte, error)
 	NodePricing(Key) (*Node, error)
 	PVPricing(PVKey) (*PV, error)


### PR DESCRIPTION
# Documentation

### Kubecost Provider Service Keys - Secrets
The benefits to using a secret for provider service keys is that keys are not lost on re-install of Kubecost. To setup a provider service key secret, you'll need to create a `service-key.json` file containing provider specific authentication keys. Each provider requires a unique JSON format outlined below:

#### GCP
When you create a service account in the GCP console, you're provided a JSON representation of that service key. For example:
```json
{
  "type": "service_account",
  "project_id": "...",
  "private_key_id": "...",
  "private_key": "-----BEGIN PRIVATE KEY-----\nKEY_HERE\n-----END PRIVATE KEY-----\n",
  "client_email": "...",
  "client_id": "...",
  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
  "token_uri": "https://oauth2.googleapis.com/token",
  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
  "client_x509_cert_url": "..."
}
```

The steps for generating the service account key can be found in [Kubecost Documentation](http://docs.kubecost.com/gcp-out-of-cluster.html).

#### AWS
For IAM roles on AWS, you'll need to provide the following JSON format:
```json
{
    "aws_access_key_id": "...",
    "aws_secret_access_key": "..."
}
```

#### Azure 
Using the following command will provide a JSON representation of a role created from the Azure CLI:
```bash
$ az ad sp create-for-rbac -n "DISPLAY_NAME"
```

The output of this command is similar to the following:
```bash
Changing "DISPLAY_NAME" to a valid URI of "http://DISPLAY_NAME", which is the required format used for service principal names
Creating a role assignment under the scope of "/subscriptions/SUBSCRIPTION_ID"
{
    "appId": "CLIENT_ID",
    "displayName": "DISPLAY_NAME",
    "name": "http://DISPLAY_NAME",
    "password": "CLIENT_SECRET",
    "tenant": "TENANT_ID"
}
```

Using the above information, your `service-key.json` should provide the JSON as the `"serviceKey"` property as well as the `SUBSCRIPTION_ID` as the `"subscriptioonId"` property. For example:
```json
{
    "subscriptionId": "SUBSCRIPTION_ID",
    "serviceKey": {
        "appId": "CLIENT_ID",
        "displayName": "DISPLAY_NAME",
        "name": "http://DISPLAY_NAME",
        "password": "CLIENT_SECRET",
        "tenant": "TENANT_ID"
    }
}
```

### Creating the Secret
To create the Kubernetes Secret using the `service-key.json` you created, issue the following `kubectl` command:
```bash
$ kubectl create secret generic SECRET_NAME -n KUBECOST_INSTALL_NAMESPACE --from-file=service-key.json
```

Make sure you create the secret in the same namespace as the Kubecost install (`kubecost` by default) by replacing `KUBECOST_INSTALL_NAMESPACE` with a valid value. There are no specific requirements for the secret name, but you _should_ ensure that the file name is `service-key.json`. 


### Configuring Kubecost Helm Values to Use Secret
In order for Kubecost to use the secret, set the helm value `kubecostProductConfigs.serviceKeySecretName` to the `SECRET_NAME` you provided when creating the secret. This can be done explicitly in a `values.yaml` file, or by passing `--set kubecostProductConfigs.serviceKeySecretName=SECRET_NAME` to helm during install/upgrade. 


### Service Account Key Priority
Providing a service key secret will ensure that service account is used by Kubecost on a new install. However, if a different service account key is provided via the frontend settings page, that service key will take priority over the secret. 