### PR TITLE
Expose YAML definition for Details in the ClusterEntry

### DIFF
--- a/pkg/clustermanager/clustermanager.go
+++ b/pkg/clustermanager/clustermanager.go
@@ -14,8 +14,9 @@ import (
 
 // Cluster definition from a configuration yaml
 type ClusterConfigEntry struct {
-	Name    string `yaml:"name"`
-	Address string `yaml:"address"`
+	Name    string                 `yaml:"name"`
+	Address string                 `yaml:"address"`
+	Details map[string]interface{} `yaml:"details,omitempty"`
 }
 
 // ClusterDefinition
@@ -88,6 +89,7 @@ func NewConfiguredClusterManager(storage ClusterStorage, config string) *Cluster
 			ID:      entry.Name,
 			Name:    entry.Name,
 			Address: entry.Address,
+			Details: entry.Details,
 		})
 	}
 


### PR DESCRIPTION
### Summary
Expose the YAML definition for "details" in the cluster entries defined in configmap. This opens up the frontend to implement it's own protocol for cluster entries.

If there is a configmap provided, which contains cluster entry definitions, they can now properly set the details field.