### PR TITLE
Aggregation by label

### DIFF
--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -64,7 +64,7 @@ const (
 // GetAWSAccessKeyID returns the environment variable value for AWSAccessKeyIDEnvVar which represents
 // the AWS access key for authentication
 func GetAppVersion() string {
-	return Get(AppVersionEnvVar, "1.71.1")
+	return Get(AppVersionEnvVar, "1.72.0")
 }
 
 // IsEmitNamespaceAnnotationsMetric returns true if cost-model is configured to emit the kube_namespace_annotations metric

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -109,9 +109,10 @@ func key(a Asset, aggregateBy []string) (string, error) {
 			if labelKey := strings.TrimPrefix(s, "label:"); labelKey != "" {
 				labelVal, ok := a.Labels()[labelKey]
 				if !ok {
-					labelVal = "__undefined__"
+					key = "__undefined__"
+				} else {
+					key = fmt.Sprintf("%s=%s", labelKey, labelVal)
 				}
-				key = fmt.Sprintf("%s=%s", labelKey, labelVal)
 			} else {
 				// Don't allow aggregating on label ""
 				return "", fmt.Errorf("Attempted to aggregate on invalid key: %s", s)

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -107,7 +107,11 @@ func key(a Asset, aggregateBy []string) (string, error) {
 			key = a.Properties().Name
 		case strings.HasPrefix(s, "label:"):
 			if labelKey := strings.TrimPrefix(s, "label:"); labelKey != "" {
-				key = a.Labels()[labelKey]
+				labelVal, ok := a.Labels()[labelKey]
+				if !ok {
+					labelVal = "__undefined__"
+				}
+				key = fmt.Sprintf("%s=%s", labelKey, labelVal)
 			} else {
 				// Don't allow aggregating on label ""
 				return "", fmt.Errorf("Attempted to aggregate on invalid key: %s", s)

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -107,8 +107,8 @@ func key(a Asset, aggregateBy []string) (string, error) {
 			key = a.Properties().Name
 		case strings.HasPrefix(s, "label:"):
 			if labelKey := strings.TrimPrefix(s, "label:"); labelKey != "" {
-				labelVal, ok := a.Labels()[labelKey]
-				if !ok {
+				labelVal := a.Labels()[labelKey]
+				if labelVal == "" {
 					key = "__undefined__"
 				} else {
 					key = fmt.Sprintf("%s=%s", labelKey, labelVal)

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2672,8 +2672,10 @@ func (as *AssetSet) accumulate(that *AssetSet) (*AssetSet, error) {
 	// In the case of an AssetSetRange with empty entries, we may end up with
 	// an incoming `as` without an `aggregateBy`, even though we are tring to
 	// aggregate here. This handles that case by assigning the correct `aggregateBy`.
-	if len(as.aggregateBy) == 0 {
-		as.aggregateBy = that.aggregateBy
+	if !sameContents(as.aggregateBy, that.aggregateBy) {
+		if len(as.aggregateBy) == 0 {
+			as.aggregateBy = that.aggregateBy
+		}
 	}
 
 	// Set start, end to min(start), max(end)
@@ -2864,4 +2866,26 @@ func jsonEncode(buffer *bytes.Buffer, name string, obj interface{}, comma string
 		buffer.Write(bytes)
 	}
 	buffer.WriteString(comma)
+}
+
+// Returns true if string slices a and b contain all of the same strings, in any order.
+func sameContents(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !contains(b, a[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(slice []string, item string) bool {
+	for _, element := range slice {
+		if element == item {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -697,8 +697,8 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 	}
 	fmt.Println(as.assets)
 	assertAssetSet(t, as, "1e", window, map[string]float64{
-		"__undefined__": 53.00,
-		"test":          7.00,
+		"test=__undefined__": 53.00,
+		"test=test":          7.00,
 	}, nil)
 
 	// 2  Multi-aggregation

--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -697,8 +697,8 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 	}
 	fmt.Println(as.assets)
 	assertAssetSet(t, as, "1e", window, map[string]float64{
-		"test=__undefined__": 53.00,
-		"test=test":          7.00,
+		"__undefined__": 53.00,
+		"test=test":     7.00,
 	}, nil)
 
 	// 2  Multi-aggregation

--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -675,17 +675,17 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 		t.Fatalf("AssetSet.AggregateBy: unexpected error: %s", err)
 	}
 	assertAssetSet(t, as, "1d", window, map[string]float64{
-		"Compute/cluster1/Node/Kubernetes/gcp-node1/node1":     7.00,
-		"Compute/cluster1/Node/Kubernetes/gcp-node2/node2":     5.50,
-		"Compute/cluster1/Node/Kubernetes/gcp-node3/node3":     6.50,
-		"Storage/cluster1/Disk/Kubernetes/gcp-disk1/disk1":     2.50,
-		"Storage/cluster1/Disk/Kubernetes/gcp-disk2/disk2":     1.50,
-		"GCP/Management/cluster1/ClusterManagement/Kubernetes": 3.00,
-		"Compute/cluster2/Node/Kubernetes/gcp-node4/node4":     11.00,
-		"Storage/cluster2/Disk/Kubernetes/gcp-disk3/disk3":     2.50,
-		"Storage/cluster2/Disk/Kubernetes/gcp-disk4/disk4":     1.50,
-		"GCP/Management/cluster2/ClusterManagement/Kubernetes": 0.00,
-		"Compute/cluster3/Node/Kubernetes/aws-node5/node5":     19.00,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node1/node1":                     7.00,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node2/node2":                     5.50,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node3/node3":                     6.50,
+		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster1/Disk/Kubernetes/gcp-disk1/disk1":                     2.50,
+		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster1/Disk/Kubernetes/gcp-disk2/disk2":                     1.50,
+		"GCP/__unallocated__/__unallocated__/Management/cluster1/ClusterManagement/Kubernetes/__unallocated__/__unallocated__": 3.00,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster2/Node/Kubernetes/gcp-node4/node4":                     11.00,
+		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster2/Disk/Kubernetes/gcp-disk3/disk3":                     2.50,
+		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster2/Disk/Kubernetes/gcp-disk4/disk4":                     1.50,
+		"GCP/__unallocated__/__unallocated__/Management/cluster2/ClusterManagement/Kubernetes/__unallocated__/__unallocated__": 0.00,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster3/Node/Kubernetes/aws-node5/node5":                     19.00,
 	}, nil)
 
 	// 2  Multi-aggregation
@@ -784,17 +784,17 @@ func TestAssetSetRange_Accumulate(t *testing.T) {
 		t.Fatalf("AssetSetRange.AggregateBy: unexpected error: %s", err)
 	}
 	assertAssetSet(t, as, "1a", window, map[string]float64{
-		"Compute/cluster1/Node/Kubernetes/gcp-node1/node1":     21.00,
-		"Compute/cluster1/Node/Kubernetes/gcp-node2/node2":     16.50,
-		"Compute/cluster1/Node/Kubernetes/gcp-node3/node3":     19.50,
-		"Storage/cluster1/Disk/Kubernetes/gcp-disk1/disk1":     7.50,
-		"Storage/cluster1/Disk/Kubernetes/gcp-disk2/disk2":     4.50,
-		"GCP/Management/cluster1/ClusterManagement/Kubernetes": 9.00,
-		"Compute/cluster2/Node/Kubernetes/gcp-node4/node4":     33.00,
-		"Storage/cluster2/Disk/Kubernetes/gcp-disk3/disk3":     7.50,
-		"Storage/cluster2/Disk/Kubernetes/gcp-disk4/disk4":     4.50,
-		"GCP/Management/cluster2/ClusterManagement/Kubernetes": 0.00,
-		"Compute/cluster3/Node/Kubernetes/aws-node5/node5":     57.00,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node1/node1":                     21.00,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node2/node2":                     16.50,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node3/node3":                     19.50,
+		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster1/Disk/Kubernetes/gcp-disk1/disk1":                     7.50,
+		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster1/Disk/Kubernetes/gcp-disk2/disk2":                     4.50,
+		"GCP/__unallocated__/__unallocated__/Management/cluster1/ClusterManagement/Kubernetes/__unallocated__/__unallocated__": 9.00,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster2/Node/Kubernetes/gcp-node4/node4":                     33.00,
+		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster2/Disk/Kubernetes/gcp-disk3/disk3":                     7.50,
+		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster2/Disk/Kubernetes/gcp-disk4/disk4":                     4.50,
+		"GCP/__unallocated__/__unallocated__/Management/cluster2/ClusterManagement/Kubernetes/__unallocated__/__unallocated__": 0.00,
+		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster3/Node/Kubernetes/aws-node5/node5":                     57.00,
 	}, nil)
 
 	asr = NewAssetSetRange(

--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -618,6 +618,7 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 	// 1b []AssetProperty=[Type]
 	// 1c []AssetProperty=[Nil]
 	// 1d []AssetProperty=nil
+	// 1e aggregateBy []string=["label:test"]
 
 	// 2  Multi-aggregation
 	// 2a []AssetProperty=[Cluster,Type]
@@ -686,6 +687,18 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 		"__undefined__/__undefined__/__undefined__/Storage/cluster2/Disk/Kubernetes/gcp-disk4/disk4":                   1.50,
 		"GCP/__undefined__/__undefined__/Management/cluster2/ClusterManagement/Kubernetes/__undefined__/__undefined__": 0.00,
 		"__undefined__/__undefined__/__undefined__/Compute/cluster3/Node/Kubernetes/aws-node5/node5":                   19.00,
+	}, nil)
+
+	// 1e aggregateBy []string=["label:test"]
+	as = generateAssetSet(startYesterday)
+	err = as.AggregateBy([]string{"label:test"}, nil)
+	if err != nil {
+		t.Fatalf("AssetSet.AggregateBy: unexpected error: %s", err)
+	}
+	fmt.Println(as.assets)
+	assertAssetSet(t, as, "1e", window, map[string]float64{
+		"__undefined__": 53.00,
+		"test":          7.00,
 	}, nil)
 
 	// 2  Multi-aggregation
@@ -935,6 +948,7 @@ func generateAssetSet(start time.Time) *AssetSet {
 	node1.CPUCoreHours = 2.0 * hours
 	node1.RAMByteHours = 4.0 * gb * hours
 	node1.SetAdjustment(1.0)
+	node1.SetLabels(map[string]string{"test": "test"})
 
 	node2 := NewNode("node2", "cluster1", "gcp-node2", *window.Clone().start, *window.Clone().end, window.Clone())
 	node2.CPUCost = 4.0

--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -675,17 +675,17 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 		t.Fatalf("AssetSet.AggregateBy: unexpected error: %s", err)
 	}
 	assertAssetSet(t, as, "1d", window, map[string]float64{
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node1/node1":                     7.00,
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node2/node2":                     5.50,
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node3/node3":                     6.50,
-		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster1/Disk/Kubernetes/gcp-disk1/disk1":                     2.50,
-		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster1/Disk/Kubernetes/gcp-disk2/disk2":                     1.50,
-		"GCP/__unallocated__/__unallocated__/Management/cluster1/ClusterManagement/Kubernetes/__unallocated__/__unallocated__": 3.00,
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster2/Node/Kubernetes/gcp-node4/node4":                     11.00,
-		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster2/Disk/Kubernetes/gcp-disk3/disk3":                     2.50,
-		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster2/Disk/Kubernetes/gcp-disk4/disk4":                     1.50,
-		"GCP/__unallocated__/__unallocated__/Management/cluster2/ClusterManagement/Kubernetes/__unallocated__/__unallocated__": 0.00,
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster3/Node/Kubernetes/aws-node5/node5":                     19.00,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster1/Node/Kubernetes/gcp-node1/node1":                   7.00,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster1/Node/Kubernetes/gcp-node2/node2":                   5.50,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster1/Node/Kubernetes/gcp-node3/node3":                   6.50,
+		"__undefined__/__undefined__/__undefined__/Storage/cluster1/Disk/Kubernetes/gcp-disk1/disk1":                   2.50,
+		"__undefined__/__undefined__/__undefined__/Storage/cluster1/Disk/Kubernetes/gcp-disk2/disk2":                   1.50,
+		"GCP/__undefined__/__undefined__/Management/cluster1/ClusterManagement/Kubernetes/__undefined__/__undefined__": 3.00,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster2/Node/Kubernetes/gcp-node4/node4":                   11.00,
+		"__undefined__/__undefined__/__undefined__/Storage/cluster2/Disk/Kubernetes/gcp-disk3/disk3":                   2.50,
+		"__undefined__/__undefined__/__undefined__/Storage/cluster2/Disk/Kubernetes/gcp-disk4/disk4":                   1.50,
+		"GCP/__undefined__/__undefined__/Management/cluster2/ClusterManagement/Kubernetes/__undefined__/__undefined__": 0.00,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster3/Node/Kubernetes/aws-node5/node5":                   19.00,
 	}, nil)
 
 	// 2  Multi-aggregation
@@ -784,17 +784,17 @@ func TestAssetSetRange_Accumulate(t *testing.T) {
 		t.Fatalf("AssetSetRange.AggregateBy: unexpected error: %s", err)
 	}
 	assertAssetSet(t, as, "1a", window, map[string]float64{
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node1/node1":                     21.00,
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node2/node2":                     16.50,
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster1/Node/Kubernetes/gcp-node3/node3":                     19.50,
-		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster1/Disk/Kubernetes/gcp-disk1/disk1":                     7.50,
-		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster1/Disk/Kubernetes/gcp-disk2/disk2":                     4.50,
-		"GCP/__unallocated__/__unallocated__/Management/cluster1/ClusterManagement/Kubernetes/__unallocated__/__unallocated__": 9.00,
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster2/Node/Kubernetes/gcp-node4/node4":                     33.00,
-		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster2/Disk/Kubernetes/gcp-disk3/disk3":                     7.50,
-		"__unallocated__/__unallocated__/__unallocated__/Storage/cluster2/Disk/Kubernetes/gcp-disk4/disk4":                     4.50,
-		"GCP/__unallocated__/__unallocated__/Management/cluster2/ClusterManagement/Kubernetes/__unallocated__/__unallocated__": 0.00,
-		"__unallocated__/__unallocated__/__unallocated__/Compute/cluster3/Node/Kubernetes/aws-node5/node5":                     57.00,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster1/Node/Kubernetes/gcp-node1/node1":                   21.00,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster1/Node/Kubernetes/gcp-node2/node2":                   16.50,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster1/Node/Kubernetes/gcp-node3/node3":                   19.50,
+		"__undefined__/__undefined__/__undefined__/Storage/cluster1/Disk/Kubernetes/gcp-disk1/disk1":                   7.50,
+		"__undefined__/__undefined__/__undefined__/Storage/cluster1/Disk/Kubernetes/gcp-disk2/disk2":                   4.50,
+		"GCP/__undefined__/__undefined__/Management/cluster1/ClusterManagement/Kubernetes/__undefined__/__undefined__": 9.00,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster2/Node/Kubernetes/gcp-node4/node4":                   33.00,
+		"__undefined__/__undefined__/__undefined__/Storage/cluster2/Disk/Kubernetes/gcp-disk3/disk3":                   7.50,
+		"__undefined__/__undefined__/__undefined__/Storage/cluster2/Disk/Kubernetes/gcp-disk4/disk4":                   4.50,
+		"GCP/__undefined__/__undefined__/Management/cluster2/ClusterManagement/Kubernetes/__undefined__/__undefined__": 0.00,
+		"__undefined__/__undefined__/__undefined__/Compute/cluster3/Node/Kubernetes/aws-node5/node5":                   57.00,
 	}, nil)
 
 	asr = NewAssetSetRange(

--- a/pkg/kubecost/asset_test.go
+++ b/pkg/kubecost/asset_test.go
@@ -636,7 +636,7 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 
 	// 1a []AssetProperty=[Cluster]
 	as = generateAssetSet(startYesterday)
-	err = as.AggregateBy([]AssetProperty{AssetClusterProp}, nil)
+	err = as.AggregateBy([]string{string(AssetClusterProp)}, nil)
 	if err != nil {
 		t.Fatalf("AssetSet.AggregateBy: unexpected error: %s", err)
 	}
@@ -648,7 +648,7 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 
 	// 1b []AssetProperty=[Type]
 	as = generateAssetSet(startYesterday)
-	err = as.AggregateBy([]AssetProperty{AssetTypeProp}, nil)
+	err = as.AggregateBy([]string{string(AssetTypeProp)}, nil)
 	if err != nil {
 		t.Fatalf("AssetSet.AggregateBy: unexpected error: %s", err)
 	}
@@ -660,7 +660,7 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 
 	// 1c []AssetProperty=[Nil]
 	as = generateAssetSet(startYesterday)
-	err = as.AggregateBy([]AssetProperty{}, nil)
+	err = as.AggregateBy([]string{}, nil)
 	if err != nil {
 		t.Fatalf("AssetSet.AggregateBy: unexpected error: %s", err)
 	}
@@ -692,7 +692,7 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 
 	// 2a []AssetProperty=[Cluster,Type]
 	as = generateAssetSet(startYesterday)
-	err = as.AggregateBy([]AssetProperty{AssetClusterProp, AssetTypeProp}, nil)
+	err = as.AggregateBy([]string{string(AssetClusterProp), string(AssetTypeProp)}, nil)
 	if err != nil {
 		t.Fatalf("AssetSet.AggregateBy: unexpected error: %s", err)
 	}
@@ -710,7 +710,7 @@ func TestAssetSet_AggregateBy(t *testing.T) {
 
 	// 3a Shared hourly cost > 0.0
 	as = generateAssetSet(startYesterday)
-	err = as.AggregateBy([]AssetProperty{AssetTypeProp}, &AssetAggregationOptions{
+	err = as.AggregateBy([]string{string(AssetTypeProp)}, &AssetAggregationOptions{
 		SharedHourlyCosts: map[string]float64{"shared1": 0.5},
 	})
 	if err != nil {
@@ -737,7 +737,7 @@ func TestAssetSet_FindMatch(t *testing.T) {
 	// Assert success of a simple match of Type and ProviderID
 	as = generateAssetSet(startYesterday)
 	query = NewNode("", "", "gcp-node3", s, e, w)
-	match, err = as.FindMatch(query, []AssetProperty{AssetTypeProp, AssetProviderIDProp})
+	match, err = as.FindMatch(query, []string{string(AssetTypeProp), string(AssetProviderIDProp)})
 	if err != nil {
 		t.Fatalf("AssetSet.FindMatch: unexpected error: %s", err)
 	}
@@ -745,7 +745,7 @@ func TestAssetSet_FindMatch(t *testing.T) {
 	// Assert error of a simple non-match of Type and ProviderID
 	as = generateAssetSet(startYesterday)
 	query = NewNode("", "", "aws-node3", s, e, w)
-	match, err = as.FindMatch(query, []AssetProperty{AssetTypeProp, AssetProviderIDProp})
+	match, err = as.FindMatch(query, []string{string(AssetTypeProp), string(AssetProviderIDProp)})
 	if err == nil {
 		t.Fatalf("AssetSet.FindMatch: expected error (no match); found %s", match)
 	}
@@ -753,7 +753,7 @@ func TestAssetSet_FindMatch(t *testing.T) {
 	// Assert error of matching ProviderID, but not Type
 	as = generateAssetSet(startYesterday)
 	query = NewCloud(ComputeCategory, "gcp-node3", s, e, w)
-	match, err = as.FindMatch(query, []AssetProperty{AssetTypeProp, AssetProviderIDProp})
+	match, err = as.FindMatch(query, []string{string(AssetTypeProp), string(AssetProviderIDProp)})
 	if err == nil {
 		t.Fatalf("AssetSet.FindMatch: expected error (no match); found %s", match)
 	}
@@ -802,7 +802,7 @@ func TestAssetSetRange_Accumulate(t *testing.T) {
 		generateAssetSet(startD1),
 		generateAssetSet(startD2),
 	)
-	err = asr.AggregateBy([]AssetProperty{}, nil)
+	err = asr.AggregateBy([]string{}, nil)
 	as, err = asr.Accumulate()
 	if err != nil {
 		t.Fatalf("AssetSetRange.AggregateBy: unexpected error: %s", err)
@@ -816,7 +816,7 @@ func TestAssetSetRange_Accumulate(t *testing.T) {
 		generateAssetSet(startD1),
 		generateAssetSet(startD2),
 	)
-	err = asr.AggregateBy([]AssetProperty{AssetTypeProp}, nil)
+	err = asr.AggregateBy([]string{string(AssetTypeProp)}, nil)
 	if err != nil {
 		t.Fatalf("AssetSetRange.AggregateBy: unexpected error: %s", err)
 	}
@@ -835,7 +835,7 @@ func TestAssetSetRange_Accumulate(t *testing.T) {
 		generateAssetSet(startD1),
 		generateAssetSet(startD2),
 	)
-	err = asr.AggregateBy([]AssetProperty{AssetClusterProp}, nil)
+	err = asr.AggregateBy([]string{string(AssetClusterProp)}, nil)
 	if err != nil {
 		t.Fatalf("AssetSetRange.AggregateBy: unexpected error: %s", err)
 	}
@@ -856,7 +856,7 @@ func TestAssetSetRange_Accumulate(t *testing.T) {
 		generateAssetSet(startD1),
 		generateAssetSet(startD2),
 	)
-	err = asr.AggregateBy([]AssetProperty{AssetTypeProp}, nil)
+	err = asr.AggregateBy([]string{string(AssetTypeProp)}, nil)
 	as, err = asr.Accumulate()
 	if err != nil {
 		t.Fatalf("AssetSetRange.AggregateBy: unexpected error: %s", err)

--- a/pkg/kubecost/assetprops.go
+++ b/pkg/kubecost/assetprops.go
@@ -55,7 +55,7 @@ func ParseAssetProperty(text string) (AssetProperty, error) {
 		return AssetProjectProp, nil
 	case "provider":
 		return AssetProviderProp, nil
-	case "providerID":
+	case "providerid":
 		return AssetProviderIDProp, nil
 	case "service":
 		return AssetServiceProp, nil

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -21,4 +21,4 @@ package kubecost
 // @bingen:generate:AllocationSet
 // @bingen:generate:AllocationSetRange
 
-//go:generate bingen -package=kubecost -version=4 -buffer=github.com/kubecost/cost-model/pkg/util
+//go:generate bingen -package=kubecost -version=5 -buffer=github.com/kubecost/cost-model/pkg/util

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -26,7 +26,7 @@ const (
 	GeneratorPackageName string = "kubecost"
 
 	// CodecVersion is the version passed into the generator
-	CodecVersion uint8 = 4
+	CodecVersion uint8 = 5
 )
 
 //--------------------------------------------------------------------------
@@ -930,6 +930,19 @@ func (target *AssetSet) MarshalBinary() (data []byte, err error) {
 	buff := util.NewBuffer()
 	buff.WriteUInt8(CodecVersion) // version
 
+	if target.aggregateBy == nil {
+		buff.WriteUInt8(uint8(0)) // write nil byte
+	} else {
+		buff.WriteUInt8(uint8(1)) // write non-nil byte
+
+		// --- [begin][write][slice]([]string) ---
+		buff.WriteInt(len(target.aggregateBy)) // array length
+		for i := 0; i < len(target.aggregateBy); i++ {
+			buff.WriteString(target.aggregateBy[i]) // write string
+		}
+		// --- [end][write][slice]([]string) ---
+
+	}
 	if target.assets == nil {
 		buff.WriteUInt8(uint8(0)) // write nil byte
 	} else {
@@ -962,22 +975,6 @@ func (target *AssetSet) MarshalBinary() (data []byte, err error) {
 			}
 		}
 		// --- [end][write][map](map[string]Asset) ---
-
-	}
-	if target.props == nil {
-		buff.WriteUInt8(uint8(0)) // write nil byte
-	} else {
-		buff.WriteUInt8(uint8(1)) // write non-nil byte
-
-		// --- [begin][write][slice]([]AssetProperty) ---
-		buff.WriteInt(len(target.props)) // array length
-		for i := 0; i < len(target.props); i++ {
-			// --- [begin][write][alias](AssetProperty) ---
-			buff.WriteString(string(target.props[i])) // write string
-			// --- [end][write][alias](AssetProperty) ---
-
-		}
-		// --- [end][write][slice]([]AssetProperty) ---
 
 	}
 	// --- [begin][write][struct](Window) ---
@@ -1043,92 +1040,88 @@ func (target *AssetSet) UnmarshalBinary(data []byte) (err error) {
 	}
 
 	if buff.ReadUInt8() == uint8(0) {
+		target.aggregateBy = nil
+	} else {
+		// --- [begin][read][slice]([]string) ---
+		b := buff.ReadInt() // array len
+		a := make([]string, b)
+		for i := 0; i < b; i++ {
+			var c string
+			d := buff.ReadString() // read string
+			c = d
+
+			a[i] = c
+		}
+		target.aggregateBy = a
+		// --- [end][read][slice]([]string) ---
+
+	}
+	if buff.ReadUInt8() == uint8(0) {
 		target.assets = nil
 	} else {
 		// --- [begin][read][map](map[string]Asset) ---
-		a := make(map[string]Asset)
-		b := buff.ReadInt() // map len
-		for i := 0; i < b; i++ {
+		e := make(map[string]Asset)
+		f := buff.ReadInt() // map len
+		for j := 0; j < f; j++ {
 			var k string
-			c := buff.ReadString() // read string
-			k = c
+			g := buff.ReadString() // read string
+			k = g
 
 			var v Asset
 			if buff.ReadUInt8() == uint8(0) {
 				v = nil
 			} else {
 				// --- [begin][read][interface](Asset) ---
-				d := buff.ReadString()
-				_, e, _ := resolveType(d)
-				if _, ok := typeMap[e]; !ok {
-					return fmt.Errorf("Unknown Type: %s", e)
+				h := buff.ReadString()
+				_, l, _ := resolveType(h)
+				if _, ok := typeMap[l]; !ok {
+					return fmt.Errorf("Unknown Type: %s", l)
 				}
-				f, okA := reflect.New(typeMap[e]).Interface().(interface{ UnmarshalBinary([]byte) error })
+				m, okA := reflect.New(typeMap[l]).Interface().(interface{ UnmarshalBinary([]byte) error })
 				if !okA {
-					return fmt.Errorf("Type: %s does not implement UnmarshalBinary([]byte) error", e)
+					return fmt.Errorf("Type: %s does not implement UnmarshalBinary([]byte) error", l)
 				}
-				g := buff.ReadInt()    // byte array length
-				h := buff.ReadBytes(g) // byte array
-				errA := f.UnmarshalBinary(h)
+				n := buff.ReadInt()    // byte array length
+				o := buff.ReadBytes(n) // byte array
+				errA := m.UnmarshalBinary(o)
 				if errA != nil {
 					return errA
 				}
-				v = f.(Asset)
+				v = m.(Asset)
 				// --- [end][read][interface](Asset) ---
 
 			}
-			a[k] = v
+			e[k] = v
 		}
-		target.assets = a
+		target.assets = e
 		// --- [end][read][map](map[string]Asset) ---
 
 	}
-	if buff.ReadUInt8() == uint8(0) {
-		target.props = nil
-	} else {
-		// --- [begin][read][slice]([]AssetProperty) ---
-		m := buff.ReadInt() // array len
-		l := make([]AssetProperty, m)
-		for j := 0; j < m; j++ {
-			// --- [begin][read][alias](AssetProperty) ---
-			var o string
-			p := buff.ReadString() // read string
-			o = p
-
-			n := AssetProperty(o)
-			// --- [end][read][alias](AssetProperty) ---
-
-			l[j] = n
-		}
-		target.props = l
-		// --- [end][read][slice]([]AssetProperty) ---
-
-	}
 	// --- [begin][read][struct](Window) ---
-	q := &Window{}
-	r := buff.ReadInt()    // byte array length
-	s := buff.ReadBytes(r) // byte array
-	errB := q.UnmarshalBinary(s)
+	p := &Window{}
+	q := buff.ReadInt()    // byte array length
+	r := buff.ReadBytes(q) // byte array
+	errB := p.UnmarshalBinary(r)
 	if errB != nil {
 		return errB
 	}
-	target.Window = *q
+	target.Window = *p
 	// --- [end][read][struct](Window) ---
 
 	if buff.ReadUInt8() == uint8(0) {
 		target.Warnings = nil
 	} else {
 		// --- [begin][read][slice]([]string) ---
-		u := buff.ReadInt() // array len
-		t := make([]string, u)
-		for ii := 0; ii < u; ii++ {
-			var w string
-			x := buff.ReadString() // read string
-			w = x
+		t := buff.ReadInt() // array len
+		s := make([]string, t)
+		for ii := 0; ii < t; ii++ {
+			var u string
+			w := buff.ReadString() // read string
+			u = w
 
-			t[ii] = w
+			s[ii] = u
 		}
-		target.Warnings = t
+		target.Warnings = s
 		// --- [end][read][slice]([]string) ---
 
 	}
@@ -1136,16 +1129,16 @@ func (target *AssetSet) UnmarshalBinary(data []byte) (err error) {
 		target.Errors = nil
 	} else {
 		// --- [begin][read][slice]([]string) ---
-		z := buff.ReadInt() // array len
-		y := make([]string, z)
-		for jj := 0; jj < z; jj++ {
-			var aa string
-			bb := buff.ReadString() // read string
-			aa = bb
+		y := buff.ReadInt() // array len
+		x := make([]string, y)
+		for jj := 0; jj < y; jj++ {
+			var z string
+			aa := buff.ReadString() // read string
+			z = aa
 
-			y[jj] = aa
+			x[jj] = z
 		}
-		target.Errors = y
+		target.Errors = x
 		// --- [end][read][slice]([]string) ---
 
 	}


### PR DESCRIPTION
Updated AssetSet and AssetSetRange to aggregate by a new property aggStrings []string.
The props []AssetProperty value is still maintained on a given AssetSet, but rather than use this for aggregation,
we now use aggStrings, which can include values other than enumerated props. Specifically, strings prefixed with "label:"
are interpreted as labels and can be grouped on.

Strings in aggStrings which match the enumerated AssetProperty strings are stored in AssetSet.props, as before.

Also updated the relevant asset_test tests to call the Aggregation funcs with []string rather than []AssetProperty