### PR TITLE
fix: removing duplicated node name labels

### DIFF
--- a/PROMETHEUS.md
+++ b/PROMETHEUS.md
@@ -14,7 +14,7 @@ After deploying the Kubecost model (see [README](README.md) for more info on ins
   static_configs:
   - targets:
     - < address of cost-model service> # example: <service-name>.<namespace>:<port>
-``` 
+```
 
 ## Example queries
 
@@ -23,10 +23,10 @@ Below are a set of sample queries that can be run after Prometheus begins ingest
 __Monthly cost of top 5 containers__
 
 ```
-topk( 5, 
-  container_memory_allocation_bytes* on(instance) group_left() node_ram_hourly_cost  / 1024 / 1024 / 1024 * 730
-  + 
-  container_cpu_allocation * on(instance) group_left() node_cpu_hourly_cost * 730
+topk( 5,
+  container_memory_allocation_bytes* on(node) group_left() node_ram_hourly_cost  / 1024 / 1024 / 1024 * 730
+  +
+  container_cpu_allocation * on(node) group_left() node_cpu_hourly_cost * 730
 )
 ```
 
@@ -34,9 +34,9 @@ __Hourly memory cost for the *default* namespace__
 
 ```
 sum(
-  avg(container_memory_allocation_bytes{namespace="default"}) by (instance) / 1024 / 1024 / 1024
-  * 
-  on(instance) group_left() avg(node_ram_hourly_cost) by (instance)
+  avg(container_memory_allocation_bytes{namespace="default"}) by (node) / 1024 / 1024 / 1024
+  *
+  on(node) group_left() avg(node_ram_hourly_cost) by (node)
 )
 ```
 

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -129,8 +129,8 @@ const (
 		label_replace(
 			label_replace(
 				avg(
-					count_over_time(kube_pod_container_resource_requests_memory_bytes{container!="",container!="POD", node!=""}[%s] %s) 
-					*  
+					count_over_time(kube_pod_container_resource_requests_memory_bytes{container!="",container!="POD", node!=""}[%s] %s)
+					*
 					avg_over_time(kube_pod_container_resource_requests_memory_bytes{container!="",container!="POD", node!=""}[%s] %s)
 				) by (namespace,container,pod,node,cluster_id) , "container_name","$1","container","(.+)"
 			), "pod_name","$1","pod","(.+)"
@@ -138,45 +138,43 @@ const (
 	) by (namespace,container_name,pod_name,node,cluster_id)`
 	queryRAMUsageStr = `sort_desc(
 		avg(
-			label_replace(count_over_time(container_memory_working_set_bytes{container_name!="",container_name!="POD", instance!=""}[%s] %s), "node", "$1", "instance","(.+)") 
-			* 
-			label_replace(avg_over_time(container_memory_working_set_bytes{container_name!="",container_name!="POD", instance!=""}[%s] %s), "node", "$1", "instance","(.+)") 
+			count_over_time(container_memory_working_set_bytes{container_name!="",container_name!="POD", node!=""}[%s] %s)
+			*
+			avg_over_time(container_memory_working_set_bytes{container_name!="",container_name!="POD", node!=""}[%s] %s)
 		) by (namespace,container_name,pod_name,node,cluster_id)
 	)`
 	queryCPURequestsStr = `avg(
 		label_replace(
 			label_replace(
 				avg(
-					count_over_time(kube_pod_container_resource_requests_cpu_cores{container!="",container!="POD", node!=""}[%s] %s) 
-					*  
+					count_over_time(kube_pod_container_resource_requests_cpu_cores{container!="",container!="POD", node!=""}[%s] %s)
+					*
 					avg_over_time(kube_pod_container_resource_requests_cpu_cores{container!="",container!="POD", node!=""}[%s] %s)
-				) by (namespace,container,pod,node,cluster_id) , "container_name","$1","container","(.+)"
+				) by (namespace,container,pod,node,cluster_id), "container_name","$1","container","(.+)"
 			), "pod_name","$1","pod","(.+)"
-		) 
+		)
 	) by (namespace,container_name,pod_name,node,cluster_id)`
 	queryCPUUsageStr = `avg(
-		label_replace(
-		rate( 
-			container_cpu_usage_seconds_total{container_name!="",container_name!="POD",instance!=""}[%s] %s
-		) , "node", "$1", "instance", "(.+)"
+		rate(
+			container_cpu_usage_seconds_total{container_name!="",container_name!="POD",node!=""}[%s] %s
 		)
 	) by (namespace,container_name,pod_name,node,cluster_id)`
 	queryGPURequestsStr = `avg(
 		label_replace(
 			label_replace(
 				avg(
-					count_over_time(kube_pod_container_resource_requests{resource="nvidia_com_gpu", container!="",container!="POD", node!=""}[%s] %s) 
-					*  
+					count_over_time(kube_pod_container_resource_requests{resource="nvidia_com_gpu", container!="",container!="POD", node!=""}[%s] %s)
+					*
 					avg_over_time(kube_pod_container_resource_requests{resource="nvidia_com_gpu", container!="",container!="POD", node!=""}[%s] %s)
 					* %f
 				) by (namespace,container,pod,node,cluster_id) , "container_name","$1","container","(.+)"
 			), "pod_name","$1","pod","(.+)"
-		) 
-	) by (namespace,container_name,pod_name,node,cluster_id) 
+		)
+	) by (namespace,container_name,pod_name,node,cluster_id)
 	* on (pod_name, namespace, cluster_id) group_left(container) label_replace(avg(avg_over_time(kube_pod_status_phase{phase="Running"}[%s] %s)) by (pod,namespace,cluster_id), "pod_name","$1","pod","(.+)")`
-	queryPVRequestsStr = `avg(avg(kube_persistentvolumeclaim_info) by (persistentvolumeclaim, storageclass, namespace, volumename, cluster_id) 
-	* 
-	on (persistentvolumeclaim, namespace, cluster_id) group_right(storageclass, volumename) 
+	queryPVRequestsStr = `avg(avg(kube_persistentvolumeclaim_info) by (persistentvolumeclaim, storageclass, namespace, volumename, cluster_id)
+	*
+	on (persistentvolumeclaim, namespace, cluster_id) group_right(storageclass, volumename)
 	sum(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim, namespace, cluster_id, kubernetes_name)) by (persistentvolumeclaim, storageclass, namespace, volumename, cluster_id)`
 	// queryRAMAllocationByteHours yields the total byte-hour RAM allocation over the given
 	// window, aggregated by container.
@@ -960,9 +958,9 @@ func findDeletedNodeInfo(cli prometheusClient.Client, missingNodes map[string]*c
 		}
 		l := strings.Join(q, "|")
 
-		queryHistoricalCPUCost := fmt.Sprintf(`avg_over_time(node_cpu_hourly_cost{instance=~"%s"}[%s])`, l, window)
-		queryHistoricalRAMCost := fmt.Sprintf(`avg_over_time(node_ram_hourly_cost{instance=~"%s"}[%s])`, l, window)
-		queryHistoricalGPUCost := fmt.Sprintf(`avg_over_time(node_gpu_hourly_cost{instance=~"%s"}[%s])`, l, window)
+		queryHistoricalCPUCost := fmt.Sprintf(`avg_over_time(node_cpu_hourly_cost{node=~"%s"}[%s])`, l, window)
+		queryHistoricalRAMCost := fmt.Sprintf(`avg_over_time(node_ram_hourly_cost{node=~"%s"}[%s])`, l, window)
+		queryHistoricalGPUCost := fmt.Sprintf(`avg_over_time(node_gpu_hourly_cost{node=~"%s"}[%s])`, l, window)
 
 		cpuCostResult, err := Query(cli, queryHistoricalCPUCost)
 		if err != nil {

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -726,11 +726,11 @@ func (a *Accesses) recordPrices() {
 
 				totalCost := cpu*cpuCost + ramCost*(ram/1024/1024/1024) + gpu*gpuCost
 
-				a.CPUPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion).Set(cpuCost)
-				a.RAMPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion).Set(ramCost)
-				a.GPUPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion).Set(gpuCost)
-				a.NodeTotalPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion).Set(totalCost)
-				labelKey := getKeyFromLabelStrings(nodeName, nodeName)
+				a.CPUPriceRecorder.WithLabelValues(nodeName, nodeType, nodeRegion).Set(cpuCost)
+				a.RAMPriceRecorder.WithLabelValues(nodeName, nodeType, nodeRegion).Set(ramCost)
+				a.GPUPriceRecorder.WithLabelValues(nodeName, nodeType, nodeRegion).Set(gpuCost)
+				a.NodeTotalPriceRecorder.WithLabelValues(nodeName, nodeType, nodeRegion).Set(totalCost)
+				labelKey := getKeyFromLabelStrings(nodeName)
 				nodeSeen[labelKey] = true
 			}
 
