### PR TITLE
fix panic on -1 index

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -644,7 +644,7 @@ func (gcp *GCP) parsePage(r io.Reader, inputKeys map[string]Key, pvKeys map[stri
 				if instanceType == "ssd" && !strings.Contains(product.Description, "Regional") { // TODO: support regional
 					lastRateIndex := len(product.PricingInfo[0].PricingExpression.TieredRates) - 1
 					var nanos float64
-					if len(product.PricingInfo) > 0 {
+					if lastRateIndex > -1 && len(product.PricingInfo) > 0 {
 						nanos = product.PricingInfo[0].PricingExpression.TieredRates[lastRateIndex].UnitPrice.Nanos
 					} else {
 						continue


### PR DESCRIPTION
This commit is fixing a panic when cost analyzer is fetching GCP pricing.