### PR TITLE
Fix formatting directive breaking costmodel tests

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -802,10 +802,10 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 				// actual errors)
 				if prom.IsErrorCollection(err) {
 					if ec, ok := err.(prom.QueryErrorCollection); ok {
-						klog.V(1).Info("Error in price recording: %d errors occurred", len(ec.Errors()))
+						log.Errorf("Error in price recording: %d errors occurred", len(ec.Errors()))
 					}
 				} else {
-					klog.V(1).Info("Error in price recording: " + err.Error())
+					log.Errorf("Error in price recording: " + err.Error())
 				}
 
 				// zero the for loop so the time.Sleep will still work


### PR DESCRIPTION
Before
```
~/code/kubecost/model/cost-model$ go test ./pkg/*
?   	github.com/kubecost/cost-model/pkg/cloud	[no test files]
?   	github.com/kubecost/cost-model/pkg/clustercache	[no test files]
?   	github.com/kubecost/cost-model/pkg/clustermanager	[no test files]
# github.com/kubecost/cost-model/pkg/costmodel
pkg/costmodel/metrics.go:805:7: Info call has possible formatting directive %d
^[[FAIL	github.com/kubecost/cost-model/pkg/costmodel [build failed]
?   	github.com/kubecost/cost-model/pkg/env	[no test files]
?   	github.com/kubecost/cost-model/pkg/errors	[no test files]
ok  	github.com/kubecost/cost-model/pkg/kubecost	0.034s
ok  	github.com/kubecost/cost-model/pkg/log	2.315s
ok  	github.com/kubecost/cost-model/pkg/prom	0.004s
?   	github.com/kubecost/cost-model/pkg/thanos	[no test files]
?   	github.com/kubecost/cost-model/pkg/util	[no test files]
FAIL
```

After
```
~/code/kubecost/model/cost-model$ go test ./pkg/*
?   	github.com/kubecost/cost-model/pkg/cloud	[no test files]
?   	github.com/kubecost/cost-model/pkg/clustercache	[no test files]
?   	github.com/kubecost/cost-model/pkg/clustermanager	[no test files]
ok  	github.com/kubecost/cost-model/pkg/costmodel	0.009s
?   	github.com/kubecost/cost-model/pkg/env	[no test files]
?   	github.com/kubecost/cost-model/pkg/errors	[no test files]
ok  	github.com/kubecost/cost-model/pkg/kubecost	(cached)
ok  	github.com/kubecost/cost-model/pkg/log	(cached)
ok  	github.com/kubecost/cost-model/pkg/prom	(cached)
?   	github.com/kubecost/cost-model/pkg/thanos	[no test files]
?   	github.com/kubecost/cost-model/pkg/util	[no test files]
```