### PR TITLE
Sean/add annotations

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -1248,15 +1248,15 @@ func (a *Accesses) ComputeAggregateCostModel(promClient prometheusClient.Client,
 					ae := aggregateEnvironment(cd)
 					for _, v := range vs {
 						if v == "__unallocated__" { // Special case. __unallocated__ means return all pods without the attached label
-							if _, ok := cd.Labels[label]; !ok {
+							if _, ok := cd.Labels[l]; !ok {
 								return true, ae
 							}
 						}
-						if cd.Labels[label] == v {
+						if cd.Labels[l] == v {
 							return true, ae
 						} else if strings.HasSuffix(v, "*") { // trigger wildcard prefix filtering
 							vTrim := strings.TrimSuffix(v, "*")
-							if strings.HasPrefix(cd.Labels[label], vTrim) {
+							if strings.HasPrefix(cd.Labels[l], vTrim) {
 								return true, ae
 							}
 						}
@@ -1297,15 +1297,15 @@ func (a *Accesses) ComputeAggregateCostModel(promClient prometheusClient.Client,
 					ae := aggregateEnvironment(cd)
 					for _, v := range vs {
 						if v == "__unallocated__" { // Special case. __unallocated__ means return all pods without the attached label
-							if _, ok := cd.Annotations[annotation]; !ok {
+							if _, ok := cd.Annotations[l]; !ok {
 								return true, ae
 							}
 						}
-						if cd.Annotations[annotation] == v {
+						if cd.Annotations[l] == v {
 							return true, ae
 						} else if strings.HasSuffix(v, "*") { // trigger wildcard prefix filtering
 							vTrim := strings.TrimSuffix(v, "*")
-							if strings.HasPrefix(cd.Annotations[annotation], vTrim) {
+							if strings.HasPrefix(cd.Annotations[l], vTrim) {
 								return true, ae
 							}
 						}
@@ -1912,9 +1912,6 @@ func (a *Accesses) AggregateCostModelHandler(w http.ResponseWriter, r *http.Requ
 	namespace := r.URL.Query().Get("namespace")
 	cluster := r.URL.Query().Get("cluster")
 	labels := r.URL.Query().Get("labels")
-	labelArray := strings.Split(labels, "=")
-	labelArray[0] = strings.ReplaceAll(labelArray[0], "-", "_")
-	labels = strings.Join(labelArray, "=")
 	annotations := r.URL.Query().Get("annotations")
 	podprefix := r.URL.Query().Get("podprefix")
 	field := r.URL.Query().Get("aggregation")

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -375,6 +375,21 @@ func AggregateCostData(costData map[string]*CostData, field string, subfields []
 				if !found {
 					aggregateDatum(cp, aggregations, costDatum, field, subfields, rate, UnallocatedSubfield, discount, customDiscount, idleCoefficient, false)
 				}
+			} else if field == "Annotations" {
+				found := false
+				if costDatum.Annotations != nil {
+					for _, sf := range subfields {
+						if subfieldName, ok := costDatum.Annotations[sf]; ok {
+							aggregateDatum(cp, aggregations, costDatum, field, subfields, rate, subfieldName, discount, customDiscount, idleCoefficient, false)
+							found = true
+							break
+						}
+					}
+				}
+				if !found {
+					aggregateDatum(cp, aggregations, costDatum, field, subfields, rate, UnallocatedSubfield, discount, customDiscount, idleCoefficient, false)
+				}
+
 			} else if field == "pod" {
 				aggregateDatum(cp, aggregations, costDatum, field, subfields, rate, costDatum.Namespace+"/"+costDatum.PodName, discount, customDiscount, idleCoefficient, false)
 			} else if field == "container" {

--- a/pkg/costmodel/containerkeys.go
+++ b/pkg/costmodel/containerkeys.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/kubecost/cost-model/pkg/log"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 )
 
 var (
@@ -13,22 +13,22 @@ var (
 	NewKeyTupleErr = errors.New("NewKeyTuple() Provided key not containing exactly 3 components.")
 
 	// Static Errors for ContainerMetric creation
-	InvalidKeyErr      error = errors.New("Not a valid key")
-	NoContainerErr     error = errors.New("Prometheus vector does not have container name")
+	InvalidKeyErr error = errors.New("Not a valid key")
+	NoContainerErr error = errors.New("Prometheus vector does not have container name")
 	NoContainerNameErr error = errors.New("Prometheus vector does not have string container name")
-	NoPodErr           error = errors.New("Prometheus vector does not have pod name")
-	NoPodNameErr       error = errors.New("Prometheus vector does not have string pod name")
-	NoNamespaceErr     error = errors.New("Prometheus vector does not have namespace")
+	NoPodErr error = errors.New("Prometheus vector does not have pod name")
+	NoPodNameErr error = errors.New("Prometheus vector does not have string pod name")
+	NoNamespaceErr error = errors.New("Prometheus vector does not have namespace")
 	NoNamespaceNameErr error = errors.New("Prometheus vector does not have string namespace")
-	NoNodeNameErr      error = errors.New("Prometheus vector does not have string node")
-	NoClusterIDErr     error = errors.New("Prometheus vector does not have string cluster_id")
+	NoNodeNameErr error = errors.New("Prometheus vector does not have string node")
+	NoClusterIDErr error = errors.New("Prometheus vector does not have string cluster_id")
 )
 
 //--------------------------------------------------------------------------
 //  KeyTuple
 //--------------------------------------------------------------------------
 
-// KeyTuple contains is a utility which parses Namespace, Key, and ClusterID from a
+// KeyTuple contains is a utility which parses Namespace, Key, and ClusterID from a 
 // comma delimitted string.
 type KeyTuple struct {
 	key    string
@@ -103,8 +103,8 @@ func containerMetricKey(ns, podName, containerName, nodeName, clusterID string) 
 	return ns + "," + podName + "," + containerName + "," + nodeName + "," + clusterID
 }
 
-// NewContainerMetricFromKey creates a new ContainerMetric instance using a provided comma delimitted
-// string key.
+// NewContainerMetricFromKey creates a new ContainerMetric instance using a provided comma delimitted 
+// string key. 
 func NewContainerMetricFromKey(key string) (*ContainerMetric, error) {
 	s := strings.Split(key, ",")
 	if len(s) == 5 {
@@ -132,7 +132,7 @@ func NewContainerMetricFromValues(ns, podName, containerName, nodeName, clusterI
 	}
 }
 
-// NewContainerMetricsFromPod creates a slice of ContainerMetric instances for each container in the
+// NewContainerMetricsFromPod creates a slice of ContainerMetric instances for each container in the 
 // provided Pod.
 func NewContainerMetricsFromPod(pod *v1.Pod, clusterID string) ([]*ContainerMetric, error) {
 	podName := pod.GetObjectMeta().GetName()

--- a/pkg/costmodel/containerkeys.go
+++ b/pkg/costmodel/containerkeys.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/kubecost/cost-model/pkg/log"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -13,22 +13,22 @@ var (
 	NewKeyTupleErr = errors.New("NewKeyTuple() Provided key not containing exactly 3 components.")
 
 	// Static Errors for ContainerMetric creation
-	InvalidKeyErr error = errors.New("Not a valid key")
-	NoContainerErr error = errors.New("Prometheus vector does not have container name")
+	InvalidKeyErr      error = errors.New("Not a valid key")
+	NoContainerErr     error = errors.New("Prometheus vector does not have container name")
 	NoContainerNameErr error = errors.New("Prometheus vector does not have string container name")
-	NoPodErr error = errors.New("Prometheus vector does not have pod name")
-	NoPodNameErr error = errors.New("Prometheus vector does not have string pod name")
-	NoNamespaceErr error = errors.New("Prometheus vector does not have namespace")
+	NoPodErr           error = errors.New("Prometheus vector does not have pod name")
+	NoPodNameErr       error = errors.New("Prometheus vector does not have string pod name")
+	NoNamespaceErr     error = errors.New("Prometheus vector does not have namespace")
 	NoNamespaceNameErr error = errors.New("Prometheus vector does not have string namespace")
-	NoNodeNameErr error = errors.New("Prometheus vector does not have string node")
-	NoClusterIDErr error = errors.New("Prometheus vector does not have string cluster_id")
+	NoNodeNameErr      error = errors.New("Prometheus vector does not have string node")
+	NoClusterIDErr     error = errors.New("Prometheus vector does not have string cluster_id")
 )
 
 //--------------------------------------------------------------------------
 //  KeyTuple
 //--------------------------------------------------------------------------
 
-// KeyTuple contains is a utility which parses Namespace, Key, and ClusterID from a 
+// KeyTuple contains is a utility which parses Namespace, Key, and ClusterID from a
 // comma delimitted string.
 type KeyTuple struct {
 	key    string
@@ -103,8 +103,8 @@ func containerMetricKey(ns, podName, containerName, nodeName, clusterID string) 
 	return ns + "," + podName + "," + containerName + "," + nodeName + "," + clusterID
 }
 
-// NewContainerMetricFromKey creates a new ContainerMetric instance using a provided comma delimitted 
-// string key. 
+// NewContainerMetricFromKey creates a new ContainerMetric instance using a provided comma delimitted
+// string key.
 func NewContainerMetricFromKey(key string) (*ContainerMetric, error) {
 	s := strings.Split(key, ",")
 	if len(s) == 5 {
@@ -132,7 +132,7 @@ func NewContainerMetricFromValues(ns, podName, containerName, nodeName, clusterI
 	}
 }
 
-// NewContainerMetricsFromPod creates a slice of ContainerMetric instances for each container in the 
+// NewContainerMetricsFromPod creates a slice of ContainerMetric instances for each container in the
 // provided Pod.
 func NewContainerMetricsFromPod(pod *v1.Pod, clusterID string) ([]*ContainerMetric, error) {
 	podName := pod.GetObjectMeta().GetName()

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -85,7 +85,7 @@ type CostData struct {
 	GPUReq          []*util.Vector               `json:"gpureq,omitempty"`
 	PVCData         []*PersistentVolumeClaimData `json:"pvcData,omitempty"`
 	NetworkData     []*util.Vector               `json:"network,omitempty"`
-	Annotations     map[string]string            `json:"Annotations,omitempty"`
+	Annotations     map[string]string            `json:"annotations,omitempty"`
 	Labels          map[string]string            `json:"labels,omitempty"`
 	NamespaceLabels map[string]string            `json:"namespaceLabels,omitempty"`
 	ClusterID       string                       `json:"clusterId"`

--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -259,11 +259,11 @@ func GetPodAnnotationsMetrics(qrs []*prom.QueryResult, defaultClusterID string) 
 
 		nsKey := ns + "," + pod + "," + clusterID
 		if labels, ok := toReturn[nsKey]; ok {
-			for k, v := range val.GetLabels() {
+			for k, v := range val.GetAnnotations() {
 				labels[k] = v
 			}
 		} else {
-			toReturn[nsKey] = val.GetLabels()
+			toReturn[nsKey] = val.GetAnnotations()
 		}
 	}
 

--- a/pkg/prom/result.go
+++ b/pkg/prom/result.go
@@ -240,7 +240,7 @@ func (qr *QueryResult) GetLabels() map[string]string {
 			continue
 		}
 
-		label := k[6:]
+		label := strings.TrimPrefix(k, "label_")
 		value, ok := v.(string)
 		if !ok {
 			log.Warningf("Failed to parse label value for label: '%s'", label)
@@ -253,6 +253,7 @@ func (qr *QueryResult) GetLabels() map[string]string {
 	return result
 }
 
+// GetAnnotations returns all annotations and their values from the query result
 func (qr *QueryResult) GetAnnotations() map[string]string {
 	result := make(map[string]string)
 
@@ -262,7 +263,7 @@ func (qr *QueryResult) GetAnnotations() map[string]string {
 			continue
 		}
 
-		annotations := k[11:]
+		annotations := strings.TrimPrefix(k, "annotation_")
 		value, ok := v.(string)
 		if !ok {
 			log.Warningf("Failed to parse label value for label: '%s'", annotations)

--- a/pkg/prom/result.go
+++ b/pkg/prom/result.go
@@ -253,6 +253,28 @@ func (qr *QueryResult) GetLabels() map[string]string {
 	return result
 }
 
+func (qr *QueryResult) GetAnnotations() map[string]string {
+	result := make(map[string]string)
+
+	// Find All keys with prefix annotation_, remove prefix, add to annotations
+	for k, v := range qr.Metric {
+		if !strings.HasPrefix(k, "annotation_") {
+			continue
+		}
+
+		annotations := k[11:]
+		value, ok := v.(string)
+		if !ok {
+			log.Warningf("Failed to parse label value for label: '%s'", annotations)
+			continue
+		}
+
+		result[annotations] = value
+	}
+
+	return result
+}
+
 // parseDataPoint parses a data point from raw prometheus query results and returns
 // a new Vector instance containing the parsed data along with any warnings or errors.
 func parseDataPoint(query string, dataPoint interface{}) (*util.Vector, warning, error) {


### PR DESCRIPTION
Tested by filtering on annotations using requests like this on bolt-1:

/model/aggregatedCostModel?window=1d&offset=1m&aggregation=namespace&allocateIdle=true&timeSeries=true&annotations=test_kubecost_annotation_instance%3Dkubecost&efficiency=true&aggregationSubfield=&sharedNamespaces=&sharedSplit=weighted&sharedLabelNames=&sharedLabelValues=&sharedSplit=weighted&req=635724

Additional annotations to filter on can be found in the bolt-1 prometheus dashboard by querying kube_pod_annotations

