### PR TITLE
Sean/aws lb recon

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -2286,6 +2286,5 @@ func (aws *AWS) ParseLBID(id string) string {
 		}
 		return id
 	}
-	log.Infof("awsprovider.ParseLBID: successful parse %s, %v", match[1], match)
 	return match[1]
 }

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -2276,3 +2276,16 @@ func (aws *AWS) ParsePVID(id string) string {
 
 	return match[1]
 }
+
+func (aws *AWS) ParseLBID(id string) string {
+	rx := regexp.MustCompile("^([^-]+)-.+$") // Capture "ad9d88195b52a47c89b5055120f28c58" from "ad9d88195b52a47c89b5055120f28c58-1037804914.us-east-2.elb.amazonaws.com"
+	match := rx.FindStringSubmatch(id)
+	if len(match) < 2 {
+		if id != "" {
+			log.Infof("awsprovider.ParseLBID: failed to parse %s, %v", id, match)
+		}
+		return id
+	}
+	log.Infof("awsprovider.ParseLBID: successful parse %s, %v", match[1], match)
+	return match[1]
+}

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -1149,3 +1149,7 @@ func (az *Azure) ParseID(id string) string {
 func (az *Azure) ParsePVID(id string) string {
 	return id
 }
+
+func (az *Azure) ParseLBID(id string) string {
+	return id
+}

--- a/pkg/cloud/csvprovider.go
+++ b/pkg/cloud/csvprovider.go
@@ -370,3 +370,7 @@ func (c *CSVProvider) ParseID(id string) string {
 func (c *CSVProvider) ParsePVID(id string) string {
 	return id
 }
+
+func (c *CSVProvider) ParseLBID(id string) string {
+	return id
+}

--- a/pkg/cloud/customprovider.go
+++ b/pkg/cloud/customprovider.go
@@ -319,3 +319,7 @@ func (cp *CustomProvider) ParseID(id string) string {
 func (cp *CustomProvider) ParsePVID(id string) string {
 	return id
 }
+
+func (cp *CustomProvider) ParseLBID(id string) string {
+	return id
+}

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -1482,3 +1482,7 @@ func (gcp *GCP) ParseID(id string) string {
 func (gcp *GCP) ParsePVID(id string) string {
 	return id
 }
+
+func (gcp *GCP) ParseLBID(id string) string {
+	return id
+}

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -240,6 +240,7 @@ type Provider interface {
 	CombinedDiscountForNode(string, bool, float64, float64) float64
 	ParseID(string) string
 	ParsePVID(string) string
+	ParseLBID(string) string
 }
 
 // ClusterName returns the name defined in cluster info, defaulting to the

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -587,8 +587,8 @@ func ClusterLoadBalancers(cp cloud.Provider, client prometheus.Client, duration,
 	hourlyToCumulative := float64(minsPerResolution) * (1.0 / 60.0)
 
 	ctx := prom.NewContext(client)
-	queryLBCost := fmt.Sprintf(`sum_over_time((avg(kubecost_load_balancer_cost) by (namespace, service_name, cluster_id))[%s:%dm]%s) * %f`, durationStr, minsPerResolution, offsetStr, hourlyToCumulative)
-	queryActiveMins := fmt.Sprintf(`count(kubecost_load_balancer_cost) by (namespace, service_name, cluster_id)[%s:%dm]%s`, durationStr, minsPerResolution, offsetStr)
+	queryLBCost := fmt.Sprintf(`sum_over_time((avg(kubecost_load_balancer_cost) by (namespace, service_name, cluster_id, ingress_ip))[%s:%dm]%s) * %f`, durationStr, minsPerResolution, offsetStr, hourlyToCumulative)
+	queryActiveMins := fmt.Sprintf(`count(kubecost_load_balancer_cost) by (namespace, service_name, cluster_id, ingress_ip)[%s:%dm]%s`, durationStr, minsPerResolution, offsetStr)
 
 	resChLBCost := ctx.Query(queryLBCost)
 	resChActiveMins := ctx.Query(queryActiveMins)
@@ -617,16 +617,26 @@ func ClusterLoadBalancers(cp cloud.Provider, client prometheus.Client, duration,
 			log.Warningf("ClusterLoadBalancers: LB cost data missing service_name")
 			continue
 		}
-		providerID := ""
+		providerID, err := result.GetString("ingress_ip")
+		if err != nil {
+			log.Warningf("ClusterLoadBalancers: LB cost data missing ingress_ip")
+			providerID = ""
+		} else {
+			providerID = cp.ParseLBID(providerID)
+		}
 		lbCost := result.Values[0].Value
+
 
 		key := fmt.Sprintf("%s/%s/%s", cluster, namespace, serviceName)
 		if _, ok := loadBalancerMap[key]; !ok {
 			loadBalancerMap[key] = &LoadBalancer{
 				Cluster:    cluster,
 				Name:       namespace + "/" + serviceName,
-				ProviderID: providerID, // cp.ParseID(providerID) if providerID does get recorded later
+				ProviderID: cp.ParseLBID(providerID),
 			}
+		}
+		if providerID != "" && loadBalancerMap[key].ProviderID == ""{
+			loadBalancerMap[key].ProviderID = providerID
 		}
 		loadBalancerMap[key].Cost += lbCost
 	}

--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -621,8 +621,6 @@ func ClusterLoadBalancers(cp cloud.Provider, client prometheus.Client, duration,
 		if err != nil {
 			log.Warningf("ClusterLoadBalancers: LB cost data missing ingress_ip")
 			providerID = ""
-		} else {
-			providerID = cp.ParseLBID(providerID)
 		}
 		lbCost := result.Values[0].Value
 
@@ -635,6 +633,8 @@ func ClusterLoadBalancers(cp cloud.Provider, client prometheus.Client, duration,
 				ProviderID: cp.ParseLBID(providerID),
 			}
 		}
+		// Fill in Provider ID if it is available and missing in the loadBalancerMap
+		// Prevents there from being a duplicate LoadBalancers on the same day
 		if providerID != "" && loadBalancerMap[key].ProviderID == ""{
 			loadBalancerMap[key].ProviderID = providerID
 		}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1227,6 +1227,7 @@ func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[string]*costA
 			newLoadBalancer := *loadBalancer
 			for _, loadBalancerIngress := range service.Status.LoadBalancer.Ingress {
 				address := loadBalancerIngress.IP
+				// Some cloud providers use hostname rather than IP
 				if address == "" {
 					address = loadBalancerIngress.Hostname
 				}

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -1226,7 +1226,12 @@ func (cm *CostModel) GetLBCost(cp costAnalyzerCloud.Provider) (map[string]*costA
 			}
 			newLoadBalancer := *loadBalancer
 			for _, loadBalancerIngress := range service.Status.LoadBalancer.Ingress {
-				newLoadBalancer.IngressIPAddresses = append(newLoadBalancer.IngressIPAddresses, loadBalancerIngress.IP)
+				address := loadBalancerIngress.IP
+				if address == "" {
+					address = loadBalancerIngress.Hostname
+				}
+				newLoadBalancer.IngressIPAddresses = append(newLoadBalancer.IngressIPAddresses, address)
+
 			}
 			loadBalancerMap[key] = &newLoadBalancer
 		}


### PR DESCRIPTION
Emit hostname of Load Balancer to Prometheus if IP address is missing and use that value to create a ProviderID in AWS for Load Balancers.

tested on EKS-Integration-Test which after changes began showing ingress-id in prometheus and a Provider ID for the Kubernetes service Load Balancer.

![Screen Shot 2021-03-16 at 5 43 24 PM](https://user-images.githubusercontent.com/12225425/111399006-ae69bb00-8681-11eb-9923-28672b1141f6.png)
![Screen Shot 2021-03-16 at 5 19 11 PM](https://user-images.githubusercontent.com/12225425/111399010-af9ae800-8681-11eb-8bd3-aba44c156a0b.png)

