### PR TITLE
Ajay tripathy nil fix

### DIFF
--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -57,7 +57,9 @@ func (pqr *PromQueryResult) GetLabels() map[string]string {
 // PromQueryResult objects
 func NewQueryResults(queryResult interface{}) ([]*PromQueryResult, error) {
 	var result []*PromQueryResult
-
+	if queryResult == nil {
+		return nil, fmt.Errorf("[Error] nil result from prometheus, has it gone down?")
+	}
 	data, ok := queryResult.(map[string]interface{})["data"]
 	if !ok {
 		e, err := wrapPrometheusError(queryResult)


### PR DESCRIPTION
Because prometheus connection refuseds result in warnings and nil interfaces, its possible for this to be nil without an error throw

> 
> I0421 05:09:08.661859       1 costmodel.go:2019] [Warning] Query Error: [Error] Post "http://kubecost-staging-prometheus-server.kubecost-staging/api/v1/query_range?end=2020-04-21T05%3A07%3A36.827Z&query=avg%28kube_persistentvolumeclaim_info%29+by+%28persistentvolumeclaim%2C+storageclass%2C+namespace%2C+volumename%2C+cluster_id%29+%0A%09%09%09%09%09%09%2A+%0A%09%09%09%09%09%09on+%28persistentvolumeclaim%2C+namespace%2C+cluster_id%29+group_right%28storageclass%2C+volumename%29+%0A%09%09%09%09sum%28kube_persistentvolumeclaim_resource_requests_storage_bytes%29+by+%28persistentvolumeclaim%2C+namespace%2C+cluster_id%29&start=2020-04-20T06%3A07%3A36.827Z&step=3600.000": dial tcp 10.39.241.249:80: connect: connection refused fetching query avg(kube_persistentvolumeclaim_info) by (persistentvolumeclaim, storageclass, namespace, volumename, cluster_id) 
> 						* 
> 						on (persistentvolumeclaim, namespace, cluster_id) group_right(storageclass, volumename) 
> 				sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace, cluster_id)
> I0421 05:09:08.661874       1 costmodel.go:2019] [Warning] Query Error: [Error] Post "http://kubecost-staging-prometheus-server.kubecost-staging/api/v1/query_range?end=2020-04-21T05%3A07%3A36.827Z&query=sum%28kube_pod_owner%7Bowner_kind%3D%22DaemonSet%22%7D%29+by+%28namespace%2Cpod%2Cowner_name%2Ccluster_id%29&start=2020-04-20T06%3A07%3A36.827Z&step=3600.000": dial tcp 10.39.241.249:80: connect: connection refused fetching query sum(kube_pod_owner{owner_kind="DaemonSet"}) by (namespace,pod,owner_name,cluster_id)
> I0421 05:09:08.661900       1 profiling.go:14] [Profiler] 31.834766138s: ComputeAggregateCostModel(duration=1d, offet=1m, field=namespace)
> panic: interface conversion: interface {} is nil, not map[string]interface {}
> 
> goroutine 318 [running]:
> github.com/kubecost/cost-model/pkg/costmodel.NewQueryResults(0x0, 0x0, 0xc0007bdc18, 0x75935b, 0x34d8e80, 0xc000000000, 0xc00051eee0)
> 	/app/cost-model/pkg/costmodel/promparsers.go:61 +0xb26
> github.com/kubecost/cost-model/pkg/costmodel.getNormalizations(0x0, 0x0, 0x34d88a0, 0x19, 0xc0007be470, 0x1, 0x1)
> 	/app/cost-model/pkg/costmodel/costmodel.go:2624 +0x4d
> github.com/kubecost/cost-model/pkg/costmodel.(*CostModel).costDataRange(0xc0003dd9e0, 0x24b6a20, 0xc000523e80, 0x251d5a0, 0xc0000c4000, 0x2510400, 0xc0003c7720, 0xc0005a4020, 0x18, 0xc0005a4060, ...)
> 	/app/cost-model/pkg/costmodel/costmodel.go:2030 +0x2f06
> github.com/kubecost/cost-model/pkg/costmodel.(*CostModel).ComputeCostDataRange.func1(0x41300b, 0xc000a87030, 0xa4b01205, 0x320dbf3575143746)
> 	/app/cost-model/pkg/costmodel/costmodel.go:1705 +0x135
> golang.org/x/sync/singleflight.(*Group).doCall(0xc00057b1b0, 0xc000ca2180, 0xc000faaf00, 0x2e, 0xc000a87100)
> 	/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/singleflight/singleflight.go:97 +0x2e
> golang.org/x/sync/singleflight.(*Group).Do(0xc00057b1b0, 0xc000faaf00, 0x2e, 0xc000a87100, 0xc000ceb078, 0x2, 0x0, 0x0, 0x0)
> 	/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/singleflight/singleflight.go:67 +0x1ba
> github.com/kubecost/cost-model/pkg/costmodel.(*CostModel).ComputeCostDataRange(0xc0003dd9e0, 0x24b6a20, 0xc000523e80, 0x251d5a0, 0xc0000c4000, 0x2510400, 0xc0003c7720, 0xc0005a4020, 0x18, 0xc0005a4060, ...)
> 	/app/cost-model/pkg/costmodel/costmodel.go:1704 +0x2ca
> main.ComputeAggregateCostModel(0x24b6a20, 0xc000523e80, 0x20b7c55, 0x2, 0x20b7c59, 0x2, 0x20bfbd1, 0x9, 0x35044a0, 0x0, ...)
> 	/app/kubecost-cost-model/aggregation.go:1176 +0x1516
> main.warmAggregateCostModelCache.func1(0x20b7c55, 0x2, 0x20b8037, 0x3, 0x20b7c59, 0x2)
> 	/app/kubecost-cost-model/main.go:493 +0x44a
> main.warmAggregateCostModelCache.func2(0x2183040, 0xc000307d18)
> 	/app/kubecost-cost-model/main.go:520 +0x95
> created by main.warmAggregateCostModelCache
> 	/app/kubecost-cost-model/main.go:513 +0x9c