### PR TITLE
Attempt to emit gpu count

### DIFF
--- a/PROMETHEUS.md
+++ b/PROMETHEUS.md
@@ -60,6 +60,7 @@ sum(node_total_hourly_cost) * 730
 | kubecost_load_balancer_cost   | Hourly cost of a load balancer                 |
 | kubecost_cluster_management_cost | Hourly management fee per cluster                 |
 | pv_hourly_cost   | Hourly cost per GP on a persistent volume                 |
+| node_gpu_count | Number of GPUs available on node |
 | container_cpu_allocation   | Average number of CPUs requested/used over last 1m                      |
 | container_gpu_allocation   | Average number of GPUs requested over last 1m                      |
 | container_memory_allocation_bytes   | Average bytes of RAM requested/used over last 1m                 |

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -67,8 +67,8 @@ var (
 )
 
 const AzureLayout = "2006-01-02"
-var HeaderStrings = []string{"MeterCategory", "UsageDateTime", "InstanceId", "AdditionalInfo", "Tags", "PreTaxCost", "SubscriptionGuid", "ConsumedService", "ResourceGroup", "ResourceType"}
 
+var HeaderStrings = []string{"MeterCategory", "UsageDateTime", "InstanceId", "AdditionalInfo", "Tags", "PreTaxCost", "SubscriptionGuid", "ConsumedService", "ResourceGroup", "ResourceType"}
 
 var loadedAzureSecret bool = false
 var azureSecret *AzureServiceKey = nil
@@ -221,6 +221,43 @@ func (k *azureKey) ID() string {
 	return ""
 }
 
