### PR TITLE
Threadsafe logging

### DIFF
--- a/pkg/log/counter.go
+++ b/pkg/log/counter.go
@@ -12,8 +12,8 @@ func newCounter() *counter {
 }
 
 func (ctr *counter) count(key string) int {
-	ctr.mu.Lock()
-	defer ctr.mu.Unlock()
+	ctr.mu.RLock()
+	defer ctr.mu.RUnlock()
 	return ctr.seen[key]
 }
 

--- a/pkg/log/counter.go
+++ b/pkg/log/counter.go
@@ -1,0 +1,31 @@
+package log
+
+import "sync"
+
+type counter struct {
+	mu   sync.RWMutex
+	seen map[string]int
+}
+
+func newCounter() *counter {
+	return &counter{seen: map[string]int{}}
+}
+
+func (ctr *counter) count(key string) int {
+	ctr.mu.Lock()
+	defer ctr.mu.Unlock()
+	return ctr.seen[key]
+}
+
+func (ctr *counter) delete(key string) {
+	ctr.mu.Lock()
+	delete(ctr.seen, key)
+	ctr.mu.Unlock()
+}
+
+func (ctr *counter) increment(key string) int {
+	ctr.mu.Lock()
+	defer ctr.mu.Unlock()
+	ctr.seen[key]++
+	return ctr.seen[key]
+}

