### PR TITLE
Rate Limited Prometheus Client

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubecost/cost-model/pkg/clustercache"
 	cm "github.com/kubecost/cost-model/pkg/clustermanager"
 	"github.com/kubecost/cost-model/pkg/errors"
+	"github.com/kubecost/cost-model/pkg/log"
 	"github.com/kubecost/cost-model/pkg/prom"
 	prometheusClient "github.com/prometheus/client_golang/api"
 	prometheusAPI "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -174,7 +175,7 @@ func maxQueryConcurrency() int {
 
 	result, err := strconv.Atoi(v)
 	if err != nil {
-		klog.Infof("[Warning] Failed to parse MAX_QUERY_CONCURRENCY. Defaulting to 5 - %s", err)
+		log.Warningf("Failed to parse MAX_QUERY_CONCURRENCY. Defaulting to 5 - %s", err)
 		return 5
 	}
 

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubecost/cost-model/pkg/clustercache"
 	cm "github.com/kubecost/cost-model/pkg/clustermanager"
 	"github.com/kubecost/cost-model/pkg/errors"
+	"github.com/kubecost/cost-model/pkg/prom"
 	prometheusClient "github.com/prometheus/client_golang/api"
 	prometheusAPI "github.com/prometheus/client_golang/api/prometheus/v1"
 	v1 "k8s.io/api/core/v1"
@@ -40,6 +41,7 @@ const (
 	logCollectionEnvVar            = "LOG_COLLECTION_ENABLED"
 	productAnalyticsEnvVar         = "PRODUCT_ANALYTICS_ENABLED"
 	errorReportingEnvVar           = "ERROR_REPORTING_ENABLED"
+	maxQueryConcurrencyEnvVar      = "MAX_QUERY_CONCURRENCY"
 	prometheusServerEndpointEnvVar = "PROMETHEUS_SERVER_ENDPOINT"
 	prometheusTroubleshootingEp    = "http://docs.kubecost.com/custom-prom#troubleshoot"
 	RFC3339Milli                   = "2006-01-02T15:04:05.000Z"
@@ -161,6 +163,22 @@ func normalizeTimeParam(param string) (string, error) {
 	}
 
 	return param, nil
+}
+
+// Parses the max query concurrency environment variable
+func maxQueryConcurrency() int {
+	v := os.Getenv(maxQueryConcurrencyEnvVar)
+	if v == "" {
+		return 5
+	}
+
+	result, err := strconv.Atoi(v)
+	if err != nil {
+		klog.Infof("[Warning] Failed to parse MAX_QUERY_CONCURRENCY. Defaulting to 5 - %s", err)
+		return 5
+	}
+
+	return result
 }
 
 // writeReportingFlags writes the reporting flags to the cluster info map
@@ -928,6 +946,8 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 		klog.Fatalf("No address for prometheus set in $%s. Aborting.", prometheusServerEndpointEnvVar)
 	}
 
+	queryConcurrency := maxQueryConcurrency()
+
 	var LongTimeoutRoundTripper http.RoundTripper = &http.Transport{ // may be necessary for long prometheus queries. TODO: make this configurable
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -941,7 +961,7 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 		Address:      address,
 		RoundTripper: LongTimeoutRoundTripper,
 	}
-	promCli, _ := prometheusClient.NewClient(pc)
+	promCli, _ := prom.NewRateLimitedClient(pc, queryConcurrency)
 
 	m, err := ValidatePrometheus(promCli, false)
 	if err != nil || m.Running == false {
@@ -1155,7 +1175,7 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 				Address:      thanosUrl,
 				RoundTripper: thanosRT,
 			}
-			thanosCli, _ := prometheusClient.NewClient(thanosConfig)
+			thanosCli, _ := prom.NewRateLimitedClient(thanosConfig, queryConcurrency)
 
 			_, err = ValidatePrometheus(thanosCli, true)
 			if err != nil {

--- a/pkg/prom/prom.go
+++ b/pkg/prom/prom.go
@@ -1,0 +1,46 @@
+package prom
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/kubecost/cost-model/pkg/util"
+	prometheus "github.com/prometheus/client_golang/api"
+)
+
+// NewRateLimitedClient creates a prometheus client which limits the number of concurrent outbound
+// prometheus requests.
+func NewRateLimitedClient(config prometheus.Config, maxConcurrency int) (prometheus.Client, error) {
+	c, err := prometheus.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	limiter := util.NewSemaphore(maxConcurrency)
+
+	return &RateLimitedPrometheusClient{
+		client:  c,
+		limiter: limiter,
+	}, nil
+}
+
+// Creates a new prometheus client which limits the total number of concurrent outbound requests
+// allowed at a given moment.
+type RateLimitedPrometheusClient struct {
+	client  prometheus.Client
+	limiter *util.Semaphore
+}
+
+// Passthrough to the prometheus client API
+func (rlpc *RateLimitedPrometheusClient) URL(ep string, args map[string]string) *url.URL {
+	return rlpc.URL(ep, args)
+}
+
+// Rate limit and passthrough to prometheus client API
+func (rlpc *RateLimitedPrometheusClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, prometheus.Warnings, error) {
+	rlpc.limiter.Acquire()
+	defer rlpc.limiter.Return()
+
+	return rlpc.client.Do(ctx, req)
+}


### PR DESCRIPTION
* Add a rate limiting prometheus client implementation
* Remove query context rate limiting
* Allow max concurrency to be passed via env var