### PR TITLE
guard against pv.Spec.AWSElasticBlockStore nil

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -464,13 +464,17 @@ type awsPVKey struct {
 }
 
 func (aws *AWS) GetPVKey(pv *v1.PersistentVolume, parameters map[string]string, defaultRegion string) PVKey {
+	providerID := ""
+	if pv.Spec.AWSElasticBlockStore != nil {
+		providerID = pv.Spec.AWSElasticBlockStore.VolumeID
+	}
 	return &awsPVKey{
 		Labels:                 pv.Labels,
 		StorageClassName:       pv.Spec.StorageClassName,
 		StorageClassParameters: parameters,
 		Name:                   pv.Name,
 		DefaultRegion:          defaultRegion,
-		ProviderID:             pv.Spec.AWSElasticBlockStore.VolumeID,
+		ProviderID:             providerID,
 	}
 }
 


### PR DESCRIPTION
User reports:

```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x192450c]

goroutine 1 [running]:
github.com/kubecost/cost-model/pkg/cloud.(*AWS).GetPVKey(...)
	/app/cost-model/pkg/cloud/awsprovider.go:473
github.com/kubecost/cost-model/pkg/cloud.(*AWS).DownloadPricingData(0xc00d917dc0, 0x0, 0x0)
	/app/cost-model/pkg/cloud/awsprovider.go:592 +0xdcc
github.com/kubecost/cost-model/pkg/costmodel.Initialize(0xc0001ddf50, 0x2, 0x2)
	/app/cost-model/pkg/costmodel/router.go:1011 +0x273f
main.Initialize()
	/app/kubecost-cost-model/main.go:3147 +0x9d
main.main()
	/app/kubecost-cost-model/main.go:3294 +0x37
```

I haven't been able to repro, but apparently this can happen on some AWS PVs. This is safer.