### PR TITLE
Ajay tripathy fix logspam

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -309,6 +309,10 @@ func (gcp *GCP) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, er
 // "start" and "end" are dates of the format YYYY-MM-DD
 // "aggregator" is the tag used to determine how to allocate those assets, ie namespace, pod, etc.
 func (gcp *GCP) ExternalAllocations(start string, end string, aggregators []string, filterType string, filterValue string, crossCluster bool) ([]*OutOfClusterAllocation, error) {
+	if env.LegacyExternalCostsAPIDisabled() {
+		return nil, fmt.Errorf("Legacy External Allocations API disabled.")
+	}
+
 	c, err := gcp.Config.GetCustomPricingData()
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -993,7 +993,7 @@ func (gcp *GCP) DownloadPricingData() error {
 	for _, pv := range pvList {
 		params, ok := storageClassMap[pv.Spec.StorageClassName]
 		if !ok {
-			klog.Infof("Unable to find params for storageClassName %s", pv.Name)
+			log.DedupedWarningf(5, "Unable to find params for storageClassName %s", pv.Name)
 			continue
 		}
 		key := gcp.GetPVKey(pv, params, "")

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -314,7 +314,7 @@ func ClusterDisks(client prometheus.Client, provider cloud.Provider, duration, o
 
 		key := fmt.Sprintf("%s/%s", cluster, name)
 		if _, ok := diskMap[key]; !ok {
-			log.Warningf("ClusterDisks: active mins for unidentified disk")
+			log.DedupedWarningf(5, "ClusterDisks: active mins for unidentified disk")
 			continue
 		}
 
@@ -371,7 +371,7 @@ func ClusterDisks(client prometheus.Client, provider cloud.Provider, duration, o
 		disk.Breakdown.Idle = 1.0 - (disk.Breakdown.System + disk.Breakdown.Other + disk.Breakdown.User)
 
 		// Set provider Id to the name for reconciliation on Azure
-		if fmt.Sprintf("%T", provider) == "*provider.Azure"{
+		if fmt.Sprintf("%T", provider) == "*provider.Azure" {
 			if disk.ProviderID == "" {
 				disk.ProviderID = disk.Name
 			}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -599,15 +599,9 @@ func (cm *CostModel) ComputeCostData(cli prometheusClient.Client, cp costAnalyze
 					missingNodes[c.NodeName] = node
 				}
 			}
-			namespacelabels, ok := namespaceLabelsMapping[c.Namespace+","+c.ClusterID]
-			if !ok {
-				klog.V(3).Infof("Missing data for namespace %s", c.Namespace)
-			}
+			namespacelabels, _ := namespaceLabelsMapping[c.Namespace+","+c.ClusterID]
 
-			namespaceAnnotations, ok := namespaceAnnotationsMapping[c.Namespace+","+c.ClusterID]
-			if !ok {
-				klog.V(3).Infof("Missing data for namespace %s", c.Namespace)
-			}
+			namespaceAnnotations, _ := namespaceAnnotationsMapping[c.Namespace+","+c.ClusterID]
 
 			costs := &CostData{
 				Name:            c.ContainerName,
@@ -676,15 +670,9 @@ func findUnmountedPVCostData(clusterMap clusters.ClusterMap, unmountedPVs map[st
 
 		ns, _, clusterID := keyParts[0], keyParts[1], keyParts[2]
 
-		namespacelabels, ok := namespaceLabelsMapping[ns+","+clusterID]
-		if !ok {
-			klog.V(3).Infof("Missing data for namespace %s", ns)
-		}
+		namespacelabels, _ := namespaceLabelsMapping[ns+","+clusterID]
 
-		namespaceAnnotations, ok := namespaceAnnotationsMapping[ns+","+clusterID]
-		if !ok {
-			klog.V(3).Infof("Missing data for namespace %s", ns)
-		}
+		namespaceAnnotations, _ := namespaceAnnotationsMapping[ns+","+clusterID]
 
 		// Should be a unique "Unmounted" cost data type
 		name := "unmounted-pvs"
@@ -1917,10 +1905,7 @@ func (cm *CostModel) costDataRange(cli prometheusClient.Client, cp costAnalyzerC
 		nsKey := c.Namespace + "," + c.ClusterID
 		podKey := c.Namespace + "," + c.PodName + "," + c.ClusterID
 
-		namespaceLabels, ok := namespaceLabelsMapping[nsKey]
-		if !ok {
-			klog.V(4).Infof("Missing data for namespace %s", c.Namespace)
-		}
+		namespaceLabels, _ := namespaceLabelsMapping[nsKey]
 
 		pLabels := podLabels[podKey]
 		if pLabels == nil {
@@ -1933,10 +1918,7 @@ func (cm *CostModel) costDataRange(cli prometheusClient.Client, cp costAnalyzerC
 			}
 		}
 
-		namespaceAnnotations, ok := namespaceAnnotationsMapping[nsKey]
-		if !ok {
-			klog.V(4).Infof("Missing data for namespace %s", c.Namespace)
-		}
+		namespaceAnnotations, _ := namespaceAnnotationsMapping[nsKey]
 
 		pAnnotations := podAnnotations[podKey]
 		if pAnnotations == nil {

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -15,8 +15,8 @@ const (
 	AWSAccessKeySecretEnvVar = "AWS_SECRET_ACCESS_KEY"
 	AWSClusterIDEnvVar       = "AWS_CLUSTER_ID"
 
-	AzureStorageAccessKeyEnvVar = "AZURE_STORAGE_ACCESS_KEY"
-	AzureStorageAccountNameEnvVar = "AZURE_STORAGE_ACCOUNT"
+	AzureStorageAccessKeyEnvVar     = "AZURE_STORAGE_ACCESS_KEY"
+	AzureStorageAccountNameEnvVar   = "AZURE_STORAGE_ACCOUNT"
 	AzureStorageContainerNameEnvVar = "AZURE_STORAGE_CONTAINER"
 
 	KubecostNamespaceEnvVar        = "KUBECOST_NAMESPACE"
@@ -61,8 +61,9 @@ const (
 
 	UTCOffsetEnvVar = "UTC_OFFSET"
 
-	CacheWarmingEnabledEnvVar = "CACHE_WARMING_ENABLED"
-	ETLEnabledEnvVar          = "ETL_ENABLED"
+	CacheWarmingEnabledEnvVar    = "CACHE_WARMING_ENABLED"
+	ETLEnabledEnvVar             = "ETL_ENABLED"
+	LegacyExternalAPIDisabledVar = "LEGACY_EXTERNAL_API_DISABLED"
 )
 
 // GetAWSAccessKeyID returns the environment variable value for AWSAccessKeyIDEnvVar which represents
@@ -335,4 +336,8 @@ func IsCacheWarmingEnabled() bool {
 
 func IsETLEnabled() bool {
 	return GetBool(ETLEnabledEnvVar, true)
+}
+
+func LegacyExternalCostsAPIDisabled() bool {
+	return GetBool(LegacyExternalAPIDisabledVar, false)
 }


### PR DESCRIPTION
* None of the namespace log errors were really informational. It's totally reasonable to not have namespace level labels or annotations.
* A storageclass can not exist for a variety of reasons, so this data was not that relevant