### PR TITLE
Base64 Encode ClusterManager Auth

### DIFF
--- a/pkg/clustermanager/clustermanager.go
+++ b/pkg/clustermanager/clustermanager.go
@@ -222,7 +222,7 @@ func fromSecret(secretName string) (string, error) {
 		return "", fmt.Errorf("Failed to load secret: %s", file)
 	}
 
-	return string(data), nil
+	return base64.StdEncoding.EncodeToString(data), nil
 }
 
 func getAuth(auth *ClusterConfigEntryAuth) (string, error) {


### PR DESCRIPTION
Return the secret auth as base64 encoded.