### PR TITLE
Add ETL resolution and max batch to status

### DIFF
--- a/pkg/kubecost/status.go
+++ b/pkg/kubecost/status.go
@@ -8,8 +8,8 @@ type ETLStatus struct {
 	LastRun     time.Time        `json:"lastRun"`
 	Progress    float64          `json:"progress"`
 	RefreshRate string           `json:"refreshRate"`
-	Resolution  time.Duration    `json:"resolution"`
-	MaxBatch    time.Duration    `json:"maxBatch"`
+	Resolution  string           `json:"resolution"`
+	MaxBatch    string           `json:"maxBatch"`
 	StartTime   time.Time        `json:"startTime"`
 	UTCOffset   string           `json:"utcOffset"`
 	Backup      *DirectoryStatus `json:"backup,omitempty"`

--- a/pkg/kubecost/status.go
+++ b/pkg/kubecost/status.go
@@ -8,6 +8,8 @@ type ETLStatus struct {
 	LastRun     time.Time        `json:"lastRun"`
 	Progress    float64          `json:"progress"`
 	RefreshRate string           `json:"refreshRate"`
+	Resolution  time.Duration    `json:"resolution"`
+	MaxBatch    time.Duration    `json:"maxBatch"`
 	StartTime   time.Time        `json:"startTime"`
 	UTCOffset   string           `json:"utcOffset"`
 	Backup      *DirectoryStatus `json:"backup,omitempty"`


### PR DESCRIPTION
Requires https://github.com/kubecost/kubecost-cost-model/pull/353

## Changes
- Add new ETL status fields

## Testing
- Manual on gcp-niko

![Screenshot from 2021-03-09 10-02-29](https://user-images.githubusercontent.com/8070055/110508784-9d87db00-80be-11eb-94ae-10a32821f81e.png)