### PR TITLE
Cw 407 load balancer costs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -559,6 +559,7 @@ k8s.io/apimachinery v0.0.0-20190913075812-e119e5e154b6 h1:tGU1C/vMoUV2ZakSH6wQq2
 k8s.io/apimachinery v0.0.0-20190913075812-e119e5e154b6/go.mod h1:nL6pwRT8NgfF8TT68DBI8uEePRt89cSvoXUVqbkWHq4=
 k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
 k8s.io/apimachinery v0.19.0 h1:gjKnAda/HZp5k4xQYjL0K/Yb66IvNqjthCb03QlKpaQ=
+k8s.io/apimachinery v0.19.1 h1:cwsxZazM/LA9aUsBaL4bRS5ygoM6bYp8dFk22DSYQa4=
 k8s.io/client-go v0.0.0-20190404172613-2e1a3ed22ac5 h1:BwY2C//EoWktJi74O6R2REBonrhsfhRI0qfVwOjOPp8=
 k8s.io/client-go v0.0.0-20190404172613-2e1a3ed22ac5/go.mod h1:bIEHXHbykaOlj+pgLllzLJ2RPGdzkjtqdk0Il07KPEM=
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab h1:E8Fecph0qbNsAbijJJQryKu4Oi9QTp5cVpjTE+nqg6g=

--- a/go.sum
+++ b/go.sum
@@ -560,6 +560,7 @@ k8s.io/apimachinery v0.0.0-20190913075812-e119e5e154b6/go.mod h1:nL6pwRT8NgfF8TT
 k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
 k8s.io/apimachinery v0.19.0 h1:gjKnAda/HZp5k4xQYjL0K/Yb66IvNqjthCb03QlKpaQ=
 k8s.io/apimachinery v0.19.1 h1:cwsxZazM/LA9aUsBaL4bRS5ygoM6bYp8dFk22DSYQa4=
+k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/client-go v0.0.0-20190404172613-2e1a3ed22ac5 h1:BwY2C//EoWktJi74O6R2REBonrhsfhRI0qfVwOjOPp8=
 k8s.io/client-go v0.0.0-20190404172613-2e1a3ed22ac5/go.mod h1:bIEHXHbykaOlj+pgLllzLJ2RPGdzkjtqdk0Il07KPEM=
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab h1:E8Fecph0qbNsAbijJJQryKu4Oi9QTp5cVpjTE+nqg6g=

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -848,6 +848,37 @@ func (aws *AWS) NetworkPricing() (*Network, error) {
 	}, nil
 }
 
