### PR TITLE
Add ProviderID to node metrics

### DIFF
--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -61,6 +61,7 @@ type Node struct {
 	InstanceType     string                `json:"instanceType,omitempty"`
 	Region           string                `json:"region,omitempty"`
 	Reserved         *ReservedInstanceData `json:"reserved,omitempty"`
+	ProviderID       string                `json:"providerID,omitempty"`
 }
 
 // IsSpot determines whether or not a Node uses spot by usage type

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1158,6 +1158,7 @@ func (cm *CostModel) GetNodeCost(cp costAnalyzerCloud.Provider) (map[string]*cos
 		if newCnode.Region == "" {
 			newCnode.Region = n.Labels[v1.LabelZoneRegion]
 		}
+		newCnode.ProviderID = n.Spec.ProviderID
 
 		var cpu float64
 		if newCnode.VCPU == "" {

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -751,10 +751,10 @@ func (a *Accesses) recordPrices() {
 
 				totalCost := cpu*cpuCost + ramCost*(ram/1024/1024/1024) + gpu*gpuCost
 
-				a.CPUPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion).Set(cpuCost)
-				a.RAMPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion).Set(ramCost)
-				a.GPUPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion).Set(gpuCost)
-				a.NodeTotalPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion).Set(totalCost)
+				a.CPUPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion, node.ProviderID).Set(cpuCost)
+				a.RAMPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion, node.ProviderID).Set(ramCost)
+				a.GPUPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion, node.ProviderID).Set(gpuCost)
+				a.NodeTotalPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion, node.ProviderID).Set(totalCost)
 				labelKey := getKeyFromLabelStrings(nodeName, nodeName)
 				nodeSeen[labelKey] = true
 			}
@@ -1058,22 +1058,22 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 	cpuGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "node_cpu_hourly_cost",
 		Help: "node_cpu_hourly_cost hourly cost for each cpu on this node",
-	}, []string{"instance", "node", "instance_type", "region"})
+	}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 
 	ramGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "node_ram_hourly_cost",
 		Help: "node_ram_hourly_cost hourly cost for each gb of ram on this node",
-	}, []string{"instance", "node", "instance_type", "region"})
+	}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 
 	gpuGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "node_gpu_hourly_cost",
 		Help: "node_gpu_hourly_cost hourly cost for each gpu on this node",
-	}, []string{"instance", "node", "instance_type", "region"})
+	}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 
 	totalGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "node_total_hourly_cost",
 		Help: "node_total_hourly_cost Total node cost per hour",
-	}, []string{"instance", "node", "instance_type", "region"})
+	}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 
 	pvGv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pv_hourly_cost",


### PR DESCRIPTION
Required for https://github.com/kubecost/kubecost-cost-model/pull/184

## Changes
- Adds `provider_id` to four node metrics: 
  - node_cpu_hourly_cost
  - node_ram_hourly_cost
  - node_gpu_hourly_cost
  - node_total_hourly_cost

## Testing
Manually tested on GCP querying `node_total_hourly_cost`
```
node_total_hourly_cost{instance="gke-niko-n1-standard-2-wljla-8df8e58a-hfy7",instance_type="n1-standard-2",job="kubecost",node="gke-niko-n1-standard-2-wljla-8df8e58a-hfy7",provider_id="gce://guestbook-227502/us-central1-a/gke-niko-n1-standard-2-wljla-8df8e58a-hfy7",region="us-central1"} | 0.0941597579689026
```