### PR TITLE
ComputeClusterCosts: stabilize startup

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/kubecost/cost-model/pkg/cloud"
-	"github.com/kubecost/cost-model/pkg/log"
 	"github.com/kubecost/cost-model/pkg/prom"
 	"github.com/kubecost/cost-model/pkg/util"
 	prometheus "github.com/prometheus/client_golang/api"
@@ -146,7 +145,7 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	hourlyToCumulative := float64(minsPerResolution) * (1.0 / 60.0)
 
 	const fmtQueryDataCount = `
-		count_over_time(sum(kube_node_status_capacity_cpu_cores) by (cluster_id)[%s:1m]%s)
+		count_over_time(sum(kube_node_status_capacity_cpu_cores) by (cluster_id)[%s:%dm]%s) * %d
 	`
 
 	const fmtQueryTotalGPU = `
@@ -207,17 +206,11 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 		fmtOffset = fmt.Sprintf("offset %s", offset)
 	}
 
-	queryDataCount := fmt.Sprintf(fmtQueryDataCount, window, fmtOffset)
+	queryDataCount := fmt.Sprintf(fmtQueryDataCount, window, minsPerResolution, fmtOffset, minsPerResolution)
 	queryTotalGPU := fmt.Sprintf(fmtQueryTotalGPU, window, minsPerResolution, fmtOffset, hourlyToCumulative)
 	queryTotalCPU := fmt.Sprintf(fmtQueryTotalCPU, window, minsPerResolution, fmtOffset, window, minsPerResolution, fmtOffset, hourlyToCumulative)
 	queryTotalRAM := fmt.Sprintf(fmtQueryTotalRAM, window, minsPerResolution, fmtOffset, window, minsPerResolution, fmtOffset, hourlyToCumulative)
 	queryTotalStorage := fmt.Sprintf(fmtQueryTotalStorage, window, minsPerResolution, fmtOffset, window, minsPerResolution, fmtOffset, hourlyToCumulative)
-
-	log.Infof("ComputeClusterCosts: queryDataCount: %s", queryDataCount)
-	log.Infof("ComputeClusterCosts: queryTotalGPU: %s", queryTotalGPU)
-	log.Infof("ComputeClusterCosts: queryTotalCPU: %s", queryTotalCPU)
-	log.Infof("ComputeClusterCosts: queryTotalRAM: %s", queryTotalRAM)
-	log.Infof("ComputeClusterCosts: queryTotalStorage: %s", queryTotalStorage)
 
 	ctx := prom.NewContext(client)
 
@@ -234,10 +227,6 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 		queryCPUModePct := fmt.Sprintf(fmtQueryCPUModePct, window, fmtOffset, window, fmtOffset)
 		queryRAMSystemPct := fmt.Sprintf(fmtQueryRAMSystemPct, window, minsPerResolution, fmtOffset, window, minsPerResolution, fmtOffset)
 		queryRAMUserPct := fmt.Sprintf(fmtQueryRAMUserPct, window, minsPerResolution, fmtOffset, window, minsPerResolution, fmtOffset)
-
-		log.Infof("ComputeClusterCosts: queryCPUModePct: %s", queryCPUModePct)
-		log.Infof("ComputeClusterCosts: queryRAMSystemPct: %s", queryRAMSystemPct)
-		log.Infof("ComputeClusterCosts: queryRAMUserPct: %s", queryRAMUserPct)
 
 		bdResChs := ctx.QueryAll(
 			queryCPUModePct,


### PR DESCRIPTION
## Changes
- Query for data count with equal resolution to cost data, so that mismatch in granularity stops causing oscillating rate data
- Remove logs

## Testing
Installed fresh from master, confirmed costs jumping. Then installed this change, confirmed costs are more stable.

### Before
2m
![Screenshot from 2020-05-21 10-15-05](https://user-images.githubusercontent.com/8070055/82581102-458ee080-9b4d-11ea-87f6-ee6985642d20.png)
3m
![Screenshot from 2020-05-21 10-17-49](https://user-images.githubusercontent.com/8070055/82581106-46c00d80-9b4d-11ea-9aef-efa113788b73.png)
4m
![Screenshot from 2020-05-21 10-18-39](https://user-images.githubusercontent.com/8070055/82581108-46c00d80-9b4d-11ea-8816-eb5cb666632f.png)
5m (correct)
![Screenshot from 2020-05-21 10-19-46](https://user-images.githubusercontent.com/8070055/82581110-4758a400-9b4d-11ea-8c44-9f8281dc4220.png)
6m (back up)
![Screenshot from 2020-05-21 10-20-10](https://user-images.githubusercontent.com/8070055/82581112-4758a400-9b4d-11ea-8b18-436be62fc41f.png)


### After
8m
![Screenshot from 2020-05-21 10-23-18](https://user-images.githubusercontent.com/8070055/82581177-69eabd00-9b4d-11ea-98bd-974aca9ef19e.png)

9m
![Screenshot from 2020-05-21 10-25-49](https://user-images.githubusercontent.com/8070055/82581243-7e2eba00-9b4d-11ea-8eeb-0144f5259417.png)
