### PR TITLE
Prevent nil *QueryResults error

### DIFF
--- a/pkg/prom/query.go
+++ b/pkg/prom/query.go
@@ -60,8 +60,10 @@ func (ctx *Context) Query(query string) QueryResultsChan {
 		raw, promErr := ctx.query(query)
 		ctx.ErrorCollector.Report(promErr)
 
-		results, parseErr := NewQueryResults(query, raw)
-		ctx.ErrorCollector.Report(parseErr)
+		results := NewQueryResults(query, raw)
+		if results.Error != nil {
+			ctx.ErrorCollector.Report(results.Error)
+		}
 
 		resCh <- results
 	}(ctx, resCh)
@@ -89,9 +91,9 @@ func (ctx *Context) QuerySync(query string) ([]*QueryResult, error) {
 		return nil, err
 	}
 
-	results, err := NewQueryResults(query, raw)
-	if err != nil {
-		return nil, err
+	results := NewQueryResults(query, raw)
+	if results.Error != nil {
+		return nil, results.Error
 	}
 
 	return results.Results, nil
@@ -143,8 +145,10 @@ func (ctx *Context) QueryRange(query string, start, end time.Time, step time.Dur
 		raw, promErr := ctx.queryRange(query, start, end, step)
 		ctx.ErrorCollector.Report(promErr)
 
-		results, parseErr := NewQueryResults(query, raw)
-		ctx.ErrorCollector.Report(parseErr)
+		results := NewQueryResults(query, raw)
+		if results.Error != nil {
+			ctx.ErrorCollector.Report(results.Error)
+		}
 
 		resCh <- results
 	}(ctx, resCh)
@@ -158,9 +162,9 @@ func (ctx *Context) QueryRangeSync(query string, start, end time.Time, step time
 		return nil, err
 	}
 
-	results, err := NewQueryResults(query, raw)
-	if err != nil {
-		return nil, err
+	results := NewQueryResults(query, raw)
+	if results.Error != nil {
+		return nil, results.Error
 	}
 
 	return results.Results, nil

--- a/pkg/prom/result.go
+++ b/pkg/prom/result.go
@@ -178,10 +178,8 @@ func NewQueryResults(query string, queryResult interface{}) *QueryResults {
 		})
 	}
 
-	return &QueryResults{
-		Query:   query,
-		Results: results,
-	}
+	qrs.Results = results
+	return qrs
 }
 
 // GetString returns the requested field, or an error if it does not exist


### PR DESCRIPTION
## Changes
- Always return a non-nil QueryResults. Now that it includes error, we need to deprecate the extra error and eliminate the `return nil, err` idiom.

## Testing
- Injected random errors, noted that nothing panicked. Queries just retried as expected.