### PR TITLE
Return error from ClusterCosts if a query fails

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -275,6 +275,10 @@ func ComputeClusterCosts(client prometheus.Client, provider cloud.Provider, wind
 	setCostsFromResults(costData, resChs[4].Await(), "storage", 0.0, customDiscount)
 	setCostsFromResults(costData, resChs[5].Await(), "localstorage", 0.0, customDiscount)
 
+	if ctx.ErrorCollector.IsError() {
+		return nil, ctx.Errors()[0]
+	}
+
 	cpuBreakdownMap := map[string]*ClusterCostsBreakdown{}
 	ramBreakdownMap := map[string]*ClusterCostsBreakdown{}
 	pvUsedCostMap := map[string]float64{}


### PR DESCRIPTION
The title says it all. Before we simply weren't checking the context's error collector, and so we'd just never return an error, returning empty results instead.