### PR TITLE
fix monthly/hourly discrepancy on certain fields

### DIFF
--- a/pkg/cloud/providerconfig.go
+++ b/pkg/cloud/providerconfig.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -138,6 +139,14 @@ func (pc *ProviderConfig) UpdateFromMap(a map[string]string) (*CustomPricing, er
 		for k, v := range a {
 			// Just so we consistently supply / receive the same values, uppercase the first letter.
 			kUpper := strings.Title(k)
+			if kUpper == "CPU" || kUpper == "SpotCPU" || kUpper == "RAM" || kUpper == "SpotRAM" || kUpper == "GPU" || kUpper == "Storage" {
+				val, err := strconv.ParseFloat(v, 64)
+				if err != nil {
+					return fmt.Errorf("Unable to parse CPU from string to float: %s", err.Error())
+				}
+				v = fmt.Sprintf("%f", val/730)
+			}
+
 			err := SetCustomPricingField(c, kUpper, v)
 			if err != nil {
 				return err


### PR DESCRIPTION
Tested from configmap & frontend. No change on frontend but this will greatly simplify the helm chart, even if this code is a mess.

See also: https://github.com/kubecost/cost-analyzer-helm-chart/pull/547