### PR TITLE
Provide endpoint for non-aws csv storage with environment variable CSV_ENDPOINT

### DIFF
--- a/pkg/cloud/csvprovider.go
+++ b/pkg/cloud/csvprovider.go
@@ -69,6 +69,10 @@ func (c *CSVProvider) DownloadPricingData() error {
 	if strings.HasPrefix(c.CSVLocation, "s3://") {
 		region := env.GetCSVRegion()
 		conf := aws.NewConfig().WithRegion(region).WithCredentialsChainVerboseErrors(true)
+		endpoint := env.GetCSVEndpoint()
+		if endpoint != "" {
+			conf = conf.WithEndpoint(endpoint)
+		}
 		s3Client := s3.New(session.New(conf))
 		bucketAndKey := strings.Split(strings.TrimPrefix(c.CSVLocation, "s3://"), "/")
 		if len(bucketAndKey) == 2 {

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -30,6 +30,7 @@ const (
 	SQLAddressEnvVar               = "SQL_ADDRESS"
 	UseCSVProviderEnvVar           = "USE_CSV_PROVIDER"
 	CSVRegionEnvVar                = "CSV_REGION"
+	CSVEndpointEnvVar 			   = "CSV_ENDPOINT"
 	CSVPathEnvVar                  = "CSV_PATH"
 	ConfigPathEnvVar               = "CONFIG_PATH"
 	CloudProviderAPIKeyEnvVar      = "CLOUD_PROVIDER_API_KEY"
@@ -171,6 +172,12 @@ func IsUseCSVProvider() bool {
 // region configured for a CSV provider.
 func GetCSVRegion() string {
 	return Get(CSVRegionEnvVar, "")
+}
+
+// GetCSVEndpoint returns the environment variable value for CSVEndpointEnvVar which represents the
+// endpoint configured for a S3 CSV provider another than AWS S3.
+func GetCSVEndpoint() string {
+	return Get(CSVEndpointEnvVar, "")
 }
 
 // GetCSVPath returns the environment variable value for CSVPathEnvVar which represents the key path


### PR DESCRIPTION
We want to store csv-files on non-aws S3 storage (Google, Minio, etc.)
This PR introduces new environment variable CSV_ENDPOINT providing storage API endpoint other than Amazon.