@@ -752,16 +752,16 @@ func (a *Accesses) recordPrices() {
 				}
 
 				if len(costs.RAMAllocation) > 0 {
-					a.RAMAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName, nodeName).Set(costs.RAMAllocation[0].Value)
+					a.RAMAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName).Set(costs.RAMAllocation[0].Value)
 				}
 				if len(costs.CPUAllocation) > 0 {
-					a.CPUAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName, nodeName).Set(costs.CPUAllocation[0].Value)
+					a.CPUAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName).Set(costs.CPUAllocation[0].Value)
 				}
 				if len(costs.GPUReq) > 0 {
 					// allocation here is set to the request because shared GPU usage not yet supported.
-					a.GPUAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName, nodeName).Set(costs.GPUReq[0].Value)
+					a.GPUAllocationRecorder.WithLabelValues(namespace, podName, containerName, nodeName).Set(costs.GPUReq[0].Value)
 				}
-				labelKey := getKeyFromLabelStrings(namespace, podName, containerName, nodeName, nodeName)
+				labelKey := getKeyFromLabelStrings(namespace, podName, containerName, nodeName)
 				if podStatus[podName] == v1.PodRunning { // Only report data for current pods
 					containerSeen[labelKey] = true
 				} else {
@@ -1027,22 +1027,22 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 	cpuGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "node_cpu_hourly_cost",
 		Help: "node_cpu_hourly_cost hourly cost for each cpu on this node",
-	}, []string{"instance", "node", "instance_type", "region"})
+	}, []string{"node", "instance_type", "region"})
 
 	ramGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "node_ram_hourly_cost",
 		Help: "node_ram_hourly_cost hourly cost for each gb of ram on this node",