--- a/pkg/log/counter_test.go
+++ b/pkg/log/counter_test.go
@@ -1,0 +1,68 @@
+package log
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestCounter_Ops(t *testing.T) {
+	ctr := newCounter()
+
+	var num int
+
+	// Should return 0 if never seen
+	num = ctr.count("something")
+	if num != 0 {
+		t.Fatalf("counter: count: expected %d; found %d", 0, num)
+	}
+
+	// Should return 1 if seen once
+	num = ctr.increment("something")
+	if num != 1 {
+		t.Fatalf("counter: count: expected %d; found %d", 1, num)
+	}
+
+	// Should still return 1 if seen only once
+	num = ctr.count("something")
+	if num != 1 {
+		t.Fatalf("counter: count: expected %d; found %d", 1, num)
+	}
+
+	// Should return 1 if seen once
+	for i := 2; i <= 234; i++ {
+		num = ctr.increment("something")
+		if num != i {
+			t.Fatalf("counter: count: expected %d; found %d", i, num)
+		}
+	}
+
+	ctr.delete("something")
+	num = ctr.count("something")
+	if num != 0 {
+		t.Fatalf("counter: count: expected %d; found %d", 0, num)
+	}
+}
+
+func TestCounter_Threadsafety(t *testing.T) {
+	var wg sync.WaitGroup
+
+	// Run 1000 goroutines, logging 10000 times each as fast as they can
+	for i := 1; i <= 1000; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 1; j <= 10000; j++ {
+				DedupedInfof(10, "this log seen %d times", j)
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestDeduping(t *testing.T) {
+	// Should log 10 times, then stop
+	for i := 1; i <= 234; i++ {
+		DedupedInfof(10, "this log seen %d times", i)
+	}
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -7,6 +7,9 @@ import (
 	"k8s.io/klog"
 )
 
+// TODO for deduped functions, if timeLogged > logTypeLimit, should we log once
+// every... 100 (?) times so we don't lose track entirely?
+
 // concurrency-safe counter
 var ctr = newCounter()
 
@@ -15,17 +18,17 @@ func Errorf(format string, a ...interface{}) {
 }
 
 func DedupedErrorf(logTypeLimit int, format string, a ...interface{}) {
-	timesLogged := ctr.increment(format)
+	// Run within a goroutine so that the original call does not block
+	go func(logTypeLimit int, format string, a ...interface{}) {
+		timesLogged := ctr.increment(format)
 
-	if timesLogged < logTypeLimit {
-		Errorf(format, a...)
-	} else if timesLogged == logTypeLimit {
-		Errorf(format, a...)
-		Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
-	}
-
-	// TODO if timeLogged > logTypeLimit, log once every... 100 (?) times so we
-	// don't lose track entirely?
+		if timesLogged < logTypeLimit {
+			Errorf(format, a...)
+		} else if timesLogged == logTypeLimit {
+			Errorf(format, a...)
+			Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
+		}
+	}(logTypeLimit, format, a...)
 }
 
 func Warningf(format string, a ...interface{}) {
@@ -33,17 +36,17 @@ func Warningf(format string, a ...interface{}) {
 }
 
 func DedupedWarningf(logTypeLimit int, format string, a ...interface{}) {
-	timesLogged := ctr.increment(format)
+	// Run within a goroutine so that the original call does not block
+	go func(logTypeLimit int, format string, a ...interface{}) {
+		timesLogged := ctr.increment(format)
 
-	if timesLogged < logTypeLimit {
-		Warningf(format, a...)
-	} else if timesLogged == logTypeLimit {
-		Warningf(format, a...)
-		Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
-	}
-
-	// TODO if timeLogged > logTypeLimit, log once every... 100 (?) times so we
-	// don't lose track entirely?
+		if timesLogged < logTypeLimit {
+			Warningf(format, a...)
+		} else if timesLogged == logTypeLimit {
+			Warningf(format, a...)
+			Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
+		}
+	}(logTypeLimit, format, a...)
 }
 
 func Infof(format string, a ...interface{}) {
@@ -51,17 +54,17 @@ func Infof(format string, a ...interface{}) {
 }
 
 func DedupedInfof(logTypeLimit int, format string, a ...interface{}) {
-	timesLogged := ctr.increment(format)
+	// Run within a goroutine so that the original call does not block
+	go func(logTypeLimit int, format string, a ...interface{}) {
+		timesLogged := ctr.increment(format)
 
-	if timesLogged < logTypeLimit {
-		Infof(format, a...)
-	} else if timesLogged == logTypeLimit {
-		Infof(format, a...)
-		Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
-	}
-
-	// TODO if timeLogged > logTypeLimit, log once every... 100 (?) times so we
-	// don't lose track entirely?
+		if timesLogged < logTypeLimit {
+			Infof(format, a...)
+		} else if timesLogged == logTypeLimit {
+			Infof(format, a...)
+			Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
+		}
+	}(logTypeLimit, format, a...)
 }
 
 func Profilef(format string, a ...interface{}) {
@@ -81,65 +84,5 @@ func ProfileWithThreshold(start time.Time, threshold time.Duration, name string)
 	elapsed := time.Since(start)
 	if elapsed > threshold {
 		Profilef("%s: %s", elapsed, name)
-	}
-}
-
-type Profiler struct {
-	profiles map[string]time.Duration
-	starts   map[string]time.Time
-}
-
-func NewProfiler() *Profiler {
-	return &Profiler{
-		profiles: map[string]time.Duration{},
-		starts:   map[string]time.Time{},
-	}
-}
-
-func (p *Profiler) Start(name string) {
-	if p == nil {
-		return
-	}
-	p.starts[name] = time.Now()
-}
-
-func (p *Profiler) Stop(name string) time.Duration {
-	if p == nil {
-		return 0
-	}
-	if start, ok := p.starts[name]; ok {
-		elapsed := time.Since(start)
-		p.profiles[name] += elapsed
-		return elapsed
-	}
-	return 0
-}
-
-func (p *Profiler) Log(name string) {
-	if p == nil {
-		return
-	}
-	Profilef("%s: %s", p.profiles[name], name)
-}
-
-func (p *Profiler) LogAll() {
-	if p == nil {
-		return
-	}
-
-	// Print profiles, largest to smallest. (Inefficienct, but shouldn't matter.)
-	print := map[string]time.Duration{}
-	for name, value := range p.profiles {
-		print[name] = value
-	}
-	for len(print) > 0 {
-		largest := ""
-		for name := range print {
-			if print[name] > print[largest] {
-				largest = name
-			}
-		}
-		Profilef("%s: %s", print[largest], largest)
-		delete(print, largest)
 	}
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -18,17 +18,14 @@ func Errorf(format string, a ...interface{}) {
 }
 
 func DedupedErrorf(logTypeLimit int, format string, a ...interface{}) {
-	// Run within a goroutine so that the original call does not block
-	go func(logTypeLimit int, format string, a ...interface{}) {
-		timesLogged := ctr.increment(format)
+	timesLogged := ctr.increment(format)
 
-		if timesLogged < logTypeLimit {
-			Errorf(format, a...)
-		} else if timesLogged == logTypeLimit {
-			Errorf(format, a...)
-			Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
-		}
-	}(logTypeLimit, format, a...)
+	if timesLogged < logTypeLimit {
+		Errorf(format, a...)
+	} else if timesLogged == logTypeLimit {
+		Errorf(format, a...)
+		Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
+	}
 }
 
 func Warningf(format string, a ...interface{}) {
@@ -36,17 +33,14 @@ func Warningf(format string, a ...interface{}) {
 }
 
 func DedupedWarningf(logTypeLimit int, format string, a ...interface{}) {
-	// Run within a goroutine so that the original call does not block
-	go func(logTypeLimit int, format string, a ...interface{}) {
-		timesLogged := ctr.increment(format)
+	timesLogged := ctr.increment(format)
 
-		if timesLogged < logTypeLimit {
-			Warningf(format, a...)
-		} else if timesLogged == logTypeLimit {
-			Warningf(format, a...)
-			Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
-		}
-	}(logTypeLimit, format, a...)
+	if timesLogged < logTypeLimit {
+		Warningf(format, a...)
+	} else if timesLogged == logTypeLimit {
+		Warningf(format, a...)
+		Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
+	}
 }
 
 func Infof(format string, a ...interface{}) {
@@ -54,17 +48,14 @@ func Infof(format string, a ...interface{}) {
 }
 
 func DedupedInfof(logTypeLimit int, format string, a ...interface{}) {
-	// Run within a goroutine so that the original call does not block
-	go func(logTypeLimit int, format string, a ...interface{}) {
-		timesLogged := ctr.increment(format)
+	timesLogged := ctr.increment(format)
 
-		if timesLogged < logTypeLimit {
-			Infof(format, a...)
-		} else if timesLogged == logTypeLimit {
-			Infof(format, a...)
-			Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
-		}
-	}(logTypeLimit, format, a...)
+	if timesLogged < logTypeLimit {
+		Infof(format, a...)
+	} else if timesLogged == logTypeLimit {
+		Infof(format, a...)
+		Infof("%s logged %d times: suppressing future logs", format, logTypeLimit)
+	}
 }
 
 func Profilef(format string, a ...interface{}) {

--- a/pkg/log/profiler.go
+++ b/pkg/log/profiler.go
@@ -1,0 +1,63 @@
+package log
+
+import "time"
+
+type Profiler struct {
+	profiles map[string]time.Duration
+	starts   map[string]time.Time
+}
+
+func NewProfiler() *Profiler {
+	return &Profiler{
+		profiles: map[string]time.Duration{},
+		starts:   map[string]time.Time{},
+	}
+}
+
+func (p *Profiler) Start(name string) {
+	if p == nil {
+		return
+	}
+	p.starts[name] = time.Now()
+}
+
+func (p *Profiler) Stop(name string) time.Duration {
+	if p == nil {
+		return 0
+	}
+	if start, ok := p.starts[name]; ok {
+		elapsed := time.Since(start)
+		p.profiles[name] += elapsed
+		return elapsed
+	}
+	return 0
+}
+
+func (p *Profiler) Log(name string) {
+	if p == nil {
+		return
+	}
+	Profilef("%s: %s", p.profiles[name], name)
+}
+
+func (p *Profiler) LogAll() {
+	if p == nil {
+		return
+	}
+
+	// Print profiles, largest to smallest. (Inefficienct, but shouldn't matter.)
+	print := map[string]time.Duration{}
+	for name, value := range p.profiles {
+		print[name] = value
+	}
+	for len(print) > 0 {
+		largest := ""
+		for name := range print {
+			if print[name] > print[largest] {
+				largest = name
+			}
+		}
+		Profilef("%s: %s", print[largest], largest)
+		delete(print, largest)
+	}
+}


### PR DESCRIPTION
## Changes
- In deduped logging, turn the `seen` map into a threadsafe counter

## Testing
- Reproduced concurrent map write panics
```
$ go test -v ./pkg/log/
=== RUN   TestCounter_Ops
--- PASS: TestCounter_Ops (0.00s)
=== RUN   TestCounter_Threadsafety
fatal error: concurrent map writes

goroutine 23 [running]:
runtime.throw(0x55c456, 0x15)
	/usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc000059eb0 sp=0xc000059e80 pc=0x42eca2
runtime.mapassign_faststr(0x529f40, 0xc0000981e0, 0x55c993, 0x16, 0xc0000ee088)
	/usr/local/go/src/runtime/map_faststr.go:211 +0x417 fp=0xc000059f18 sp=0xc000059eb0 pc=0x413667
github.com/kubecost/cost-model/pkg/log.(*counter).increment(...)
	/home/niko/code/kubecost/model/cost-model/pkg/log/counter.go:29
github.com/kubecost/cost-model/pkg/log.DedupedInfof(0xa, 0x55c993, 0x16, 0xc000059fb8, 0x1, 0x1)
	/home/niko/code/kubecost/model/cost-model/pkg/log/log.go:54 +0x5a fp=0xc000059f80 sp=0xc000059f18 pc=0x50561a
github.com/kubecost/cost-model/pkg/log.TestCounter_Threadsafety.func1(0xc0000a00d0)
	/home/niko/code/kubecost/model/cost-model/pkg/log/counter_test.go:54 +0x92 fp=0xc000059fd8 sp=0xc000059f80 pc=0x505f42
runtime.goexit()
```

- With changes, test are passing
```
$ go test -v ./pkg/log/
=== RUN   TestCounter_Ops
--- PASS: TestCounter_Ops (0.00s)
=== RUN   TestCounter_Threadsafety
--- PASS: TestCounter_Threadsafety (1.58s)
=== RUN   TestDeduping
--- PASS: TestDeduping (0.00s)
PASS
ok  	github.com/kubecost/cost-model/pkg/log	1.579s
```