### PR TITLE
Ajay tripathy use capacitystatus

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -174,6 +174,7 @@ type AWSProductAttributes struct {
 	OperatingSystem string `json:"operatingSystem"`
 	PreInstalledSw  string `json:"preInstalledSw"`
 	InstanceFamily  string `json:"instanceFamily"`
+	CapacityStatus  string `json:"capacitystatus"`
 	GPU             string `json:"gpu"` // GPU represents the number of GPU on the instance
 }
 
@@ -743,7 +744,8 @@ func (aws *AWS) DownloadPricingData() error {
 				}
 
 				if product.Attributes.PreInstalledSw == "NA" &&
-					(strings.HasPrefix(product.Attributes.UsageType, "BoxUsage") || strings.Contains(product.Attributes.UsageType, "-BoxUsage")) {
+					(strings.HasPrefix(product.Attributes.UsageType, "BoxUsage") || strings.Contains(product.Attributes.UsageType, "-BoxUsage")) &&
+					product.Attributes.CapacityStatus == "Used" {
 					key := aws.KubeAttrConversion(product.Attributes.Location, product.Attributes.InstanceType, product.Attributes.OperatingSystem)
 					spotKey := key + ",preemptible"
 					if inputkeys[key] || inputkeys[spotKey] { // Just grab the sku even if spot, and change the price later.


### PR DESCRIPTION
Fix for using capacitystatus in pricing API

User Reports:
```
I0216 16:08:42.101266       1 awsprovider.go:853] Finished downloading "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-gov-west-1/index.json"
I0216 16:08:42.101478       1 awsprovider.go:858] Pricing us-gov-west-1,t2.large,linux: 0.0000000000
...
I0216 16:08:42.101680       1 awsprovider.go:858] Pricing us-gov-west-1,t2.large,linux,preemptible: 0.0000000000
```

After this PR, and simulating govcloud nodetype:
```
I0216 19:37:59.519701       1 awsprovider.go:856] Finished downloading "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/us-gov-west-1/index.json"
I0216 19:37:59.519783       1 awsprovider.go:861] Pricing us-gov-west-1,t2.large,linux: BP3D9JS4K9UCBBZ3: 0.1088000000
...
I0216 19:37:59.519795       1 awsprovider.go:861] Pricing us-gov-west-1,t2.large,linux,preemptible: BP3D9JS4K9UCBBZ3: 0.1088000000
```