### PR TITLE
add array length check before accessing lb.IngressIPAddresses

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -518,7 +518,12 @@ func StartCostModelMetricRecording(a *Accesses) bool {
 				keyParts := getLabelStringsFromKey(lbKey)
 				namespace := keyParts[0]
 				serviceName := keyParts[1]
-				ingressIP := lb.IngressIPAddresses[0] // assumes one ingress IP per load balancer
+				ingressIP := ""
+				if len(lb.IngressIPAddresses) > 0 {
+					ingressIP = lb.IngressIPAddresses[0] // assumes one ingress IP per load balancer
+				} else {
+					ingressIP = "N/A"
+				}
 				a.LBCostRecorder.WithLabelValues(ingressIP, namespace, serviceName).Set(lb.Cost)
 
 				labelKey := getKeyFromLabelStrings(namespace, serviceName)

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -521,8 +521,6 @@ func StartCostModelMetricRecording(a *Accesses) bool {
 				ingressIP := ""
 				if len(lb.IngressIPAddresses) > 0 {
 					ingressIP = lb.IngressIPAddresses[0] // assumes one ingress IP per load balancer
-				} else {
-					ingressIP = "N/A"
 				}
 				a.LBCostRecorder.WithLabelValues(ingressIP, namespace, serviceName).Set(lb.Cost)
 


### PR DESCRIPTION
Description: Add length check before array access to get ingress IP addresses.

Potential diagnosis: Application load balancer gets treated like ELB, despite not having ingress IPs.