### PR TITLE
Ajay tripathy fix async issue

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1042,17 +1042,17 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) *Accesses {
 	// Initialize mechanism for subscribing to settings changes
 	a.InitializeSettingsPubSub()
 
+	err = a.CloudProvider.DownloadPricingData()
+	if err != nil {
+		klog.V(1).Info("Failed to download pricing data: " + err.Error())
+	}
+
 	// Warm the aggregate cache unless explicitly set to false
 	if env.IsCacheWarmingEnabled() {
 		log.Infof("Init: AggregateCostModel cache warming enabled")
 		a.warmAggregateCostModelCache()
 	} else {
 		log.Infof("Init: AggregateCostModel cache warming disabled")
-	}
-
-	err = a.CloudProvider.DownloadPricingData()
-	if err != nil {
-		klog.V(1).Info("Failed to download pricing data: " + err.Error())
 	}
 
 	a.MetricsEmitter.Start()


### PR DESCRIPTION
No sense warming the cache until pricing data is available.

Previously, reported by user:
**I0212 15:03:06.821485       1 log.go:47] [Info] ComputeAggregateCostModel: missed cache: 1d:1m:1.000000h:false (found false, disableCache true, noCache false)**
**I0212 15:03:06.821729       1 awsprovider.go:592] starting download of "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-gov-west-1/index.json", which is quite large ...**
I0212 15:03:07.850618       1 log.go:47] [Info] ComputeAggregateCostModel: setting L2 cache: 1d:1m:1.000000h:false
**I0212 15:03:07.850931       1 log.go:32] [Warning] No pricing data found for node `<redacted>-1.compute.internal`
I0212 15:03:07.851042       1 log.go:32] [Warning] No pricing data found for node `<redacted>-1.compute.internal` , using custom pricing
I0212 15:03:07.851133       1 log.go:32] [Warning] No pricing data found for node  `<redacted>-1.compute.internal` , using custom pricing
I0212 15:03:07.851240       1 log.go:32] [Warning] No pricing data found for node  `<redacted>-1.compute.internal` , using custom pricing
I0212 15:03:07.851315       1 log.go:32] [Warning] No pricing data found for node `<redacted>-1.compute.internal` , using custom pricing**
I0212 15:03:07.851410       1 log.go:47] [Info] No pricing data found for node `%s` , using custom pricing logged 5 times: suppressing future logs
**I0212 15:03:07.877238       1 log.go:47] [Info] ComputeAggregateCostModel: setting aggregate cache: 1d:1m::::::namespace:::cattle-system,fleet-system,ingress-nginx,kube-system,kubecost::weighted:false:false:true**
I0212 15:03:08.010474       1 log.go:47] [Info] caching 1d cluster costs for 11m0s
I0212 15:03:08.010798       1 log.go:47] [Info] aggregation: warm cache: 1d
I0212 15:03:08.011011       1 log.go:47] [Info] aggregation: cache warming defaults: 2d:1m::::::namespace:::cattle-system,fleet-system,ingress-nginx,kube-system,kubecost::weighted:false:false:true
I0212 15:03:08.011160       1 log.go:47] [Info] ComputeAggregateCostModel: missed cache: 2d:1m:2.000000h:false (found false, disableCache true, noCache false)
**I0212 15:03:09.170732       1 awsprovider.go:724] done loading "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-gov-west-1/index.json"
I0212 15:03:09.170758       1 awsprovider.go:853] Finished downloading "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-gov-west-1/index.json"**



Reproduced:

I0216 00:25:19.033182       1 log.go:47] [Info] ComputeAggregateCostModel: setting aggregate cache: 1d:1m:::::::namespace::::weighted:false:false:true
I0216 00:25:19.136047       1 log.go:47] [Info] caching 1d cluster costs for 11m0s
**I0216 00:25:19.136065       1 log.go:47] [Info] aggregation: warm cache: 1d**
**I0216 00:25:29.189370       1 awsprovider.go:592] starting download of "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-east-2/index.json", which is quite large ...
I0216 00:25:29.189627       1 awsprovider.go:701] Savings Plan watcher running... next update in 1h
I0216 00:25:33.493523       1 awsprovider.go:724] done loading "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-east-2/index.json"**
I0216 00:25:33.493706       1 awsprovider.go:853] Finished downloading "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-east-2/index.json"


Fixed:

I0216 00:33:56.941408       1 awsprovider.go:592] starting download of "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-east-2/index.json", which is quite large ...
I0216 00:33:56.941676       1 awsprovider.go:701] Savings Plan watcher running... next update in 1h
I0216 00:34:43.292945       1 awsprovider.go:724] done loading "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-east-2/index.json"
**I0216 00:34:43.292979       1 awsprovider.go:853] Finished downloading "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-east-2/index.json"**
I0216 00:34:43.410147       1 awsprovider.go:2116] Found 22 spot data files from yesterday
I0216 00:34:43.425152       1 awsprovider.go:2125] Found 0 spot data files from today
I0216 00:34:43.526239       1 log.go:47] [Info] Found spot info for: %s logged 5 times: suppressing future logs
**I0216 00:34:43.856565       1 log.go:47] [Info] Init: AggregateCostModel cache warming enabled**
I0216 00:34:43.856797       1 log.go:47] [Info] aggregation: cache warming defaults: 1d:1m:::::::namespace::::weighted:false:false:true
I0216 00:34:43.856834       1 log.go:47] [Info] ComputeAggregateCostModel: missed cache: 1d:1m:1.000000h:false (found false, disableCache true, noCache false)
I0216 00:34:43.857623       1 awsprovider.go:866] Spot Pricing Refresh scheduled in 15.00 minutes.