-	}, []string{"instance", "node", "instance_type", "region"})
+	}, []string{"node", "instance_type", "region"})
 
 	gpuGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "node_gpu_hourly_cost",
 		Help: "node_gpu_hourly_cost hourly cost for each gpu on this node",
-	}, []string{"instance", "node", "instance_type", "region"})
+	}, []string{"node", "instance_type", "region"})
 
 	totalGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "node_total_hourly_cost",
 		Help: "node_total_hourly_cost Total node cost per hour",
-	}, []string{"instance", "node", "instance_type", "region"})
+	}, []string{"node", "instance_type", "region"})
 
 	pvGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pv_hourly_cost",
@@ -1052,17 +1052,17 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 	RAMAllocation := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "container_memory_allocation_bytes",
 		Help: "container_memory_allocation_bytes Bytes of RAM used",
-	}, []string{"namespace", "pod", "container", "instance", "node"})
+	}, []string{"namespace", "pod", "container", "node"})
 
 	CPUAllocation := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "container_cpu_allocation",
 		Help: "container_cpu_allocation Percent of a single CPU used in a minute",
-	}, []string{"namespace", "pod", "container", "instance", "node"})
+	}, []string{"namespace", "pod", "container", "node"})
 
 	GPUAllocation := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "container_gpu_allocation",
 		Help: "container_gpu_allocation GPU used",
-	}, []string{"namespace", "pod", "container", "instance", "node"})
+	}, []string{"namespace", "pod", "container", "node"})
 	PVAllocation := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pod_pvc_allocation",
 		Help: "pod_pvc_allocation Bytes used by a PVC attached to a pod",


### PR DESCRIPTION
some metrics are exposed with an `instance` and a `node` label, and both have the same values.

as far as I was able to look at, the places where `instance` is used, `node` could be used instead.

this patch (although I'm not yet 100% sure is correct) would reduce metric cardinality (specially in clusters that autoscale a lot and/or with spot/preemptible nodes) and improve query performance by dropping some `label_replace`s. 