### PR TITLE
Convert all error messages back to exact closed-source functions

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -1898,19 +1898,19 @@ func (a *Accesses) AggregateCostModelHandler(w http.ResponseWriter, r *http.Requ
 
 	// aggregation field is required
 	if field == "" {
-		http.Error(w, "Missing aggregation field parameter", http.StatusBadRequest)
+		w.Write(WrapDataWithMessage(nil, fmt.Errorf("Missing aggregation field parameter"), "Missing aggregation field parameter"))
 		return
 	}
 
 	// aggregation subfield is required when aggregation field is "label"
 	if field == "label" && len(subfields) == 0 {
-		http.Error(w, "Missing aggregation subfield parameter for aggregation by label", http.StatusBadRequest)
+		w.Write(WrapDataWithMessage(nil, fmt.Errorf("Missing aggregation subfield parameter for aggregation by label"), "Missing aggregation subfield parameter for aggregation by label"))
 		return
 	}
 
 	// enforce one of four available rate options
 	if opts.Rate != "" && opts.Rate != "hourly" && opts.Rate != "daily" && opts.Rate != "monthly" {
-		http.Error(w, "If set, rate parameter must be one of: 'hourly', 'daily', 'monthly'", http.StatusBadRequest)
+		w.Write(WrapDataWithMessage(nil, fmt.Errorf("If set, rate parameter must be one of: 'hourly', 'daily', 'monthly'"), "If set, rate parameter must be one of: 'hourly', 'daily', 'monthly'"))
 		return
 	}
 
@@ -1936,7 +1936,7 @@ func (a *Accesses) AggregateCostModelHandler(w http.ResponseWriter, r *http.Requ
 		sln = strings.Split(sharedLabelNames, ",")
 		slv = strings.Split(sharedLabelValues, ",")
 		if len(sln) != len(slv) || slv[0] == "" {
-			http.Error(w, "Supply exacly one shared label value per shared label name", http.StatusBadRequest)
+			w.Write(WrapDataWithMessage(nil, fmt.Errorf("Supply exacly one shared label value per shared label name"), "Supply exacly one shared label value per shared label name"))
 			return
 		}
 	}
@@ -1980,15 +1980,15 @@ func (a *Accesses) AggregateCostModelHandler(w http.ResponseWriter, r *http.Requ
 					}
 				}
 
-				http.Error(w, msg, http.StatusInternalServerError)
+				w.Write(WrapDataWithMessage(nil, fmt.Errorf(msg), msg))
 			} else {
 				// Boundary error outside of 90 day period; may not be available
-				http.Error(w, boundaryErr.Error(), http.StatusInternalServerError)
+				w.Write(WrapDataWithMessage(nil, boundaryErr, boundaryErr.Error()))
 			}
 			return
 		}
 		errStr := fmt.Sprintf("error computing aggregate cost model: %s", err)
-		http.Error(w, errStr, http.StatusInternalServerError)
+		w.Write(WrapDataWithMessage(nil, fmt.Errorf(errStr), errStr))
 		return
 	}
 

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -1802,7 +1802,7 @@ func (a *Accesses) AggregateCostModelHandler(w http.ResponseWriter, r *http.Requ
 	// determine duration and offset from query parameters
 	window, err := kubecost.ParseWindowWithOffset(windowStr, env.GetParsedUTCOffset())
 	if err != nil || window.Start() == nil {
-		http.Error(w, fmt.Sprintf("invalid window: %s", err), http.StatusBadRequest)
+		w.Write(WrapDataWithMessage(nil, fmt.Errorf("invalid window: %s", err), fmt.Sprintf("invalid window: %s", err)))
 		return
 	}
 

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -1937,7 +1937,7 @@ func (a *Accesses) AggregateCostModelHandler(w http.ResponseWriter, r *http.Requ
 		sln = strings.Split(sharedLabelNames, ",")
 		slv = strings.Split(sharedLabelValues, ",")
 		if len(sln) != len(slv) || slv[0] == "" {
-			w.Write(WrapDataWithMessage(nil, fmt.Errorf("Supply exacly one shared label value per shared label name"), "Supply exacly one shared label value per shared label name"))
+			WriteError(w, BadRequest("Supply exacly one shared label value per shared label name"))
 			return
 		}
 	}
@@ -1981,15 +1981,15 @@ func (a *Accesses) AggregateCostModelHandler(w http.ResponseWriter, r *http.Requ
 					}
 				}
 
-				w.Write(WrapDataWithMessage(nil, fmt.Errorf(msg), msg))
+				WriteError(w, InternalServerError(msg))
 			} else {
 				// Boundary error outside of 90 day period; may not be available
-				w.Write(WrapDataWithMessage(nil, boundaryErr, boundaryErr.Error()))
+				WriteError(w, InternalServerError(boundaryErr.Error()))
 			}
 			return
 		}
 		errStr := fmt.Sprintf("error computing aggregate cost model: %s", err)
-		w.Write(WrapDataWithMessage(nil, fmt.Errorf(errStr), errStr))
+		WriteError(w, InternalServerError(errStr))
 		return
 	}
 
@@ -2027,5 +2027,22 @@ func BadRequest(message string) Error {
 	return Error{
 		StatusCode: http.StatusBadRequest,
 		Body:       message,
+	}
+}
+
+func InternalServerError(message string) Error {
+	if message == "" {
+		message = "Internal Server Error"
+	}
+	return Error{
+		StatusCode: http.StatusInternalServerError,
+		Body:       message,
+	}
+}
+
+func NotFound() Error {
+	return Error{
+		StatusCode: http.StatusNotFound,
+		Body:       "Not Found",
 	}
 }

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -484,18 +484,18 @@ func (a *Accesses) CostDataModelRange(w http.ResponseWriter, r *http.Request, ps
 	layout := "2006-01-02T15:04:05.000Z"
 	start, err := time.Parse(layout, startStr)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("invalid start date: %s", startStr), http.StatusBadRequest)
+		w.Write(WrapDataWithMessage(nil, fmt.Errorf("invalid start date: %s", startStr), fmt.Sprintf("invalid start date: %s", startStr)))
 		return
 	}
 	end, err := time.Parse(layout, endStr)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("invalid end date: %s", endStr), http.StatusBadRequest)
+		w.Write(WrapDataWithMessage(nil, fmt.Errorf("invalid end date: %s", endStr), fmt.Sprintf("invalid end date: %s", endStr)))
 		return
 	}
 
 	window := kubecost.NewWindow(&start, &end)
 	if window.IsOpen() || window.IsEmpty() || window.IsNegative() {
-		http.Error(w, fmt.Sprintf("invalid date range: %s", window), http.StatusBadRequest)
+		w.Write(WrapDataWithMessage(nil, fmt.Errorf("invalid date range: %s", window), fmt.Sprintf("invalid date range: %s", window)))
 		return
 	}
 


### PR DESCRIPTION
Reverting to old closed-source error handling functions.

Before: http://kubecost.nikovacevic.io/model/aggregatedCostModel?window=today returned `400`
```
Missing aggregation field parameter
```
After: http://kubecost.nikovacevic.io/model/aggregatedCostModel?window=today again returns `500`
```json
{
  "code": 400,
  "status": "",
  "data": null,
  "message": "Error: Missing aggregation field parameter"
}
```