### PR TITLE
ComputeClusterCosts: efficiency and bug fix

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -138,7 +138,7 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	// minsPerResolution determines accuracy and resource use for the following
 	// queries. Smaller values (higher resolution) result in better accuracy,
 	// but more expensive queries, and vice-a-versa.
-	minsPerResolution := 2
+	minsPerResolution := 5
 
 	// hourlyToCumulative is a scaling factor that, when multiplied by an hourly
 	// value, converts it to a cumulative value; i.e.

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -332,7 +332,7 @@ func (a *Accesses) ClusterCosts(w http.ResponseWriter, r *http.Request, ps httpr
 	window := r.URL.Query().Get("window")
 	offset := r.URL.Query().Get("offset")
 
-	data, err := ComputeClusterCosts(a.PrometheusClient, a.Cloud, window, offset)
+	data, err := ComputeClusterCosts(a.PrometheusClient, a.Cloud, window, offset, true)
 	w.Write(WrapData(data, err))
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/461
Requires https://github.com/kubecost/kubecost-cost-model/pull/139

## Changes
- Fix cluster costs for clusters with no PVs
- Implement new async prom querying
- Add flag for disabling breakdown, which is a memory burden on Prom
- Decrease resolution from of cluster costs queries from 1m to 5m

## Testing

### Disabling breakdown
_Not tested yet_

### No PV fix
Before: cluster costs don't load
![Screenshot from 2020-05-19 12-09-20](https://user-images.githubusercontent.com/8070055/82393133-d4dbad00-9a02-11ea-8ffd-e4c5ea2a6a50.png)

After: cluster costs load
![Screenshot from 2020-05-19 18-52-38](https://user-images.githubusercontent.com/8070055/82393155-e1600580-9a02-11ea-8e9d-37dc49bdb1d3.png)

