### PR TITLE
Refactor window.ToDurationOffset into DurationOffset and DurationOffsetStrings

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -1294,7 +1294,7 @@ func (a *Accesses) ComputeAggregateCostModel(promClient prometheusClient.Client,
 		window.Set(&s, &e)
 	}
 
-	dur, off := window.ToDurationOffset()
+	dur, off := window.DurationOffsetStrings()
 	key := fmt.Sprintf(`%s:%s:%fh:%t`, dur, off, resolution.Hours(), remoteEnabled)
 
 	// report message about which of the two caches hit. by default report a miss
@@ -1391,7 +1391,7 @@ func (a *Accesses) ComputeAggregateCostModel(promClient prometheusClient.Client,
 
 	idleCoefficients := make(map[string]float64)
 	if allocateIdle {
-		duration, offset := window.ToDurationOffset()
+		duration, offset := window.DurationOffsetStrings()
 
 		idleDurationCalcHours := window.Hours()
 		if window.Hours() < 1 {
@@ -1540,7 +1540,7 @@ func GenerateAggKey(window kubecost.Window, field string, subfields []string, op
 
 	// Covert to duration, offset so that cache hits occur, even when timestamps have
 	// shifted slightly.
-	duration, offset := window.ToDurationOffset()
+	duration, offset := window.DurationOffsetStrings()
 
 	// parse, trim, and sort podprefix filters
 	podPrefixFilters := []string{}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1967,7 +1967,7 @@ func (cm *CostModel) costDataRange(cli prometheusClient.Client, cp costAnalyzerC
 	}
 
 	if window.Minutes() > 0 {
-		dur, off := window.ToDurationOffset()
+		dur, off := window.DurationOffsetStrings()
 		err = findDeletedNodeInfo(cli, missingNodes, dur, off)
 		if err != nil {
 			klog.V(1).Infof("Error fetching historical node data: %s", err.Error())

--- a/pkg/kubecost/status.go
+++ b/pkg/kubecost/status.go
@@ -5,6 +5,7 @@ import "time"
 // ETLStatus describes ETL metadata
 type ETLStatus struct {
 	Coverage    Window           `json:"coverage"`
+	LastRun     time.Time        `json:"lastRun"`
 	Progress    float64          `json:"progress"`
 	RefreshRate string           `json:"refreshRate"`
 	StartTime   time.Time        `json:"startTime"`

--- a/pkg/kubecost/window.go
+++ b/pkg/kubecost/window.go
@@ -467,9 +467,23 @@ func (w Window) String() string {
 	return fmt.Sprintf("[%s, %s)", w.start.Format("2006-01-02T15:04:05-0700"), w.end.Format("2006-01-02T15:04:05-0700"))
 }
 
-// ToDurationOffset returns formatted strings representing the duration and
+// DurationOffset returns durations representing the duration and offset of the
+// given window
+func (w Window) DurationOffset() (time.Duration, time.Duration, error) {
+	if w.IsOpen() || w.IsNegative() {
+		return 0, 0, fmt.Errorf("illegal window: %s", w)
+	}
+
+	duration := w.Duration()
+	offset := time.Now().Sub(*w.End())
+
+	return duration, offset, nil
+}
+
+// DurationOffsetStrings returns formatted strings representing the duration and
 // offset of the window in terms of minutes; e.g. ("30m", "1m")
-func (w Window) ToDurationOffset() (string, string) {
+// TODO check for nils in Window
+func (w Window) DurationOffsetStrings() (string, string) {
 	durMins := int(w.Duration().Minutes())
 
 	offStr := ""

--- a/pkg/kubecost/window_test.go
+++ b/pkg/kubecost/window_test.go
@@ -566,12 +566,12 @@ func TestParseWindowWithOffsetString(t *testing.T) {
 // TODO niko/etl
 // func TestWindow_String(t *testing.T) {}
 
-func TestWindow_ToDurationOffset(t *testing.T) {
+func TestWindow_DurationOffsetStrings(t *testing.T) {
 	w, err := ParseWindowUTC("1d")
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "1d": %s`, err)
 	}
-	dur, off := w.ToDurationOffset()
+	dur, off := w.DurationOffsetStrings()
 	if dur != "1d" {
 		t.Fatalf(`expect: window to be "1d"; actual: "%s"`, dur)
 	}
@@ -583,7 +583,7 @@ func TestWindow_ToDurationOffset(t *testing.T) {
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "1d": %s`, err)
 	}
-	dur, off = w.ToDurationOffset()
+	dur, off = w.DurationOffsetStrings()
 	if dur != "3h" {
 		t.Fatalf(`expect: window to be "3h"; actual: "%s"`, dur)
 	}
@@ -595,7 +595,7 @@ func TestWindow_ToDurationOffset(t *testing.T) {
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "1d": %s`, err)
 	}
-	dur, off = w.ToDurationOffset()
+	dur, off = w.DurationOffsetStrings()
 	if dur != "10m" {
 		t.Fatalf(`expect: window to be "10m"; actual: "%s"`, dur)
 	}
@@ -607,7 +607,7 @@ func TestWindow_ToDurationOffset(t *testing.T) {
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "1589448338,1589534798": %s`, err)
 	}
-	dur, off = w.ToDurationOffset()
+	dur, off = w.DurationOffsetStrings()
 	if dur != "1441m" {
 		t.Fatalf(`expect: window to be "1441m"; actual: "%s"`, dur)
 	}
@@ -619,7 +619,7 @@ func TestWindow_ToDurationOffset(t *testing.T) {
 	if err != nil {
 		t.Fatalf(`unexpected error parsing "1589448338,1589534798": %s`, err)
 	}
-	dur, off = w.ToDurationOffset()
+	dur, off = w.DurationOffsetStrings()
 	if dur != "1d" {
 		t.Fatalf(`expect: window to be "1d"; actual: "%s"`, dur)
 	}


### PR DESCRIPTION
Required for https://github.com/kubecost/kubecost-cost-model/pull/295

Just a rename of a function to make it more decsriptive and to make room for the verison of the function that returns two `time.Duration`s instead of `string`s.