### PR TITLE
add csv fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go v1.28.9
 	github.com/dimchansky/utfbom v1.1.0 // indirect
 	github.com/getsentry/sentry-go v0.6.1
-	github.com/google/martian v2.1.0+incompatible // indirect
+	github.com/google/martian v2.1.0+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
 	github.com/gophercloud/gophercloud v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -433,6 +433,7 @@ k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719 h1:uV4S5IB5g4Nvi+TBVNf3e9
 k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719/go.mod h1:I4A+glKBHiTgiEjQiCCQfCAIcIMFGt291SmsvcrFzJA=
 k8s.io/apimachinery v0.0.0-20190913075812-e119e5e154b6 h1:tGU1C/vMoUV2ZakSH6wQq2shk9KiFtjoH2vDDHlhpA4=
 k8s.io/apimachinery v0.0.0-20190913075812-e119e5e154b6/go.mod h1:nL6pwRT8NgfF8TT68DBI8uEePRt89cSvoXUVqbkWHq4=
+k8s.io/apimachinery v0.20.1 h1:LAhz8pKbgR8tUwn7boK+b2HZdt7MiTu2mkYtFMUjTRQ=
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab h1:E8Fecph0qbNsAbijJJQryKu4Oi9QTp5cVpjTE+nqg6g=
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=
 k8s.io/client-go v1.5.1 h1:XaX/lo2/u3/pmFau8HN+sB5C/b4dc4Dmm2eXjBH4p1E=

