### PR TITLE
CPU Optimization

### DIFF
--- a/pkg/util/vector.go
+++ b/pkg/util/vector.go
@@ -68,7 +68,7 @@ func ApplyVectorOp(xvs []*Vector, yvs []*Vector, op VectorJoinOp) []*Vector {
 		// round all non-zero timestamps to the nearest 10 second mark
 		xv.Timestamp = roundTimestamp(xv.Timestamp, 10.0)
 
-		xMap[xv.Timestamp] = xv.Value
+		xMap[uint64(xv.Timestamp)] = xv.Value
 		timestamps = append(timestamps, &Vector{
 			Timestamp: xv.Timestamp,
 		})
@@ -85,8 +85,8 @@ func ApplyVectorOp(xvs []*Vector, yvs []*Vector, op VectorJoinOp) []*Vector {
 		// round all non-zero timestamps to the nearest 10 second mark
 		yv.Timestamp = roundTimestamp(yv.Timestamp, 10.0)
 
-		yMap[yv.Timestamp] = yv.Value
-		if _, ok := xMap[yv.Timestamp]; !ok {
+		yMap[uint64(yv.Timestamp)] = yv.Value
+		if _, ok := xMap[uint64(yv.Timestamp)]; !ok {
 			// no need to double add, since we'll range over sorted timestamps and check.
 			timestamps = append(timestamps, &Vector{
 				Timestamp: yv.Timestamp,
@@ -98,8 +98,8 @@ func ApplyVectorOp(xvs []*Vector, yvs []*Vector, op VectorJoinOp) []*Vector {
 	// reuse the existing slice to reduce allocations
 	result := timestamps[:0]
 	for _, sv := range timestamps {
-		x, okX := xMap[sv.Timestamp]
-		y, okY := yMap[sv.Timestamp]
+		x, okX := xMap[uint64(sv.Timestamp)]
+		y, okY := yMap[uint64(sv.Timestamp)]
 
 		if op(sv, VectorValue(x, okX), VectorValue(y, okY)) {
 			result = append(result, sv)

--- a/test/keytuple_test.go
+++ b/test/keytuple_test.go
@@ -1,0 +1,93 @@
+package costmodel_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubecost/cost-model/pkg/costmodel"
+)
+
+func TestKeyTupleSplit(t *testing.T) {
+	const (
+		ns        = "kubecost"
+		key       = "my-pod"
+		clusterID = "cluster-one"
+		fullKey   = "kubecost,my-pod,cluster-one"
+	)
+
+	kt, err := costmodel.NewKeyTuple(fullKey)
+	if err != nil {
+		t.Errorf("Error: %s\n", err)
+		return
+	}
+
+	t.Logf("Namespace: %s, Key: %s, ClusterID: %s\n", kt.Namespace(), kt.Key(), kt.ClusterID())
+
+	if !strings.EqualFold(kt.Namespace(), ns) {
+		t.Errorf("Namespace: \"%s\" != \"%s\"", kt.Namespace(), ns)
+		return
+	}
+	if !strings.EqualFold(kt.Key(), key) {
+		t.Errorf("Key: \"%s\" != \"%s\"\n", kt.Key(), key)
+		return
+	}
+	if !strings.EqualFold(kt.ClusterID(), clusterID) {
+		t.Errorf("ClusterID: \"%s\" != \"%s\"\n", kt.ClusterID(), clusterID)
+		return
+	}
+}
+
+func TestKeyTupleSingleFail(t *testing.T) {
+	_, err := costmodel.NewKeyTuple("foo")
+	if err == nil {
+		t.Errorf("Error was non-nil for single element!")
+		return
+	}
+}
+
+func TestKeyTupleDoubleFail(t *testing.T) {
+	_, err := costmodel.NewKeyTuple("foo,bar")
+	if err == nil {
+		t.Errorf("Error was non-nil for two elements!")
+		return
+	}
+}
+
+func TestKeyTupleMoreThanThreeFail(t *testing.T) {
+	_, err := costmodel.NewKeyTuple("foo,bar,fizz,buzz")
+	if err == nil {
+		t.Errorf("Error was non-nil for two elements!")
+		return
+	}
+}
+
+func TestOnlyCommas(t *testing.T) {
+	kt, err := costmodel.NewKeyTuple(",,")
+	if err != nil {
+		t.Errorf("Error: %s\n", err)
+		return
+	}
+
+	t.Logf("Namespace: \"%s\", Key: \"%s\", ClusterID: \"%s\"\n", kt.Namespace(), kt.Key(), kt.ClusterID())
+
+	if !strings.EqualFold(kt.Namespace(), "") {
+		t.Errorf("Namespace: \"%s\" != \"%s\"", kt.Namespace(), "")
+		return
+	}
+	if !strings.EqualFold(kt.Key(), "") {
+		t.Errorf("Key: \"%s\" != \"%s\"\n", kt.Key(), "")
+		return
+	}
+	if !strings.EqualFold(kt.ClusterID(), "") {
+		t.Errorf("ClusterID: \"%s\" != \"%s\"\n", kt.ClusterID(), "")
+		return
+	}
+}
+
+func TestManyEntrys(t *testing.T) {
+	_, err := costmodel.NewKeyTuple("a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p")
+	if err == nil {
+		t.Errorf("Error was non-nil for single element!")
+		return
+	}
+}


### PR DESCRIPTION
### Map Clear Proposed Solution 
For `map[float64]float64`, we should update the pool to use `uint64` keys.

* We're already rounding all non-zero timestamps to the nearest 10 second. 
```mark xv.Timestamp = roundTimestamp(xv.Timestamp, 10.0)```
* Instead of updating the `Vector` struct to use a `uint64` Timestamp, we'll just cast to an `uint64` before accessing the maps.
* This will cause the go compiler to convert the key deletion iteration to `runtime.mapclear()` which is way more performant.

---
### NewKeyTuple Proposed Solution
`NewKeyTuple()` is a function that takes a key, runs `string.Split(key, ",")` and then returns an object containing `Namespace()`, `PodName()`, etc... This is, of course, better than a reverse map, but `string.Split()` allocates every call.

* `NewKeyTuple()` should create a key type that leverages string. Instead of running `strings.Split()`, it should scan the runes for ',' and generate substr bounds within the string.
* `Namespace()` would return `key[0:8]` where `8` is the index of the first , etc....
* This leverages the preallocated string data without having the allocate a new `[]string` every call