### PR TITLE
support running cost-model locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,15 @@ To test, build the cost-model docker container and then push it to a Kubernetes 
 
 To confirm that the server is running, you can hit [http://localhost:9003/costDataModel?timeWindow=1d](http://localhost:9003/costDataModel?timeWindow=1d)
 
+## Running locally ##
+
+In order to run cost-model locally, or outside of the runtime of a Kubernetes cluster, you can set the environment variable `KUBECONFIG_PATH`.
+
+Example:
+```bash
+export KUBECONFIG_PATH=~/.kube/config
+```
+
 ## Running the integration tests ##
 To run these tests:
 * Make sure you have a kubeconfig that can point to your cluster, and have permissions to create/modify a namespace called "test"

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -36,6 +36,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -764,7 +765,13 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 	}
 
 	// Kubernetes API setup
-	kc, err := rest.InClusterConfig()
+	var kc *rest.Config
+	if kubeconfig := env.GetKubeConfigPath(); kubeconfig != "" {
+		kc, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		kc, err = rest.InClusterConfig()
+	}
+
 	if err != nil {
 		panic(err.Error())
 	}

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -37,6 +37,8 @@ const (
 	MultiClusterBearerToken       = "MC_BEARER_TOKEN"
 
 	InsecureSkipVerify = "INSECURE_SKIP_VERIFY"
+
+	KubeConfigPathEnvVar = "KUBECONFIG_PATH"
 )
 
 // GetAWSAccessKeyID returns the environment variable value for AWSAccessKeyIDEnvVar which represents
@@ -208,4 +210,9 @@ func GetMultiClusterBasicAuthPassword() string {
 
 func GetMultiClusterBearerToken() string {
 	return Get(MultiClusterBearerToken, "")
+}
+
+// GetKubeConfigPath returns the environment variable value for KubeConfigPathEnvVar
+func GetKubeConfigPath() string {
+	return Get(KubeConfigPathEnvVar, "")
 }


### PR DESCRIPTION
expose the env var KUBECONFIG_PATH in order to run cost-model outside of a kubernetes pod.