### PR TITLE
support for cost model currency conversion

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -166,6 +166,9 @@ func (gcp *GCP) GetConfig() (*CustomPricing, error) {
 	if c.NegotiatedDiscount == "" {
 		c.NegotiatedDiscount = "0%"
 	}
+	if c.CurrencyCode == "" {
+		c.CurrencyCode = "USD"
+	}
 	return c, nil
 }
 

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -575,7 +575,7 @@ type GCPPricing struct {
 type PricingInfo struct {
 	Summary                string             `json:"summary"`
 	PricingExpression      *PricingExpression `json:"pricingExpression"`
-	CurrencyConversionRate int                `json:"currencyConversionRate"`
+	CurrencyConversionRate float64            `json:"currencyConversionRate"`
 	EffectiveTime          string             `json:""`
 }
 
@@ -874,7 +874,11 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]Key, pvKeys map[stri
 
 func (gcp *GCP) parsePages(inputKeys map[string]Key, pvKeys map[string]PVKey) (map[string]*GCPPricing, error) {
 	var pages []map[string]*GCPPricing
-	url := "https://cloudbilling.googleapis.com/v1/services/6F81-5844-456A/skus?key=" + gcp.APIKey
+	c, err := gcp.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	url := "https://cloudbilling.googleapis.com/v1/services/6F81-5844-456A/skus?key=" + gcp.APIKey + "&currencyCode=" + c.CurrencyCode
 	klog.V(2).Infof("Fetch GCP Billing Data from URL: %s", url)
 	var parsePagesHelper func(string) error
 	parsePagesHelper = func(pageToken string) error {
@@ -894,7 +898,7 @@ func (gcp *GCP) parsePages(inputKeys map[string]Key, pvKeys map[string]PVKey) (m
 		pages = append(pages, page)
 		return parsePagesHelper(token)
 	}
-	err := parsePagesHelper("")
+	err = parsePagesHelper("")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Tag: add currency conversion support to the cost model (work in progress)

Description: new code calls gcp.GetConfig() and then appends the CurrencyCode to the url, GET request on the url returns json body, after which `nanos` is automatically returned as the new units (e.g., nanos could be 100 in USD, but returns as 135 if `&currencyCode=CAD` is appended to the url), after which it is fed to the client (intended behavior)

Testing: built and pushed to Docker, ran by port forwarding docker url to local. queried Prometheus for `node_total_hourly_cost` to see no value changed upon selecting a different currency in the settings dropdown.

Problems: ran into a bug where json unmarshalling was failing because of PricingInfo struct `CurrencyConversionRate` variable typing, fixed it and now it's back to the original behavior (selecting a different currency in the settings dropdown and saving only changes the currency character in the client, but doesn't convert the numbers)

Questions:
1. What is the code path that calls `DownloadPricingData()` when the currency setting is changed?
2. Does the aforementioned function even need to be called again?
3. Are any of my assumptions in the Description incorrect? How does the back end send the price to the client?