+func (k *azureKey) GetGPUCount() string {
+	instance, _ := util.GetInstanceType(k.Labels)
+	// Double digits that could get matches lower in logic
+	if strings.Contains(instance, "NC64") {
+		return "4"
+	}
+	if strings.Contains(instance, "ND96") ||
+		strings.Contains(instance, "ND40") {
+		return "8"
+	}
+
+	// Ordered asc because of some series have different gpu counts on different versions
+	if strings.Contains(instance, "NC6") ||
+		strings.Contains(instance, "NC4") ||
+		strings.Contains(instance, "NC8") ||
+		strings.Contains(instance, "NC16") ||
+		strings.Contains(instance, "ND6") ||
+		strings.Contains(instance, "NV12s") ||
+		strings.Contains(instance, "NV6") {
+		return "1"
+	}
+
+	if strings.Contains(instance, "NC12") ||
+		strings.Contains(instance, "ND12") ||
+		strings.Contains(instance, "NV24s") ||
+		strings.Contains(instance, "NV12") {
+		return "2"
+	}
+	if strings.Contains(instance, "NC24") ||
+		strings.Contains(instance, "ND24") ||
+		strings.Contains(instance, "NV48s") ||
+		strings.Contains(instance, "NV24") {
+		return "4"
+	}
+	return "0"
+}
+
 // Represents an azure storage config
 type AzureStorageConfig struct {
 	AccountName   string `json:"azureStorageAccount"`
@@ -242,7 +279,6 @@ type AzureServiceKey struct {
 	SubscriptionID string       `json:"subscriptionId"`
 	ServiceKey     *AzureAppKey `json:"serviceKey"`
 }
-
 
 // Validity check on service key
 func (ask *AzureServiceKey) IsValid() bool {
@@ -701,7 +737,7 @@ func (az *Azure) NodePricing(key Key) (*Node, error) {
 	if n, ok := az.Pricing[key.Features()]; ok {
 		klog.V(4).Infof("Returning pricing for node %s: %+v from key %s", key, n, key.Features())
 		if key.GPUType() != "" {
-			n.Node.GPU = "1" // TODO: support multiple GPUs
+			n.Node.GPU = key.(*azureKey).GetGPUCount()
 		}
 		return n.Node, nil
 	}
@@ -715,7 +751,7 @@ func (az *Azure) NodePricing(key Key) (*Node, error) {
 			VCPUCost: c.CPU,
 			RAMCost:  c.RAM,
 			GPUCost:  c.GPU,
-			GPU:      "1", // TODO: support multiple GPUs
+			GPU: key.(*azureKey).GetGPUCount(),
 		}, nil
 	}
 	return &Node{
@@ -1040,7 +1076,6 @@ func makeValidJSON(jsonString string) string {
 	}
 	return fmt.Sprintf("{%v}", jsonString)
 }
-
 
 // UsageDateTime only contains date information and not time because of this filtering usageDate time is inclusive on start and exclusive on end
 func isValidUsageDateTime(start, end, usageDateTime time.Time) bool {

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -389,6 +389,7 @@ type Node struct {
 	CPUCost         float64
 	CPUCores        float64
 	GPUCost         float64
+	GPUCount        float64
 	RAMCost         float64
 	RAMBytes        float64
 	Discount        float64
@@ -449,7 +450,8 @@ func ClusterNodes(cp cloud.Provider, client prometheus.Client, duration, offset 
 	queryNodeCPUCores := fmt.Sprintf(`avg_over_time(avg(kube_node_status_capacity_cpu_cores) by (cluster_id, node)[%s:%dm]%s)`, durationStr, minsPerResolution, offsetStr)
 	queryNodeRAMCost := fmt.Sprintf(`sum_over_time((avg(kube_node_status_capacity_memory_bytes) by (cluster_id, node) * on(cluster_id, node) group_right avg(node_ram_hourly_cost) by (cluster_id, node, instance_type, provider_id))[%s:%dm]%s) / 1024 / 1024 / 1024 * %f`, durationStr, minsPerResolution, offsetStr, hourlyToCumulative)
 	queryNodeRAMBytes := fmt.Sprintf(`avg_over_time(avg(kube_node_status_capacity_memory_bytes) by (cluster_id, node)[%s:%dm]%s)`, durationStr, minsPerResolution, offsetStr)
-	queryNodeGPUCost := fmt.Sprintf(`sum_over_time((avg(node_gpu_hourly_cost * %d.0 / 60.0) by (cluster_id, node, provider_id))[%s:%dm]%s)`, minsPerResolution, durationStr, minsPerResolution, offsetStr)
+	queryNodeGPUCost := fmt.Sprintf(`sum_over_time((avg(node_gpu_count) by (cluster_id, node) * on(node, cluster_id) group_right avg(node_gpu_hourly_cost) by (cluster_id, node, instance_type, provider_id))[%s:%dm]%s) * %f`, durationStr, minsPerResolution, offsetStr, hourlyToCumulative)
+	queryNodeGPUCount := fmt.Sprintf(`avg_over_time(avg(node_gpu_count) by (cluster_id, node)[%s:%dm]%s)`, durationStr, minsPerResolution, offsetStr)
 	queryNodeCPUModeTotal := fmt.Sprintf(`sum(rate(node_cpu_seconds_total[%s:%dm]%s)) by (kubernetes_node, cluster_id, mode)`, durationStr, minsPerResolution, offsetStr)
 	queryNodeRAMSystemPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",namespace="kube-system"}[%s:%dm]%s)) by (instance, cluster_id) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes[%s:%dm]%s)) by (node, cluster_id), "instance", "$1", "node", "(.*)")) by (instance, cluster_id)`, durationStr, minsPerResolution, offsetStr, durationStr, minsPerResolution, offsetStr)
 	queryNodeRAMUserPct := fmt.Sprintf(`sum(sum_over_time(container_memory_working_set_bytes{container_name!="POD",container_name!="",namespace!="kube-system"}[%s:%dm]%s)) by (instance, cluster_id) / avg(label_replace(sum(sum_over_time(kube_node_status_capacity_memory_bytes[%s:%dm]%s)) by (node, cluster_id), "instance", "$1", "node", "(.*)")) by (instance, cluster_id)`, durationStr, minsPerResolution, offsetStr, durationStr, minsPerResolution, offsetStr)
@@ -463,6 +465,7 @@ func ClusterNodes(cp cloud.Provider, client prometheus.Client, duration, offset 
 	resChNodeRAMCost := requiredCtx.Query(queryNodeRAMCost)
 	resChNodeRAMBytes := requiredCtx.Query(queryNodeRAMBytes)
 	resChNodeGPUCost := requiredCtx.Query(queryNodeGPUCost)
+	resChNodeGPUCount := requiredCtx.Query(queryNodeGPUCount)
 	resChActiveMins := requiredCtx.Query(queryActiveMins)
 	resChIsSpot := requiredCtx.Query(queryIsSpot)
 
@@ -475,6 +478,7 @@ func ClusterNodes(cp cloud.Provider, client prometheus.Client, duration, offset 
 	resNodeCPUCost, _ := resChNodeCPUCost.Await()
 	resNodeCPUCores, _ := resChNodeCPUCores.Await()
 	resNodeGPUCost, _ := resChNodeGPUCost.Await()
+	resNodeGPUCount, _ := resChNodeGPUCount.Await()
 	resNodeRAMCost, _ := resChNodeRAMCost.Await()
 	resNodeRAMBytes, _ := resChNodeRAMBytes.Await()
 	resIsSpot, _ := resChIsSpot.Await()
@@ -506,6 +510,7 @@ func ClusterNodes(cp cloud.Provider, client prometheus.Client, duration, offset 
 
 	cpuCoresMap := buildCPUCoresMap(resNodeCPUCores, clusterAndNameToType)
 
+	gpuCountMap := buildGPUCountMap(resNodeGPUCount)
 	ramBytesMap := buildRAMBytesMap(resNodeRAMBytes)
 
 	ramUserPctMap := buildRAMUserPctMap(resNodeRAMUserPct)
@@ -518,7 +523,7 @@ func ClusterNodes(cp cloud.Provider, client prometheus.Client, duration, offset 
 
 	nodeMap := buildNodeMap(
 		cpuCostMap, ramCostMap, gpuCostMap,
-		cpuCoresMap, ramBytesMap, ramUserPctMap,
+		cpuCoresMap, ramBytesMap, ramUserPctMap, gpuCountMap,
 		ramSystemPctMap,
 		cpuBreakdownMap,
 		activeDataMap,

--- a/pkg/costmodel/cluster_helpers.go
+++ b/pkg/costmodel/cluster_helpers.go
@@ -158,7 +158,7 @@ func buildGPUCostMap(
 		clusterAndNameToType[keyNon] = nodeType
 
 		// If gpu count is available use it to multiply gpu cost
-		if value, ok := gpuCountMap[key]; ok {
+		if value, ok := gpuCountMap[key]; ok && value != 0 {
 			gpuCostMap[key] = gpuCost * value
 		} else {
 			gpuCostMap[key] = gpuCost

--- a/pkg/costmodel/cluster_helpers_test.go
+++ b/pkg/costmodel/cluster_helpers_test.go
@@ -133,6 +133,7 @@ func TestBuildNodeMap(t *testing.T) {
 		ramCostMap           map[NodeIdentifier]float64
 		gpuCostMap           map[NodeIdentifier]float64
 		cpuCoresMap          map[nodeIdentifierNoProviderID]float64
+		gpuCountMap          map[nodeIdentifierNoProviderID]float64
 		ramBytesMap          map[nodeIdentifierNoProviderID]float64
 		ramUserPctMap        map[nodeIdentifierNoProviderID]float64
 		ramSystemPctMap      map[nodeIdentifierNoProviderID]float64
@@ -318,6 +319,16 @@ func TestBuildNodeMap(t *testing.T) {
 					Name:    "node2",
 				}: 5.0,
 			},
+			gpuCountMap: map[nodeIdentifierNoProviderID]float64{
+				nodeIdentifierNoProviderID{
+					Cluster: "cluster1",
+					Name:    "node1",
+				}: 1.0,
+				nodeIdentifierNoProviderID{
+					Cluster: "cluster1",
+					Name:    "node2",
+				}: 2.0,
+			},
 			ramBytesMap: map[nodeIdentifierNoProviderID]float64{
 				nodeIdentifierNoProviderID{
 					Cluster: "cluster1",
@@ -450,6 +461,7 @@ func TestBuildNodeMap(t *testing.T) {
 					RAMCost:    0.09,
 					GPUCost:    0.8,
 					CPUCores:   2.0,
+					GPUCount: 1.0,
 					RAMBytes:   2048.0,
 					RAMBreakdown: &ClusterCostsBreakdown{
 						User:   30.0,
@@ -481,6 +493,7 @@ func TestBuildNodeMap(t *testing.T) {
 					RAMCost:    0.3,
 					GPUCost:    1.4,
 					CPUCores:   2.0,
+					GPUCount:   1.0,
 					RAMBytes:   2048.0,
 					RAMBreakdown: &ClusterCostsBreakdown{
 						User:   30.0,
@@ -512,6 +525,7 @@ func TestBuildNodeMap(t *testing.T) {
 					RAMCost:    0.024,
 					GPUCost:    3.1,
 					CPUCores:   5.0,
+					GPUCount:   2.0,
 					RAMBytes:   6303.0,
 					RAMBreakdown: &ClusterCostsBreakdown{
 						User:   42.6,
@@ -652,7 +666,7 @@ func TestBuildNodeMap(t *testing.T) {
 
 		result := buildNodeMap(
 			testCase.cpuCostMap, testCase.ramCostMap, testCase.gpuCostMap,
-			testCase.cpuCoresMap, testCase.ramBytesMap, testCase.ramUserPctMap,
+			testCase.cpuCoresMap, testCase.ramBytesMap, testCase.ramUserPctMap, testCase.gpuCountMap,
 			testCase.ramSystemPctMap,
 			testCase.cpuBreakdownMap,
 			testCase.activeDataMap,

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -580,7 +580,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 
 		gpuCountGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "node_gpu_count",
-			Help: "node_gpu_count hourly cost for each gpu on this node",
+			Help: "node_gpu_count count of gpu on this node",
 		}, []string{"instance", "node", "instance_type", "region", "provider_id"})
 
 		pvGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
Emit gpu count and use number to multiple gpu costs in cost model. Get accurate GPU count for Azure GPU nodes, previously hard coded to 1.

Testing:
The Emission was tested by the presence of the node_gpu_count value in prometheus.

Calculation of GPU cost should follow the formula node_gpu_count * node_gpu_hourly_cost * number_of_hours. To test this on AWS  nodes were given a fake type of p2.8xlarge, which has a node count of 8. Since the nodes with these fake types did not have GPUs before node_gpu_count and node_gpu_hourly_cost before they received the fake type the total gpu cost of one of these nodes should follow the above equations with the number_of_hours being equal to the amount of time they had the fake type. 8 * .793521 * ~57/60 =  ~6.03

![Screen Shot 2021-03-11 at 11 50 19 AM](https://user-images.githubusercontent.com/12225425/110847855-47ec3380-8262-11eb-8300-9987aa434729.png)
![Screen Shot 2021-03-11 at 11 50 10 AM](https://user-images.githubusercontent.com/12225425/110847858-4884ca00-8262-11eb-8059-ed609e61aeb1.png)
![Screen Shot 2021-03-11 at 12 04 17 PM](https://user-images.githubusercontent.com/12225425/110847688-14110e00-8262-11eb-9c1b-7272b102985c.png)

On Azure to validate the real GPU count being used I ran a NC12s. When I initialized it it showed 1 GPU in count and once the code was updated to GPU count for azure the node_gpu_count jumped to 2.

![Screen Shot 2021-03-11 at 11 24 19 AM](https://user-images.githubusercontent.com/12225425/110842834-7404b600-825c-11eb-8bae-c12ecf635fc0.png)
