### PR TITLE
Add "kubernetes_label_" prefix to label filters of OOC queries

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -371,7 +371,8 @@ func (gcp *GCP) ExternalAllocations(start string, end string, aggregators []stri
 		if filterType == "kubernetes_labels" {
 			fvs := strings.Split(filterValue, "=")
 			if len(fvs) == 2 {
-				filterType = fvs[0]
+				// if we are given "app=myapp" then look for label "kubernetes_label_app=myapp"
+				filterType = fmt.Sprintf("kubernetes_label_%s", fvs[0])
 				filterValue = fvs[1]
 			} else {
 				klog.V(2).Infof("[Warning] illegal kubernetes_labels filterValue: %s", filterValue)


### PR DESCRIPTION
Map requests for label `app=myapp` to GCP OOC costs with label `kubernetes_label_app=myapp`. Previously we rolled this back to support OOC labels that weren't prepended with `kubernetes_label_`, so this is a return to old behavior.

![Screenshot from 2020-03-27 12-01-35](https://user-images.githubusercontent.com/8070055/77786376-56c2e180-7023-11ea-9f32-b3c15af2cae2.png)
In this example, BigQuery has resources labeled `kubernetes_label_app=cost-analyzer`, which we pick up with label filter `app=cost-analyzer`. Before this PR we'd have to explicitly request label filter `kubernetes_app_label=cost-analyzer` (which doesn't match any cost data).

We have a product and documentation question to answer here. This change works with what our documentation says to do (see [GCP Out of Cluster: Step 3: Label cloud assets](http://docs.kubecost.com/gcp-out-of-cluster.html)) but might break people who got used to having everything (Prometheus & BigQuery) just labeled `app=myapp`.

Addresses https://github.com/kubecost/cost-analyzer-helm-chart/issues/313