### PR TITLE
Fix recent changes to match Allocation type change

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -684,7 +684,6 @@ func (as *AllocationSet) AggregateBy(properties Properties, options *AllocationA
 				Start:      as.Start(),
 				End:        as.End(),
 				SharedCost: totalSharedCost,
-				TotalCost:  totalSharedCost,
 			})
 		}
 	}
@@ -831,7 +830,6 @@ func (as *AllocationSet) AggregateBy(properties Properties, options *AllocationA
 				alloc.CPUCost += idleCPUCost
 				alloc.GPUCost += idleGPUCost
 				alloc.RAMCost += idleRAMCost
-				alloc.TotalCost += idleCPUCost + idleGPUCost + idleRAMCost
 			}
 		}
 	}


### PR DESCRIPTION
## Changes
- We recently made `TotalCost` a function, but a PR made it in in the meantime that tries to use it as a field. This fixes that.

## Testing
- Didn't compile before. Now it compiles and passes unit tests.