### PR TITLE
first pass of savings plan implementation

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -1957,7 +1957,6 @@ func (f fnames) Less(i, j int) bool {
 
 func parseSpotData(bucket string, prefix string, projectID string, region string, accessKeyID string, accessKeySecret string) (map[string]*spotInfo, error) {
 	// credentials may exist on the actual AWS node-- if so, use those. If not, override with the service key
-	klog.Infof("AWS KEY USED FOR SPOT: '%s'", accessKeyID)
 	if accessKeyID != "" && accessKeySecret != "" {
 		err := env.Set(env.AWSAccessKeyIDEnvVar, accessKeyID)
 		if err != nil {


### PR DESCRIPTION
First pass of savingsplan implementation. Use SavingsPlan/SavingsPlanEffectiveCost as an hourly node price.

Testing: Compare logs to AWS data.

I0727 01:51:32.190320       1 awsprovider.go:1508] StartQueryExecution result:
I0727 01:51:32.190517       1 awsprovider.go:1509] {
  QueryExecutionId: "9df49495-00cf-4515-895b-2fda5bbb3720"
}
I0727 01:51:36.429582       1 awsprovider.go:1574] Fetching SavingsPlan data...
I0727 01:51:36.429603       1 awsprovider.go:1597] Found 2 savings plan applied instances
I0727 01:51:36.429611       1 awsprovider.go:1599] Reserved Instance Data found for node i-071001c20d001bb6b : 0.019200 at time 2020-07-26 11:00:00.000
I0727 01:51:36.429633       1 awsprovider.go:1599] Reserved Instance Data found for node i-0bc472d64082379e4 : 0.030800 at time 2020-07-26 11:00:00.000
