### PR TITLE
Capture CronJob name without timestamp

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,6 +49,9 @@ const (
 	epConfig          = apiPrefix + "/status/config"
 	epFlags           = apiPrefix + "/status/flags"
 )
+
+// isCron matches a CronJob name and captures the non-timestamp name
+var isCron = regexp.MustCompile(`^(.+)-\d{10}$`)
 
 type CostModel struct {
 	Cache        clustercache.ClusterCache
@@ -115,6 +119,11 @@ func (cd *CostData) GetController() (name string, kind string, hasController boo
 		name = cd.Jobs[0]
 		kind = "job"
 		hasController = true
+
+		match := isCron.FindStringSubmatch(name)
+		if match != nil {
+			name = match[1]
+		}
 	}
 
 	return name, kind, hasController


### PR DESCRIPTION
## Changes
- If job name ends with timestamp, drop it so that CronJobs are treated like regualr Jobs

## Testing
- Manually on gcp-niko

`cost-analyzer-checks` is a CronJob with Job names like `cost-analyzer-checks-1596756244`
![Screenshot from 2020-08-06 17-20-35](https://user-images.githubusercontent.com/8070055/89592327-912a5f80-d809-11ea-88f3-623e3994fada.png)