+func (aws *AWS) LoadBalancerPricing() (*LoadBalancer, error) {
+	cpricing, err := aws.Config.GetCustomPricingData()
+	if err != nil {
+		return nil, err
+	}
+	fffrc, err := strconv.ParseFloat(cpricing.FirstFiveForwardingRulesCost, 64)
+	if err != nil {
+		return nil, err
+	}
+	afrc, err := strconv.ParseFloat(cpricing.AdditionalForwardingRuleCost, 64)
+	if err != nil {
+		return nil, err
+	}
+	lbidc, err := strconv.ParseFloat(cpricing.LBIngressDataCost, 64)
+	if err != nil {
+		return nil, err
+	}
+	var totalCost float64
+	numForwardingRules := 1.0 // hard-code at 1 for now
+	dataIngressGB := 0.0      // hard-code at 0 for now
+
+	if numForwardingRules < 5 {
+		totalCost = fffrc*numForwardingRules + lbidc*dataIngressGB
+	} else {
+		totalCost = fffrc*5 + afrc*(numForwardingRules-5) + lbidc*dataIngressGB
+	}
+	return &LoadBalancer{
+		Cost: totalCost,
+	}, nil
+}
+
 // AllNodePricing returns all the billing data fetched.
 func (aws *AWS) AllNodePricing() (interface{}, error) {
 	aws.DownloadPricingDataLock.RLock()

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -849,26 +849,14 @@ func (aws *AWS) NetworkPricing() (*Network, error) {
 }
 
 func (aws *AWS) LoadBalancerPricing() (*LoadBalancer, error) {
-	cpricing, err := aws.Config.GetCustomPricingData()
-	if err != nil {
-		return nil, err
-	}
-	fffrc, err := strconv.ParseFloat(cpricing.FirstFiveForwardingRulesCost, 64)
-	if err != nil {
-		return nil, err
-	}
-	afrc, err := strconv.ParseFloat(cpricing.AdditionalForwardingRuleCost, 64)
-	if err != nil {
-		return nil, err
-	}
-	lbidc, err := strconv.ParseFloat(cpricing.LBIngressDataCost, 64)
-	if err != nil {
-		return nil, err
-	}
-	var totalCost float64
-	numForwardingRules := 1.0 // hard-code at 1 for now
-	dataIngressGB := 0.0      // hard-code at 0 for now
+	fffrc := 0.025
+	afrc := 0.010
+	lbidc := 0.008
 
+	numForwardingRules := 1.0
+	dataIngressGB := 0.0
+
+	var totalCost float64
 	if numForwardingRules < 5 {
 		totalCost = fffrc*numForwardingRules + lbidc*dataIngressGB
 	} else {

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -651,26 +651,14 @@ func (az *Azure) NetworkPricing() (*Network, error) {
 }
 
 func (azr *Azure) LoadBalancerPricing() (*LoadBalancer, error) {
-	cpricing, err := azr.Config.GetCustomPricingData()
-	if err != nil {
-		return nil, err
-	}
-	fffrc, err := strconv.ParseFloat(cpricing.FirstFiveForwardingRulesCost, 64)
-	if err != nil {
-		return nil, err
-	}
-	afrc, err := strconv.ParseFloat(cpricing.AdditionalForwardingRuleCost, 64)
-	if err != nil {
-		return nil, err
-	}
-	lbidc, err := strconv.ParseFloat(cpricing.LBIngressDataCost, 64)
-	if err != nil {
-		return nil, err
-	}
-	var totalCost float64
-	numForwardingRules := 1.0 // hard-code at 1 for now
-	dataIngressGB := 0.0      // hard-code at 0 for now
+	fffrc := 0.025
+	afrc := 0.010
+	lbidc := 0.008
 
+	numForwardingRules := 1.0
+	dataIngressGB := 0.0
+
+	var totalCost float64
 	if numForwardingRules < 5 {
 		totalCost = fffrc*numForwardingRules + lbidc*dataIngressGB
 	} else {

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -650,6 +650,37 @@ func (az *Azure) NetworkPricing() (*Network, error) {
 	}, nil
 }
 
+func (azr *Azure) LoadBalancerPricing() (*LoadBalancer, error) {
+	cpricing, err := azr.Config.GetCustomPricingData()
+	if err != nil {
+		return nil, err
+	}
+	fffrc, err := strconv.ParseFloat(cpricing.FirstFiveForwardingRulesCost, 64)
+	if err != nil {
+		return nil, err
+	}
+	afrc, err := strconv.ParseFloat(cpricing.AdditionalForwardingRuleCost, 64)
+	if err != nil {
+		return nil, err
+	}
+	lbidc, err := strconv.ParseFloat(cpricing.LBIngressDataCost, 64)
+	if err != nil {
+		return nil, err
+	}
+	var totalCost float64
+	numForwardingRules := 1.0 // hard-code at 1 for now
+	dataIngressGB := 0.0      // hard-code at 0 for now
+
+	if numForwardingRules < 5 {
+		totalCost = fffrc*numForwardingRules + lbidc*dataIngressGB
+	} else {
+		totalCost = fffrc*5 + afrc*(numForwardingRules-5) + lbidc*dataIngressGB
+	}
+	return &LoadBalancer{
+		Cost: totalCost,
+	}, nil
+}
+
 type azurePvKey struct {
 	Labels                 map[string]string
 	StorageClass           string

--- a/pkg/cloud/customprovider.go
+++ b/pkg/cloud/customprovider.go
@@ -240,6 +240,37 @@ func (cp *CustomProvider) NetworkPricing() (*Network, error) {
 	}, nil
 }
 
+func (cp *CustomProvider) LoadBalancerPricing() (*LoadBalancer, error) {
+	cpricing, err := cp.Config.GetCustomPricingData()
+	if err != nil {
+		return nil, err
+	}
+	fffrc, err := strconv.ParseFloat(cpricing.FirstFiveForwardingRulesCost, 64)
+	if err != nil {
+		return nil, err
+	}
+	afrc, err := strconv.ParseFloat(cpricing.AdditionalForwardingRuleCost, 64)
+	if err != nil {
+		return nil, err
+	}
+	lbidc, err := strconv.ParseFloat(cpricing.LBIngressDataCost, 64)
+	if err != nil {
+		return nil, err
+	}
+	var totalCost float64
+	numForwardingRules := 1.0 // hard-code at 1 for now
+	dataIngressGB := 0.0      // hard-code at 0 for now
+
+	if numForwardingRules < 5 {
+		totalCost = fffrc*numForwardingRules + lbidc*dataIngressGB
+	} else {
+		totalCost = fffrc*5 + afrc*(numForwardingRules-5) + lbidc*dataIngressGB
+	}
+	return &LoadBalancer{
+		Cost: totalCost,
+	}, nil
+}
+
 func (*CustomProvider) GetPVKey(pv *v1.PersistentVolume, parameters map[string]string, defaultRegion string) PVKey {
 	return &awsPVKey{
 		Labels:                 pv.Labels,

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -1049,26 +1049,14 @@ func (gcp *GCP) NetworkPricing() (*Network, error) {
 }
 
 func (gcp *GCP) LoadBalancerPricing() (*LoadBalancer, error) {
-	cpricing, err := gcp.Config.GetCustomPricingData()
-	if err != nil {
-		return nil, err
-	}
-	fffrc, err := strconv.ParseFloat(cpricing.FirstFiveForwardingRulesCost, 64)
-	if err != nil {
-		return nil, err
-	}
-	afrc, err := strconv.ParseFloat(cpricing.AdditionalForwardingRuleCost, 64)
-	if err != nil {
-		return nil, err
-	}
-	lbidc, err := strconv.ParseFloat(cpricing.LBIngressDataCost, 64)
-	if err != nil {
-		return nil, err
-	}
-	var totalCost float64
-	numForwardingRules := 1.0 // hard-code at 1 for now
-	dataIngressGB := 0.0      // hard-code at 0 for now
+	fffrc := 0.025
+	afrc := 0.010
+	lbidc := 0.008
 
+	numForwardingRules := 1.0
+	dataIngressGB := 0.0
+
+	var totalCost float64
 	if numForwardingRules < 5 {
 		totalCost = fffrc*numForwardingRules + lbidc*dataIngressGB
 	} else {

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -70,6 +70,18 @@ func (n *Node) IsSpot() bool {
 	}
 }
 
+// LoadBalancer is the interface by which the provider and cost model communicate LoadBalancer prices.
+// The provider will best-effort try to fill out this struct.
+type LoadBalancer struct {
+	IngressIPAddresses           []string `json:"IngressIPAddresses"`
+	Cost                         float64  `json:"hourlyCost"` // TODO: find out if cloud providers return these values as strings or floats
+	FirstFiveForwardingRulesCost float64  `json:"firstFiveForwardingRulesCost"`
+	AdditionalForwardingRuleCost float64  `json:"additionalForwardingRuleCost"`
+	IngressDataCostPerGB         float64  `json:"ingressDataCostPerGB"`
+	// TODO: work in progress. Currently designed for GCP, unsure if other cloud providers price differently (e.g., if Azure prices a flat rate per rule)
+	// TODO: potentially need to make an additional struct to marshal GCP ALB data
+}
+
 // Network is the interface by which the provider and cost model communicate network egress prices.
 // The provider will best-effort try to fill out this struct.
 type Network struct {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1183,6 +1183,45 @@ func (cm *CostModel) GetNodeCost(cp costAnalyzerCloud.Provider) (map[string]*cos
 	return nodes, nil
 }
 
+// TODO: drop some logs
+func (cm *CostModel) getLBCost(cp costAnalyzerCloud.Provider) (map[string]*costAnalyzerCloud.LoadBalancer, error) {
+	// for fetching prices from cloud provider
+	// cfg, err := cp.GetConfig()
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	servicesList := cm.Cache.GetAllServices()
+	loadBalancerMap := make(map[string]*costAnalyzerCloud.LoadBalancer)
+
+	// 1. need to check whether the service is a loadbalancer /
+	// 2. need to generate a unique key for this loadbalancer --> use name, which is unique across a namespace
+	// 3. need to check if key exists in servicesList and then populate loadBalancers with it
+
+	for _, service := range servicesList {
+		// namespace := service.GetObjectMeta().GetNamespace() // do I need this?
+		name := service.GetObjectMeta().GetName()
+
+		// Does this identify ELB vs. ILB? Need to test the /api/allServices call with an ALB. Current work is on ELBs.
+		if service.Spec.Type == "LoadBalancer" {
+			// TODO: dynamically fetch based on cloud provider and region. Currently using hard-coded GCP us-central1 values.
+			loadBalancer := &costAnalyzerCloud.LoadBalancer{
+				FirstFiveForwardingRulesCost: 0.025,
+				AdditionalForwardingRuleCost: 0.010,
+				IngressDataCostPerGB:         0.008,
+			}
+			newLoadBalancer := *loadBalancer
+			if len(service.Status.LoadBalancer.Ingress) > 0 { // should actually check if LoadBalancer.Ingress exists
+				for _, loadBalancerIngress := range service.Status.LoadBalancer.Ingress {
+					newLoadBalancer.IngressIPAddresses = append(newLoadBalancer.IngressIPAddresses, loadBalancerIngress.IP)
+				}
+			}
+			loadBalancerMap[name] = &newLoadBalancer
+		}
+	}
+	return loadBalancerMap, nil
+}
+
 func getPodServices(cache clustercache.ClusterCache, podList []*v1.Pod, clusterID string) (map[string]map[string][]string, error) {
 	servicesList := cache.GetAllServices()
 	podServicesMapping := make(map[string]map[string][]string)

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1200,12 +1200,9 @@ func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[string]*costA
 		key := namespace + "," + name // + "," + clusterID?
 
 		if service.Spec.Type == "LoadBalancer" {
-			// loadBalancer, err := cp.LoadBalancerPricing()
-			// if err != nil {
-			// 	return nil, err
-			// }
-			loadBalancer := &costAnalyzerCloud.LoadBalancer{ // hard-coded to test asset pipeline reads, delete and uncomment above four lines
-				Cost: 0.025,
+			loadBalancer, err := cp.LoadBalancerPricing()
+			if err != nil {
+				return nil, err
 			}
 			newLoadBalancer := *loadBalancer
 			for _, loadBalancerIngress := range service.Status.LoadBalancer.Ingress {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1200,9 +1200,12 @@ func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[string]*costA
 		key := namespace + "," + name // + "," + clusterID?
 
 		if service.Spec.Type == "LoadBalancer" {
-			loadBalancer, err := cp.LoadBalancerPricing()
-			if err != nil {
-				return nil, err
+			// loadBalancer, err := cp.LoadBalancerPricing()
+			// if err != nil {
+			// 	return nil, err
+			// }
+			loadBalancer := &costAnalyzerCloud.LoadBalancer{ // hard-coded to test asset pipeline reads, delete and uncomment above four lines
+				Cost: 0.025,
 			}
 			newLoadBalancer := *loadBalancer
 			for _, loadBalancerIngress := range service.Status.LoadBalancer.Ingress {

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1205,10 +1205,8 @@ func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[string]*costA
 				return nil, err
 			}
 			newLoadBalancer := *loadBalancer
-			if len(service.Status.LoadBalancer.Ingress) > 0 { // assumes passing service.Spec.Type check means service.Status.LoadBalancer.Ingress field exists
-				for _, loadBalancerIngress := range service.Status.LoadBalancer.Ingress {
-					newLoadBalancer.IngressIPAddresses = append(newLoadBalancer.IngressIPAddresses, loadBalancerIngress.IP)
-				}
+			for _, loadBalancerIngress := range service.Status.LoadBalancer.Ingress {
+				newLoadBalancer.IngressIPAddresses = append(newLoadBalancer.IngressIPAddresses, loadBalancerIngress.IP)
 			}
 			loadBalancerMap[key] = &newLoadBalancer
 		}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1205,7 +1205,7 @@ func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[string]*costA
 				return nil, err
 			}
 			newLoadBalancer := *loadBalancer
-			if len(service.Status.LoadBalancer.Ingress) > 0 { // should actually check if LoadBalancer.Ingress exists
+			if len(service.Status.LoadBalancer.Ingress) > 0 { // assumes passing service.Spec.Type check means service.Status.LoadBalancer.Ingress field exists
 				for _, loadBalancerIngress := range service.Status.LoadBalancer.Ingress {
 					newLoadBalancer.IngressIPAddresses = append(newLoadBalancer.IngressIPAddresses, loadBalancerIngress.IP)
 				}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1200,7 +1200,10 @@ func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[string]*costA
 		key := namespace + "," + name // + "," + clusterID?
 
 		if service.Spec.Type == "LoadBalancer" {
-			loadBalancer := cp.LoadBalancerPricing()
+			loadBalancer, err := cp.LoadBalancerPricing()
+			if err != nil {
+				return nil, err
+			}
 			newLoadBalancer := *loadBalancer
 			if len(service.Status.LoadBalancer.Ingress) > 0 { // should actually check if LoadBalancer.Ingress exists
 				for _, loadBalancerIngress := range service.Status.LoadBalancer.Ingress {

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -518,7 +518,8 @@ func StartCostModelMetricRecording(a *Accesses) bool {
 				keyParts := getLabelStringsFromKey(lbKey)
 				namespace := keyParts[0]
 				serviceName := keyParts[1]
-				a.LBCostRecorder.WithLabelValues(namespace, serviceName).Set(lb.Cost)
+				ingressIP := lb.IngressIPAddresses[0] // assumes one ingress IP per load balancer
+				a.LBCostRecorder.WithLabelValues(ingressIP, namespace, serviceName).Set(lb.Cost)
 
 				labelKey := getKeyFromLabelStrings(namespace, serviceName)
 				loadBalancerSeen[labelKey] = true

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -899,10 +899,10 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 		Name: "kubecost_cluster_management_cost",
 		Help: "kubecost_cluster_management_cost Hourly cost paid as a cluster management fee.",
 	}, []string{"provisioner_name"})
-	LBCostRecorder := prometheus.NewGaugeVec(prometheus.GaugeOpts{ // don't know if necessary to differentiate ELB vs. ALB cost
+	LBCostRecorder := prometheus.NewGaugeVec(prometheus.GaugeOpts{ // no differentiation between ELB and ALB right now
 		Name: "kubecost_load_balancer_cost",
 		Help: "kubecost_load_balancer_cost Hourly cost of load balancer",
-	}, []string{"namespace", "service_name"}) // will likely need some adjustments. could have multiple IPs per LB, so ignore for now
+	}, []string{"ingress_ip", "namespace", "service_name"}) // assumes one ingress IP per load balancer
 
 	prometheus.MustRegister(cpuGv)
 	prometheus.MustRegister(ramGv)

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -902,7 +902,7 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 	LBCostRecorder := prometheus.NewGaugeVec(prometheus.GaugeOpts{ // don't know if necessary to differentiate ELB vs. ALB cost
 		Name: "load_balancer_cost",
 		Help: "load_balancer_cost Hourly cost of load balancer",
-	}, []string{"ip_address", "namespace", "service_name"}) // will likely need some adjustments
+	}, []string{"namespace", "service_name"}) // will likely need some adjustments. could have multiple IPs per LB, so ignore for now
 
 	prometheus.MustRegister(cpuGv)
 	prometheus.MustRegister(ramGv)

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -900,8 +900,8 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) {
 		Help: "kubecost_cluster_management_cost Hourly cost paid as a cluster management fee.",
 	}, []string{"provisioner_name"})
 	LBCostRecorder := prometheus.NewGaugeVec(prometheus.GaugeOpts{ // don't know if necessary to differentiate ELB vs. ALB cost
-		Name: "load_balancer_cost",
-		Help: "load_balancer_cost Hourly cost of load balancer",
+		Name: "kubecost_load_balancer_cost",
+		Help: "kubecost_load_balancer_cost Hourly cost of load balancer",
 	}, []string{"namespace", "service_name"}) // will likely need some adjustments. could have multiple IPs per LB, so ignore for now
 
 	prometheus.MustRegister(cpuGv)


### PR DESCRIPTION
Description: writing load balancer cost to prometheus
Issue: https://github.com/kubecost/cost-model/issues/407
Testing: build, push, and edit docker deployment

Steps & Goals in Feature Development (**step I'm currently on**):
1. create a new Prometheus metric called `load_balancer_cost` that detects the ELB on my cluster
2. _start dynamically fetching cloud provider data from GCP based on region_ (skip for now)
3. _extend cloud functionality to handle internal load balancers as well as other providers (Azure, AWS, etc.)_ (skip for now)
4. add metric to assets pipeline
5. **test, debug, release**

What I've Changed:
1. `router.go` -- added a LBCostRecorder as a gauge vector, called `prometheus.MustRegister()` on it, and added it to the `Accesses` struct
2. `provider.go` -- created a `LoadBalancer` struct to store dynamically fetched cloud provider pricing rates, as well as the cost of the load balancer (mimicking the `Node` struct before it)
3. `costmodel.go` -- added a `getLBCost()` function that identifies which services are load balancers, and subsequently fetches and populates a `LoadBalancer` struct with cloud pricing info (currently hardcoded values, but will dynamically fetch after I get Step 1 working)
4. `metrics.go` -- `StartCostModelMetricRecording()` calls `getLBCost()` and loops through the returned map of `LoadBalancer` structs

Questions:
1. What else am I missing from my understanding of how Prometheus metrics are recorded?
2. Why is `getNodeCost()` called in both `metrics.go:StartCostModelMetricRecording()` as well as `costmodel.go:ComputeCostData()`, which `StartCostModelMetricRecording()` also calls again in the same for loop?
3. _See comments on the diff._

Feel free to point out anything that warrants discussion or correct any assumptions or misunderstandings that I have regarding the code.