### PR TITLE
Pass Start Time to Query Worker

### DIFF
--- a/pkg/prom/prom.go
+++ b/pkg/prom/prom.go
@@ -194,6 +194,7 @@ func (rlpc *RateLimitedPrometheusClient) Do(ctx context.Context, req *http.Reque
 	rlpc.queue.Enqueue(&workRequest{
 		ctx:      ctx,
 		req:      req,
+		start:    time.Now(),
 		respChan: respChan,
 		closer:   false,
 	})


### PR DESCRIPTION
Ensure we pass the start time into the work request to adequately log query times.