### PR TITLE
Fix idle allocation for windows < 1h

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -204,22 +204,13 @@ func (a *Accesses) ComputeIdleCoefficient(costData map[string]*CostData, cli pro
 
 	key := fmt.Sprintf("%s:%s", windowString, offset)
 	if data, valid := a.ClusterCostsCache.Get(key); valid {
-
 		clusterCosts = data.(map[string]*ClusterCosts)
-
-		log.Infof("AggAPI: ComputeIdleCoefficient: ClusterCostsCache is valid")
-
 	} else {
 		clusterCosts, err = a.ComputeClusterCosts(cli, cp, windowString, offset, false)
 		if err != nil {
 			return nil, err
 		}
-
-		log.Infof("AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts")
-
 	}
-
-	log.Infof("AggAPI: ComputeIdleCoefficient: clusterCosts: %+v", clusterCosts)
 
 	measureTime(profileStart, profileThreshold, profileName)
 
@@ -300,8 +291,6 @@ func AggregateCostData(costData map[string]*CostData, field string, subfields []
 	includeEfficiency := opts.IncludeEfficiency
 	rate := opts.Rate
 	sr := opts.SharedResourceInfo
-
-	log.Infof("AggAPI: AggregateCostData: idleCoefficients: %+v", idleCoefficients)
 
 	resolutionHours := 1.0
 	if opts.ResolutionHours > 0.0 {
@@ -1402,22 +1391,38 @@ func (a *Accesses) ComputeAggregateCostModel(promClient prometheusClient.Client,
 
 	idleCoefficients := make(map[string]float64)
 	if allocateIdle {
-		duration, offset := window.DurationOffsetStrings()
-
-		idleDurationCalcHours := window.Hours()
-		if window.Hours() < 1 {
-			idleDurationCalcHours = 1
-		}
-		duration = fmt.Sprintf("%dh", int(idleDurationCalcHours))
-
-		if a.ThanosClient != nil {
-			offset = thanos.Offset()
-			log.Infof("ComputeAggregateCostModel: setting offset to %s", offset)
-		}
-
-		idleCoefficients, err = a.ComputeIdleCoefficient(costData, promClient, a.CloudProvider, discount, customDiscount, duration, offset)
+		dur, off, err := window.DurationOffset()
 		if err != nil {
-			log.Errorf("ComputeAggregateCostModel: error computing idle coefficient: duration=%s, offset=%s, err=%s", duration, offset, err)
+			log.Errorf("ComputeAggregateCostModel: error computing idle coefficient: illegal window: %s (%s)", window, err)
+			return nil, "", err
+		}
+
+		if a.ThanosClient != nil && off < thanos.OffsetDuration() {
+			// Determine difference between the Thanos offset and the requested
+			// offset; e.g. off=1h, thanosOffsetDuration=3h => diff=2h
+			diff := thanos.OffsetDuration() - off
+
+			// Reduce duration by difference and increase offset by difference
+			// e.g. 24h offset 0h => 21h offset 3h
+			dur = dur - diff
+			off = thanos.OffsetDuration()
+
+			log.Infof("ComputeAggregateCostModel: setting duration, offset to %s, %s due to Thanos", dur, off)
+
+			// Idle computation cannot be fulfilled for some windows, specifically
+			// those with sum(duration, offset) < Thanos offset, because there is
+			// no data within that window.
+			if dur <= 0 {
+				return nil, "", fmt.Errorf("requested idle coefficients from Thanos for illegal duration, offset: %s, %s (original window %s)", dur, off, window)
+			}
+		}
+
+		// Convert to Prometheus-compatible strings
+		durStr, offStr := util.DurationOffsetStrings(dur, off)
+
+		idleCoefficients, err = a.ComputeIdleCoefficient(costData, promClient, a.CloudProvider, discount, customDiscount, durStr, offStr)
+		if err != nil {
+			log.Errorf("ComputeAggregateCostModel: error computing idle coefficient: duration=%s, offset=%s, err=%s", durStr, offStr, err)
 			return nil, "", err
 		}
 	}

--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -204,13 +204,22 @@ func (a *Accesses) ComputeIdleCoefficient(costData map[string]*CostData, cli pro
 
 	key := fmt.Sprintf("%s:%s", windowString, offset)
 	if data, valid := a.ClusterCostsCache.Get(key); valid {
+
 		clusterCosts = data.(map[string]*ClusterCosts)
+
+		log.Infof("AggAPI: ComputeIdleCoefficient: ClusterCostsCache is valid")
+
 	} else {
 		clusterCosts, err = a.ComputeClusterCosts(cli, cp, windowString, offset, false)
 		if err != nil {
 			return nil, err
 		}
+
+		log.Infof("AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts")
+
 	}
+
+	log.Infof("AggAPI: ComputeIdleCoefficient: clusterCosts: %+v", clusterCosts)
 
 	measureTime(profileStart, profileThreshold, profileName)
 
@@ -291,6 +300,8 @@ func AggregateCostData(costData map[string]*CostData, field string, subfields []
 	includeEfficiency := opts.IncludeEfficiency
 	rate := opts.Rate
 	sr := opts.SharedResourceInfo
+
+	log.Infof("AggAPI: AggregateCostData: idleCoefficients: %+v", idleCoefficients)
 
 	resolutionHours := 1.0
 	if opts.ResolutionHours > 0.0 {

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -7,8 +7,20 @@ import (
 )
 
 const (
+	// SecsPerMin expresses the amount of seconds in a minute
+	SecsPerMin = 60.0
+
+	// SecsPerHour expresses the amount of seconds in a minute
+	SecsPerHour = 3600.0
+
+	// SecsPerDay expressed the amount of seconds in a day
+	SecsPerDay = 86400.0
+
 	// MinsPerHour expresses the amount of minutes in an hour
 	MinsPerHour = 60.0
+
+	// MinsPerDay expresses the amount of minutes in a day
+	MinsPerDay = 1440.0
 
 	// HoursPerDay expresses the amount of hours in a day
 	HoursPerDay = 24.0
@@ -19,6 +31,48 @@ const (
 	// DaysPerMonth expresses the amount of days in a month
 	DaysPerMonth = 30.42
 )
+
+// DurationOffsetStrings converts a (duration, offset) pair to Prometheus-
+// compatible strings in terms of days, hours, minutes, or seconds.
+func DurationOffsetStrings(duration, offset time.Duration) (string, string) {
+	durSecs := int64(duration.Seconds())
+	offSecs := int64(offset.Seconds())
+
+	durStr := ""
+	if durSecs > 0 {
+		if durSecs%SecsPerDay == 0 {
+			// convert to days
+			durStr = fmt.Sprintf("%dd", durSecs/SecsPerDay)
+		} else if durSecs%SecsPerHour == 0 {
+			// convert to hours
+			durStr = fmt.Sprintf("%dh", durSecs/SecsPerHour)
+		} else if durSecs%SecsPerMin == 0 {
+			// convert to mins
+			durStr = fmt.Sprintf("%dm", durSecs/SecsPerMin)
+		} else if durSecs > 0 {
+			// default to mins, as long as duration is positive
+			durStr = fmt.Sprintf("%ds", durSecs)
+		}
+	}
+
+	offStr := ""
+	if offSecs > 0 {
+		if offSecs%SecsPerDay == 0 {
+			// convert to days
+			offStr = fmt.Sprintf("%dd", offSecs/SecsPerDay)
+		} else if offSecs%SecsPerHour == 0 {
+			// convert to hours
+			offStr = fmt.Sprintf("%dh", offSecs/SecsPerHour)
+		} else if offSecs%SecsPerMin == 0 {
+			// convert to mins
+			offStr = fmt.Sprintf("%dm", offSecs/SecsPerMin)
+		} else if offSecs > 0 {
+			// default to mins, as long as offation is positive
+			offStr = fmt.Sprintf("%ds", offSecs)
+		}
+	}
+	return durStr, offStr
+}
 
 // ParseDuration converts a Prometheus-style duration string into a Duration
 func ParseDuration(duration string) (*time.Duration, error) {

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDurationOffsetStrings(t *testing.T) {
+	dur, off := "", ""
+
+	dur, off = DurationOffsetStrings(0, 0)
+	if dur != "" || off != "" {
+		t.Fatalf("DurationOffsetStrings: exp (%s %s); act (%s, %s)", "", "", dur, off)
+	}
+
+	dur, off = DurationOffsetStrings(24*time.Hour, 0)
+	if dur != "1d" || off != "" {
+		t.Fatalf("DurationOffsetStrings: exp (%s %s); act (%s, %s)", "1d", "", dur, off)
+	}
+
+	dur, off = DurationOffsetStrings(24*time.Hour+5*time.Minute, 0)
+	if dur != "1445m" || off != "" {
+		t.Fatalf("DurationOffsetStrings: exp (%s %s); act (%s, %s)", "1445m", "", dur, off)
+	}
+
+	dur, off = DurationOffsetStrings(25*time.Hour, 5*time.Minute)
+	if dur != "25h" || off != "5m" {
+		t.Fatalf("DurationOffsetStrings: exp (%s %s); act (%s, %s)", "25h", "5m", dur, off)
+	}
+
+	dur, off = DurationOffsetStrings(25*time.Hour, 60*time.Minute)
+	if dur != "25h" || off != "1h" {
+		t.Fatalf("DurationOffsetStrings: exp (%s %s); act (%s, %s)", "25h", "1h", dur, off)
+	}
+
+	dur, off = DurationOffsetStrings(72*time.Hour, 1440*time.Minute)
+	if dur != "3d" || off != "1d" {
+		t.Fatalf("DurationOffsetStrings: exp (%s %s); act (%s, %s)", "3d", "1d", dur, off)
+	}
+
+	dur, off = DurationOffsetStrings(25*time.Hour, 1*time.Second)
+	if dur != "25h" || off != "1s" {
+		t.Fatalf("DurationOffsetStrings: exp (%s %s); act (%s, %s)", "25h", "1s", dur, off)
+	}
+
+	dur, off = DurationOffsetStrings(24*time.Hour+time.Second, 1*time.Second)
+	if dur != "86401s" || off != "1s" {
+		t.Fatalf("DurationOffsetStrings: exp (%s %s); act (%s, %s)", "86401s", "1s", dur, off)
+	}
+
+	// Expect empty strings if durations are negative
+	dur, off = DurationOffsetStrings(-25*time.Hour, -1*time.Second)
+	if dur != "" || off != "" {
+		t.Fatalf("DurationOffsetStrings: exp (%s %s); act (%s, %s)", "", "", dur, off)
+	}
+}


### PR DESCRIPTION
## Changes
- Fix idle allocation for windows < 1h by removing some old code that always queried cluster costs for at least "1h", regardless of the requested window duration.
- Fix idle allocation query w/r/t Thanos offset, too. This fix will now provide more accurate duration/offset pairs, but it will also correctly return an error when sum(duration, offset) < Thanos offset. (We shouldn't be returning any data for very short intervals in Thanos.)
- Improve, refactor, and test DurationOffset string conversion utility

## Testing
- Unit tests for DurationOffset utility
- Manual testing via aggregatedCostModel API and logging on gcp-niko and aws-integration. Details below.

### Before
2h results were approximately twice 1h results, but 30m and 10m results equalled 1h results because the cluster costs query was always being run on window of at least 1h, even for smaller windows. This made the cluster cost superficially high and the idle coefficient superficially low.

#### Results (total cost)
- 2h = 0.42533738155606143
- 1h = 0.21266869077803044
- 30m = 0.21266869077803058
- 10m = 0.21266869077803063

#### Logs
aws/model/aggregatedCostModel?window=2h&aggregation=cluster&allocateIdle=true
```
[Info] AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts(2h, )
[Info] AggAPI: ComputeIdleCoefficient: clusterCosts: map[cluster-one:window=2021-01-12T15:56:09-2021-01-12T17:56:09;minutes=120.00;cost=0.43]
[Info] AggAPI: AggregateCostData: idleCoefficients: map[cluster-one:0.3470892041300827]
```
aws/model/aggregatedCostModel?window=1h&aggregation=cluster&allocateIdle=true
```
[Info] AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts(1h, )
[Info] AggAPI: ComputeIdleCoefficient: clusterCosts: map[cluster-one:window=2021-01-12T16:56:14-2021-01-12T17:56:14;minutes=60.00;cost=0.21]
[Info] AggAPI: AggregateCostData: idleCoefficients: map[cluster-one:0.35091839505836386]
```
aws/model/aggregatedCostModel?window=30m&aggregation=cluster&allocateIdle=true
```
[Info] AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts(1h, )
[Info] AggAPI: ComputeIdleCoefficient: clusterCosts: map[cluster-one:window=2021-01-12T16:56:17-2021-01-12T17:56:17;minutes=60.00;cost=0.21]
[Info] AggAPI: AggregateCostData: idleCoefficients: map[cluster-one:0.17550468495444643]
```
aws/model/aggregatedCostModel?window=10m&aggregation=cluster&allocateIdle=true
```
[Info] AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts(1h, )
[Info] AggAPI: ComputeIdleCoefficient: clusterCosts: map[cluster-one:window=2021-01-12T16:56:21-2021-01-12T17:56:21;minutes=60.00;cost=0.21]
[Info] AggAPI: AggregateCostData: idleCoefficients: map[cluster-one:0.05852953026530949]
```

### After
With the windows fixed, idle coefficients remain approximately constant and the cluster cost scales with time as expected. Thus, resultant total cost scales correctly.

#### Results (total cost)
- 2h: 0.4253373815560614
- 1h: 0.2126686907780305
- 30m: 0.10633434538901525
- 10m: 0.035444781796338455

#### Logs
aws/model/aggregatedCostModel?window=2h&aggregation=cluster&allocateIdle=true
```
[Info] AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts(2h, )
[Info] AggAPI: ComputeIdleCoefficient: clusterCosts: map[cluster-one:window=2021-01-12T17:26:43-2021-01-12T19:26:43;minutes=120.00;cost=0.43]
[Info] AggAPI: AggregateCostData: idleCoefficients: map[cluster-one:0.3448314841031037]
```
aws/model/aggregatedCostModel?window=1h&aggregation=cluster&allocateIdle=true
```
[Info] AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts(1h, )
[Info] AggAPI: ComputeIdleCoefficient: clusterCosts: map[cluster-one:window=2021-01-12T18:26:49-2021-01-12T19:26:49;minutes=60.00;cost=0.21]
[Info] AggAPI: AggregateCostData: idleCoefficients: map[cluster-one:0.3448840603470777]
```
aws/model/aggregatedCostModel?window=30m&aggregation=cluster&allocateIdle=true
```
[Info] AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts(30m, )
[Info] AggAPI: ComputeIdleCoefficient: clusterCosts: map[cluster-one:window=2021-01-12T18:56:59-2021-01-12T19:26:59;minutes=30.00;cost=0.11]
[Info] AggAPI: AggregateCostData: idleCoefficients: map[cluster-one:0.3395844644982903]
```
aws/model/aggregatedCostModel?window=10m&aggregation=cluster&allocateIdle=true
```
[Info] AggAPI: ComputeIdleCoefficient: ClusterCostsCache is not valid: ComputeClusterCosts(10m, )
[Info] AggAPI: ComputeIdleCoefficient: clusterCosts: map[cluster-one:window=2021-01-12T19:17:04-2021-01-12T19:27:04;minutes=10.00;cost=0.04]
[Info] AggAPI: AggregateCostData: idleCoefficients: map[cluster-one:0.31649492442735655]
```
