### PR TITLE
Fix Minutes on Allocation

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -81,6 +81,105 @@ type Aggregation struct {
 	TotalCostVector            []*util.Vector       `json:"totalCostVector,omitempty"`
 }
 
+// Start returns the time the aggregation begins according to the cost and
+// allocation vectors.
+func (a *Aggregation) Start() (time.Time, error) {
+	var start time.Time
+
+	if len(a.CPUAllocationVectors) > 0 {
+		t := time.Unix(int64(a.CPUAllocationVectors[0].Timestamp), 0)
+		if start.IsZero() || t.Before(start) {
+			start = t
+		}
+	}
+
+	if len(a.GPUAllocationVectors) > 0 {
+		t := time.Unix(int64(a.GPUAllocationVectors[0].Timestamp), 0)
+		if start.IsZero() || t.Before(start) {
+			start = t
+		}
+	}
+
+	if len(a.RAMAllocationVectors) > 0 {
+		t := time.Unix(int64(a.RAMAllocationVectors[0].Timestamp), 0)
+		if start.IsZero() || t.Before(start) {
+			start = t
+		}
+	}
+
+	if len(a.PVAllocationVectors) > 0 {
+		t := time.Unix(int64(a.PVAllocationVectors[0].Timestamp), 0)
+		if start.IsZero() || t.Before(start) {
+			start = t
+		}
+	}
+
+	if len(a.TotalCostVector) > 0 {
+		t := time.Unix(int64(a.TotalCostVector[0].Timestamp), 0)
+		if start.IsZero() || t.Before(start) {
+			start = t
+		}
+	}
+
+	if start.IsZero() {
+		return start, fmt.Errorf("cannot determine start time of Aggregation without vectors")
+	}
+
+	return start, nil
+}
+
+// End returns the time the aggregation begins according to the cost and
+// allocation vectors.
+func (a *Aggregation) End() (time.Time, error) {
+	var end time.Time
+
+	if len(a.CPUAllocationVectors) > 0 {
+		i := len(a.CPUAllocationVectors) - 1
+		t := time.Unix(int64(a.CPUAllocationVectors[i].Timestamp), 0)
+		if end.IsZero() || t.After(end) {
+			end = t
+		}
+	}
+
+	if len(a.GPUAllocationVectors) > 0 {
+		i := len(a.GPUAllocationVectors) - 1
+		t := time.Unix(int64(a.GPUAllocationVectors[i].Timestamp), 0)
+		if end.IsZero() || t.After(end) {
+			end = t
+		}
+	}
+
+	if len(a.RAMAllocationVectors) > 0 {
+		i := len(a.RAMAllocationVectors) - 1
+		t := time.Unix(int64(a.RAMAllocationVectors[i].Timestamp), 0)
+		if end.IsZero() || t.After(end) {
+			end = t
+		}
+	}
+
+	if len(a.PVAllocationVectors) > 0 {
+		i := len(a.PVAllocationVectors) - 1
+		t := time.Unix(int64(a.PVAllocationVectors[i].Timestamp), 0)
+		if end.IsZero() || t.After(end) {
+			end = t
+		}
+	}
+
+	if len(a.TotalCostVector) > 0 {
+		i := len(a.TotalCostVector) - 1
+		t := time.Unix(int64(a.TotalCostVector[i].Timestamp), 0)
+		if end.IsZero() || t.After(end) {
+			end = t
+		}
+	}
+
+	if end.IsZero() {
+		return end, fmt.Errorf("cannot determine end time of Aggregation without vectors")
+	}
+
+	return end, nil
+}
+
 // TotalHours determines the amount of hours the Aggregation covers, as a
 // function of the cost vectors and the resolution of those vectors' data
 func (a *Aggregation) TotalHours(resolutionHours float64) float64 {

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -47,6 +47,8 @@ type Aggregation struct {
 	Environment                string               `json:"environment"`
 	Cluster                    string               `json:"cluster,omitempty"`
 	Properties                 *kubecost.Properties `json:"-"`
+	Start                      time.Time            `json:"-"`
+	End                        time.Time            `json:"-"`
 	CPUAllocationHourlyAverage float64              `json:"cpuAllocationAverage"`
 	CPUAllocationVectors       []*util.Vector       `json:"-"`
 	CPUAllocationTotal         float64              `json:"-"`
@@ -79,105 +81,6 @@ type Aggregation struct {
 	SharedCost                 float64              `json:"sharedCost"`
 	TotalCost                  float64              `json:"totalCost"`
 	TotalCostVector            []*util.Vector       `json:"totalCostVector,omitempty"`
-}
-
-// Start returns the time the aggregation begins according to the cost and
-// allocation vectors.
-func (a *Aggregation) Start() (time.Time, error) {
-	var start time.Time
-
-	if len(a.CPUAllocationVectors) > 0 {
-		t := time.Unix(int64(a.CPUAllocationVectors[0].Timestamp), 0)
-		if start.IsZero() || t.Before(start) {
-			start = t
-		}
-	}
-
-	if len(a.GPUAllocationVectors) > 0 {
-		t := time.Unix(int64(a.GPUAllocationVectors[0].Timestamp), 0)
-		if start.IsZero() || t.Before(start) {
-			start = t
-		}
-	}
-
-	if len(a.RAMAllocationVectors) > 0 {
-		t := time.Unix(int64(a.RAMAllocationVectors[0].Timestamp), 0)
-		if start.IsZero() || t.Before(start) {
-			start = t
-		}
-	}
-
-	if len(a.PVAllocationVectors) > 0 {
-		t := time.Unix(int64(a.PVAllocationVectors[0].Timestamp), 0)
-		if start.IsZero() || t.Before(start) {
-			start = t
-		}
-	}
-
-	if len(a.TotalCostVector) > 0 {
-		t := time.Unix(int64(a.TotalCostVector[0].Timestamp), 0)
-		if start.IsZero() || t.Before(start) {
-			start = t
-		}
-	}
-
-	if start.IsZero() {
-		return start, fmt.Errorf("cannot determine start time of Aggregation without vectors")
-	}
-
-	return start, nil
-}
-
-// End returns the time the aggregation begins according to the cost and
-// allocation vectors.
-func (a *Aggregation) End() (time.Time, error) {
-	var end time.Time
-
-	if len(a.CPUAllocationVectors) > 0 {
-		i := len(a.CPUAllocationVectors) - 1
-		t := time.Unix(int64(a.CPUAllocationVectors[i].Timestamp), 0)
-		if end.IsZero() || t.After(end) {
-			end = t
-		}
-	}
-
-	if len(a.GPUAllocationVectors) > 0 {
-		i := len(a.GPUAllocationVectors) - 1
-		t := time.Unix(int64(a.GPUAllocationVectors[i].Timestamp), 0)
-		if end.IsZero() || t.After(end) {
-			end = t
-		}
-	}
-
-	if len(a.RAMAllocationVectors) > 0 {
-		i := len(a.RAMAllocationVectors) - 1
-		t := time.Unix(int64(a.RAMAllocationVectors[i].Timestamp), 0)
-		if end.IsZero() || t.After(end) {
-			end = t
-		}
-	}
-
-	if len(a.PVAllocationVectors) > 0 {
-		i := len(a.PVAllocationVectors) - 1
-		t := time.Unix(int64(a.PVAllocationVectors[i].Timestamp), 0)
-		if end.IsZero() || t.After(end) {
-			end = t
-		}
-	}
-
-	if len(a.TotalCostVector) > 0 {
-		i := len(a.TotalCostVector) - 1
-		t := time.Unix(int64(a.TotalCostVector[i].Timestamp), 0)
-		if end.IsZero() || t.After(end) {
-			end = t
-		}
-	}
-
-	if end.IsZero() {
-		return end, fmt.Errorf("cannot determine end time of Aggregation without vectors")
-	}
-
-	return end, nil
 }
 
 // TotalHours determines the amount of hours the Aggregation covers, as a

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -197,25 +197,28 @@ func (a *Allocation) IsUnallocated() bool {
 	return strings.Contains(a.Name, UnallocatedSuffix)
 }
 
+// CPUCores converts the Allocation's CPUCoreHours into average CPUCores
 func (a *Allocation) CPUCores() float64 {
 	if a.Minutes() <= 0.0 {
 		return 0.0
 	}
-	return a.CPUCoreHours / (a.Minutes() * 60.0)
+	return a.CPUCoreHours / (a.Minutes() / 60.0)
 }
 
+// RAMBytes converts the Allocation's RAMByteHours into average RAMBytes
 func (a *Allocation) RAMBytes() float64 {
 	if a.Minutes() <= 0.0 {
 		return 0.0
 	}
-	return a.RAMByteHours / (a.Minutes() * 60.0)
+	return a.RAMByteHours / (a.Minutes() / 60.0)
 }
 
+// PVBytes converts the Allocation's PVByteHours into average PVBytes
 func (a *Allocation) PVBytes() float64 {
 	if a.Minutes() <= 0.0 {
 		return 0.0
 	}
-	return a.PVByteHours / (a.Minutes() * 60.0)
+	return a.PVByteHours / (a.Minutes() / 60.0)
 }
 
 // MarshalJSON implements json.Marshal interface

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -32,9 +32,9 @@ func NewUnitAllocation(name string, start time.Time, resolution time.Duration, p
 	alloc := &Allocation{
 		Name:            name,
 		Properties:      *properties,
+		Window:          NewWindow(&start, &end),
 		Start:           start,
 		End:             end,
-		Minutes:         1440,
 		CPUCoreHours:    1,
 		CPUCost:         1,
 		CPUEfficiency:   1,
@@ -208,7 +208,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 	// Idle allocations
 	a1i := NewUnitAllocation(fmt.Sprintf("cluster1/%s", IdleSuffix), start, day, &Properties{
 		ClusterProp: "cluster1",
-		NodeProp: "node1",
+		NodeProp:    "node1",
 	})
 	a1i.CPUCost = 5.0
 	a1i.RAMCost = 15.0
@@ -398,8 +398,8 @@ func assertAllocationWindow(t *testing.T, as *AllocationSet, msg string, expStar
 		if !a.End.Equal(expEnd) {
 			t.Fatalf("AllocationSet.AggregateBy[%s]: expected end %s, actual %s", msg, expEnd, a.End)
 		}
-		if a.Minutes != expMinutes {
-			t.Fatalf("AllocationSet.AggregateBy[%s]: expected minutes %f, actual %f", msg, expMinutes, a.Minutes)
+		if a.Minutes() != expMinutes {
+			t.Fatalf("AllocationSet.AggregateBy[%s]: expected minutes %f, actual %f", msg, expMinutes, a.Minutes())
 		}
 	})
 }
@@ -1126,8 +1126,8 @@ func TestAllocationSetRange_Accumulate(t *testing.T) {
 	if !alloc.End.Equal(tomorrow) {
 		t.Fatalf("accumulating AllocationSetRange: expected to end %s; actual %s", tomorrow, alloc.End)
 	}
-	if alloc.Minutes != 2880.0 {
-		t.Fatalf("accumulating AllocationSetRange: expected %f minutes; actual %f", 2880.0, alloc.Minutes)
+	if alloc.Minutes() != 2880.0 {
+		t.Fatalf("accumulating AllocationSetRange: expected %f minutes; actual %f", 2880.0, alloc.Minutes())
 	}
 }
 

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -5,7 +5,6 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
-	"math"
 	"strings"
 	"sync"
 	"time"
@@ -2783,31 +2782,4 @@ func (asr *AssetSetRange) Window() Window {
 	end := asr.assets[asr.Length()-1].End()
 
 	return NewWindow(&start, &end)
-}
-
-// TODO move everything below to a separate package
-
-func jsonEncodeFloat64(buffer *bytes.Buffer, name string, val float64, comma string) {
-	var encoding string
-	if math.IsNaN(val) {
-		encoding = fmt.Sprintf("\"%s\":null%s", name, comma)
-	} else {
-		encoding = fmt.Sprintf("\"%s\":%f%s", name, val, comma)
-	}
-
-	buffer.WriteString(encoding)
-}
-
-func jsonEncodeString(buffer *bytes.Buffer, name, val, comma string) {
-	buffer.WriteString(fmt.Sprintf("\"%s\":\"%s\"%s", name, val, comma))
-}
-
-func jsonEncode(buffer *bytes.Buffer, name string, obj interface{}, comma string) {
-	buffer.WriteString(fmt.Sprintf("\"%s\":", name))
-	if bytes, err := json.Marshal(obj); err != nil {
-		buffer.WriteString("null")
-	} else {
-		buffer.Write(bytes)
-	}
-	buffer.WriteString(comma)
 }

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -21,4 +21,4 @@ package kubecost
 // @bingen:generate:AllocationSet
 // @bingen:generate:AllocationSetRange
 
-//go:generate bingen -package=kubecost -version=4 -buffer=github.com/kubecost/cost-model/pkg/util
+//go:generate bingen -package=kubecost -version=5 -buffer=github.com/kubecost/cost-model/pkg/util

--- a/pkg/kubecost/json.go
+++ b/pkg/kubecost/json.go
@@ -1,0 +1,35 @@
+package kubecost
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+// TODO move everything below to a separate package
+
+func jsonEncodeFloat64(buffer *bytes.Buffer, name string, val float64, comma string) {
+	var encoding string
+	if math.IsNaN(val) {
+		encoding = fmt.Sprintf("\"%s\":null%s", name, comma)
+	} else {
+		encoding = fmt.Sprintf("\"%s\":%f%s", name, val, comma)
+	}
+
+	buffer.WriteString(encoding)
+}
+
+func jsonEncodeString(buffer *bytes.Buffer, name, val, comma string) {
+	buffer.WriteString(fmt.Sprintf("\"%s\":\"%s\"%s", name, val, comma))
+}
+
+func jsonEncode(buffer *bytes.Buffer, name string, obj interface{}, comma string) {
+	buffer.WriteString(fmt.Sprintf("\"%s\":", name))
+	if bytes, err := json.Marshal(obj); err != nil {
+		buffer.WriteString("null")
+	} else {
+		buffer.Write(bytes)
+	}
+	buffer.WriteString(comma)
+}


### PR DESCRIPTION
Requires https://github.com/kubecost/kubecost-cost-model/pull/302

## Changes
- Derive Allocation.Minutes from (Start, End), rather than recording it. This requires relatively minimial, but sensitive changes to Allocation functions like Aggregate and Accumulate.
- Custom JSON encode (required because of the above) with me CPUCores, RAMBytes, and PVBytes helpers.
- Rebuild codec (will require ETL rebuild)

## Testing
- Manual testing (see https://github.com/kubecost/kubecost-cost-model/pull/302)
- TO DO unit tests to confirm that new Minutes logic is working under all circumstances