### PR TITLE
Fix controller duplicate pruning

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -970,10 +970,12 @@ func getServiceLabels(resServiceLabels []*prom.QueryResult) map[serviceKey]map[s
 	// Prune duplicate services. That is, if the same service exists with
 	// hyphens instead of underscores, keep the one that uses hyphens.
 	for key := range serviceLabels {
-		duplicateService := strings.Replace(key.Service, "_", "-", -1)
-		duplicateKey := newServiceKey(key.Cluster, key.Namespace, duplicateService)
-		if _, ok := serviceLabels[duplicateKey]; ok {
-			delete(serviceLabels, key)
+		if strings.Contains(key.Service, "_") {
+			duplicateService := strings.Replace(key.Service, "_", "-", -1)
+			duplicateKey := newServiceKey(key.Cluster, key.Namespace, duplicateService)
+			if _, ok := serviceLabels[duplicateKey]; ok {
+				delete(serviceLabels, key)
+			}
 		}
 	}
 
@@ -1001,10 +1003,12 @@ func resToDeploymentLabels(resDeploymentLabels []*prom.QueryResult) map[controll
 	// Prune duplicate deployments. That is, if the same deployment exists with
 	// hyphens instead of underscores, keep the one that uses hyphens.
 	for key := range deploymentLabels {
-		duplicateController := strings.Replace(key.Controller, "_", "-", -1)
-		duplicateKey := newControllerKey(key.Cluster, key.Namespace, key.ControllerKind, duplicateController)
-		if _, ok := deploymentLabels[duplicateKey]; ok {
-			delete(deploymentLabels, key)
+		if strings.Contains(key.Controller, "_") {
+			duplicateController := strings.Replace(key.Controller, "_", "-", -1)
+			duplicateKey := newControllerKey(key.Cluster, key.Namespace, key.ControllerKind, duplicateController)
+			if _, ok := deploymentLabels[duplicateKey]; ok {
+				delete(deploymentLabels, key)
+			}
 		}
 	}
 
@@ -1032,10 +1036,12 @@ func resToStatefulSetLabels(resStatefulSetLabels []*prom.QueryResult) map[contro
 	// Prune duplicate stateful sets. That is, if the same stateful set exists
 	// with hyphens instead of underscores, keep the one that uses hyphens.
 	for key := range statefulSetLabels {
-		duplicateController := strings.Replace(key.Controller, "_", "-", -1)
-		duplicateKey := newControllerKey(key.Cluster, key.Namespace, key.ControllerKind, duplicateController)
-		if _, ok := statefulSetLabels[duplicateKey]; ok {
-			delete(statefulSetLabels, key)
+		if strings.Contains(key.Controller, "_") {
+			duplicateController := strings.Replace(key.Controller, "_", "-", -1)
+			duplicateKey := newControllerKey(key.Cluster, key.Namespace, key.ControllerKind, duplicateController)
+			if _, ok := statefulSetLabels[duplicateKey]; ok {
+				delete(statefulSetLabels, key)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Changes
- Fix duplicate pruning logic to only prune when underscores exist

## Testing
- Manual on gcp-niko

Before
![Screenshot from 2021-03-09 08-27-34](https://user-images.githubusercontent.com/8070055/110506121-0de12d00-80bc-11eb-990a-3dddb16d4117.png)

After
![Screenshot from 2021-03-09 09-44-45](https://user-images.githubusercontent.com/8070055/110506203-1df90c80-80bc-11eb-9b99-da3070703cb7.png)
