### PR TITLE
Open source /allocation/compute

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -2182,9 +2182,9 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 		http.Error(w, fmt.Sprintf("Invalid 'window' parameter: %s", err), http.StatusBadRequest)
 	}
 
-	// Block is an optional parameter that defines the duration per-block, i.e.
+	// Step is an optional parameter that defines the duration per-set, i.e.
 	// the window for an AllocationSet, of the AllocationSetRange to be
-	// computed. Defaults to the window size, making one block.
+	// computed. Defaults to the window size, making one set.
 	step := qp.GetDuration("step", window.Duration())
 
 	// Resolution is an optional parameter, defaulting to the configured ETL

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1070,6 +1070,7 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) *Accesses {
 	a.Router.GET("/costDataModel", a.CostDataModel)
 	a.Router.GET("/costDataModelRange", a.CostDataModelRange)
 	a.Router.GET("/aggregatedCostModel", a.AggregateCostModelHandler)
+	a.Router.GET("/allocation/compute", a.ComputeAllocationHandler)
 	a.Router.GET("/outOfClusterCosts", a.OutOfClusterCostsWithCache)
 	a.Router.GET("/allNodePricing", a.GetAllNodePricing)
 	a.Router.POST("/refreshPricing", a.RefreshPricingData)

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -64,6 +64,7 @@ const (
 	CacheWarmingEnabledEnvVar    = "CACHE_WARMING_ENABLED"
 	ETLEnabledEnvVar             = "ETL_ENABLED"
 	ETLMaxBatchHours             = "ETL_MAX_BATCH_HOURS"
+	ETLResolutionSeconds         = "ETL_RESOLUTION_SECONDS"
 	LegacyExternalAPIDisabledVar = "LEGACY_EXTERNAL_API_DISABLED"
 )
 
@@ -347,6 +348,22 @@ func GetETLMaxBatchDuration() time.Duration {
 	// Default to 6h
 	hrs := time.Duration(GetInt64(ETLMaxBatchHours, 6))
 	return hrs * time.Hour
+}
+
+// GetETLResolution determines the resolution of ETL queries. The smaller the
+// duration, the higher the resolution; the higher the resolution, the more
+// accurate the query results, but the more computationally expensive. This
+// value is always 1m for Prometheus, but is configurable for Thanos.
+func GetETLResolution() time.Duration {
+	// If Thanos is not enabled, hard-code to 1m resolution
+	if !IsThanosEnabled() {
+		return 60 * time.Second
+	}
+
+	// Thanos is enabled, so use the configured ETL resolution, or default to
+	// 5m (i.e. 300s)
+	secs := time.Duration(GetInt64(ETLResolutionSeconds, 300))
+	return secs * time.Second
 }
 
 func LegacyExternalCostsAPIDisabled() bool {


### PR DESCRIPTION
Requires https://github.com/kubecost/kubecost-cost-model/pull/360

## Changes
- Move `/model/allocation/compute` to open source

## Testing
- Manual on gcp-niko