--- a/pkg/cloud/csvprovider.go
+++ b/pkg/cloud/csvprovider.go
@@ -215,6 +215,7 @@ func (c *CSVProvider) NodePricing(key Key) (*Node, error) {
 	}
 	classKey := key.Features() // Use node attributes to try and do a class match
 	if cost, ok := c.NodeClassPricing[classKey]; ok {
+		klog.Infof("Unable to find provider ID `%s`, using features:`%s`", key.ID(), key.Features())
 		return &Node{
 			Cost: fmt.Sprintf("%f", cost),
 		}, nil

--- a/pkg/cloud/csvprovider.go
+++ b/pkg/cloud/csvprovider.go
@@ -203,7 +203,7 @@ func (c *CSVProvider) NodePricing(key Key) (*Node, error) {
 	if p, ok := c.Pricing[key.ID()]; ok {
 		return &Node{
 			Cost:        p.MarketPriceHourly,
-			PricingType: csvExact,
+			PricingType: CsvExact,
 		}, nil
 	}
 	s := strings.Split(key.ID(), ",") // Try without a region to be sure
@@ -211,7 +211,7 @@ func (c *CSVProvider) NodePricing(key Key) (*Node, error) {
 		if p, ok := c.Pricing[s[1]]; ok {
 			return &Node{
 				Cost:        p.MarketPriceHourly,
-				PricingType: csvExact,
+				PricingType: CsvExact,
 			}, nil
 		}
 	}
@@ -220,7 +220,7 @@ func (c *CSVProvider) NodePricing(key Key) (*Node, error) {
 		klog.Infof("Unable to find provider ID `%s`, using features:`%s`", key.ID(), key.Features())
 		return &Node{
 			Cost:        fmt.Sprintf("%f", cost),
-			PricingType: csvClass,
+			PricingType: CsvClass,
 		}, nil
 	}
 	return nil, fmt.Errorf("Unable to find Node matching `%s`:`%s`", key.ID(), key.Features())

--- a/pkg/cloud/csvprovider.go
+++ b/pkg/cloud/csvprovider.go
@@ -202,14 +202,16 @@ func (c *CSVProvider) NodePricing(key Key) (*Node, error) {
 	defer c.DownloadPricingDataLock.RUnlock()
 	if p, ok := c.Pricing[key.ID()]; ok {
 		return &Node{
-			Cost: p.MarketPriceHourly,
+			Cost:        p.MarketPriceHourly,
+			PricingType: csvExact,
 		}, nil
 	}
 	s := strings.Split(key.ID(), ",") // Try without a region to be sure
 	if len(s) == 2 {
 		if p, ok := c.Pricing[s[1]]; ok {
 			return &Node{
-				Cost: p.MarketPriceHourly,
+				Cost:        p.MarketPriceHourly,
+				PricingType: csvExact,
 			}, nil
 		}
 	}
@@ -217,7 +219,8 @@ func (c *CSVProvider) NodePricing(key Key) (*Node, error) {
 	if cost, ok := c.NodeClassPricing[classKey]; ok {
 		klog.Infof("Unable to find provider ID `%s`, using features:`%s`", key.ID(), key.Features())
 		return &Node{
-			Cost: fmt.Sprintf("%f", cost),
+			Cost:        fmt.Sprintf("%f", cost),
+			PricingType: csvClass,
 		}, nil
 	}
 	return nil, fmt.Errorf("Unable to find Node matching `%s`:`%s`", key.ID(), key.Features())

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -199,13 +199,13 @@ type PricingSource struct {
 type PricingType string
 
 const (
-	api           PricingType = "api"
-	spot          PricingType = "spot"
-	reserved      PricingType = "reserved"
-	savingsPlan   PricingType = "savingsPlan"
-	csvExact      PricingType = "csvExact"
-	csvClass      PricingType = "csvClass"
-	defaultPrices PricingType = "defaultPrices"
+	Api           PricingType = "api"
+	Spot          PricingType = "spot"
+	Reserved      PricingType = "reserved"
+	SavingsPlan   PricingType = "savingsPlan"
+	CsvExact      PricingType = "csvExact"
+	CsvClass      PricingType = "csvClass"
+	DefaultPrices PricingType = "defaultPrices"
 )
 
 type PricingMatchMetadata struct {

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -59,6 +59,7 @@ type Node struct {
 	Region           string                `json:"region,omitempty"`
 	Reserved         *ReservedInstanceData `json:"reserved,omitempty"`
 	ProviderID       string                `json:"providerID,omitempty"`
+	PricingType      PricingType           `json:"pricingType,omitempty"`
 }
 
 // IsSpot determines whether or not a Node uses spot by usage type
@@ -193,6 +194,23 @@ type PricingSource struct {
 	Name      string `json:"name"`
 	Available bool   `json:"available"`
 	Error     string `json:"error"`
+}
+
+type PricingType string
+
+const (
+	api           PricingType = "api"
+	spot          PricingType = "spot"
+	reserved      PricingType = "reserved"
+	savingsPlan   PricingType = "savingsPlan"
+	csvExact      PricingType = "csvExact"
+	csvClass      PricingType = "csvClass"
+	defaultPrices PricingType = "defaultPrices"
+)
+
+type PricingMatchMetadata struct {
+	TotalNodes        int                 `json:"TotalNodes"`
+	PricingTypeCounts map[PricingType]int `json:"PricingType"`
 }
 
 // Provider represents a k8s provider.

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -721,6 +721,13 @@ func (a *Accesses) GetPricingSourceStatus(w http.ResponseWriter, _ *http.Request
 	w.Write(WrapData(a.CloudProvider.PricingSourceStatus(), nil))
 }
 
+func (a *Accesses) GetPricingSourceCounts(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	w.Write(WrapData(a.Model.GetPricingSourceCounts()))
+}
+
 func (a *Accesses) GetPrometheusMetadata(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -1067,6 +1074,7 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) *Accesses {
 	a.Router.GET("/clusterInfoMap", a.GetClusterInfoMap)
 	a.Router.GET("/serviceAccountStatus", a.GetServiceAccountStatus)
 	a.Router.GET("/pricingSourceStatus", a.GetPricingSourceStatus)
+	a.Router.GET("/pricingSourceCounts", a.GetPricingSourceCounts)
 
 	// cluster manager endpoints
 	a.Router.GET("/clusters", managerEndpoints.GetAllClusters)

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2468,6 +2468,7 @@ func (as *AssetSet) ReconciliationMatch(query Asset) (Asset, bool, error) {
 	var providerIDMatch Asset
 	for _, asset := range as.assets {
 		if key(asset, fullMatchProps) == fullMatchKey {
+			log.DedupedInfof(10, "Asset ETL: Reconciliation[rcnw]: ReconcileRange Match: %s", fullMatchKey)
 			return asset, true, nil
 		}
 		if key(asset, providerIDMatchProps) == providerIDMatchKey {

--- a/test/cloud_test.go
+++ b/test/cloud_test.go
@@ -287,6 +287,76 @@ func TestNodePriceFromCSVWithBadConfig(t *testing.T) {
 	}
 }
 
+func TestSourceMatchesFromCSV(t *testing.T) {
+	os.Setenv("CONFIG_PATH", "../configs")
+	c := &cloud.CSVProvider{
+		CSVLocation: "../configs/pricing_schema_case.csv",
+		CustomProvider: &cloud.CustomProvider{
+			Config: cloud.NewProviderConfig("/default.json"),
+		},
+	}
+	c.DownloadPricingData()
+
+	n := &v1.Node{}
+	n.Spec.ProviderID = "fake"
+	n.Name = "nameWant"
+	n.Labels = make(map[string]string)
+	n.Labels["foo"] = "labelFooWant"
+	n.Labels[v1.LabelZoneRegion] = "regionone"
+
+	n2 := &v1.Node{}
+	n2.Spec.ProviderID = "azure:///subscriptions/123a7sd-asd-1234-578a9-123abcdef/resourceGroups/case_12_STaGe_TeSt7/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-agent-worker0-12stagetest7-ezggnore/virtualMachines/7"
+	n2.Labels = make(map[string]string)
+	n2.Labels[v1.LabelZoneRegion] = "eastus2"
+	n2.Labels["foo"] = "labelFooWant"
+
+	k := c.GetKey(n2.Labels, n2)
+	resN, err := c.NodePricing(k)
+	if err != nil {
+		t.Errorf("Error in NodePricing: %s", err.Error())
+	} else {
+		wantPrice := "0.13370357"
+		gotPrice := resN.Cost
+		if gotPrice != wantPrice {
+			t.Errorf("Wanted price '%s' got price '%s'", wantPrice, gotPrice)
+		}
+	}
+
+	n3 := &v1.Node{}
+	n3.Spec.ProviderID = "fake"
+	n3.Name = "nameWant"
+	n3.Labels = make(map[string]string)
+	n.Labels[v1.LabelZoneRegion] = "eastus2"
+	n.Labels[v1.LabelInstanceType] = "Standard_F32s_v2"
+
+	fc := NewFakeNodeCache([]*v1.Node{n, n2, n3})
+	fm := FakeClusterMap{}
+	d, _ := time.ParseDuration("1m")
+
+	model := costmodel.NewCostModel(fc, fm, d)
+
+	_, err = model.GetNodeCost(c)
+	if err != nil {
+		t.Errorf("Error in node pricing: %s", err)
+	}
+	p, err := model.GetPricingSourceCounts()
+	if err != nil {
+		t.Errorf("Error in pricing source counts: %s", err)
+	} else if p.TotalNodes != 3 {
+		t.Errorf("Wanted 3 nodes got %d", p.TotalNodes)
+	}
+	if p.PricingTypeCounts[""] != 1 {
+		t.Errorf("Wanted 1 default match got %d: %+v", p.PricingTypeCounts[""], p.PricingTypeCounts)
+	}
+	if p.PricingTypeCounts["csvExact"] != 1 {
+		t.Errorf("Wanted 1 exact match got %d: %+v", p.PricingTypeCounts["csvExact"], p.PricingTypeCounts)
+	}
+	if p.PricingTypeCounts["csvClass"] != 1 {
+		t.Errorf("Wanted 1 class match got %d: %+v", p.PricingTypeCounts["csvClass"], p.PricingTypeCounts)
+	}
+
+}
+
 func TestNodePriceFromCSVWithCase(t *testing.T) {
 	n := &v1.Node{}
 	n.Spec.ProviderID = "azure:///subscriptions/123a7sd-asd-1234-578a9-123abcdef/resourceGroups/case_12_STaGe_TeSt7/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-agent-worker0-12stagetest7-ezggnore/virtualMachines/7"


### PR DESCRIPTION
See #637

Goal will be to use existing data points in the CSV pipeline to infer new node prices. Initial algorithm will follow this logic:
* First search for an exact match in CSV pipeline
* If exact match not available, search for an existing CSV data point that matches region, instanceType, and AssetClass 
* If neither available, fallback to pricing estimates 