### PR TITLE
Add GPU count to Asset node type

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -1660,6 +1660,7 @@ type Node struct {
 	RAMBreakdown *Breakdown
 	CPUCost      float64
 	GPUCost      float64
+	GPUCount     float64
 	RAMCost      float64
 	Discount     float64
 	Preemptible  float64
@@ -1908,6 +1909,7 @@ func (n *Node) Clone() Asset {
 		RAMBreakdown: n.RAMBreakdown.Clone(),
 		CPUCost:      n.CPUCost,
 		GPUCost:      n.GPUCost,
+		GPUCount:      n.GPUCount,
 		RAMCost:      n.RAMCost,
 		Preemptible:  n.Preemptible,
 		Discount:     n.Discount,
@@ -1997,6 +1999,7 @@ func (n *Node) MarshalJSON() ([]byte, error) {
 	jsonEncodeFloat64(buffer, "discount", n.Discount, ",")
 	jsonEncodeFloat64(buffer, "cpuCost", n.CPUCost, ",")
 	jsonEncodeFloat64(buffer, "gpuCost", n.GPUCost, ",")
+	jsonEncodeFloat64(buffer, "gpuCount", n.GPUCount, ",")
 	jsonEncodeFloat64(buffer, "ramCost", n.RAMCost, ",")
 	jsonEncodeFloat64(buffer, "adjustment", n.Adjustment(), ",")
 	jsonEncodeFloat64(buffer, "totalCost", n.TotalCost(), "")


### PR DESCRIPTION
Added GPU to the Asset Node type that is used by the ETL so that the value is saved and distributed by Asset endpoint.
Tested on testspot azure cluster by querying for the node aks-testgpu-19213364-vmss000000 between 3/9/21 and 3/11/21.
During this time this node was running and had a GPU count of one.
<img width="927" alt="Screen Shot 2021-03-23 at 3 57 25 PM" src="https://user-images.githubusercontent.com/12225425/112229935-20498380-8bf1-11eb-8973-1d3a4f691c9a.png">
Twin PR:
https://github.com/kubecost/kubecost-cost-model/pull/363