### PR TITLE
Add CPU and RAM usage maximums to Allocation

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -714,7 +714,13 @@ func applyCPUCoresUsedMax(podMap map[podKey]*Pod, resCPUCoresUsedMax []*prom.Que
 			pod.AppendContainer(container)
 		}
 
-		pod.Allocations[container].CPUCoreUsageMax = res.Values[0].Value
+		if pod.Allocations[container].RawAllocationOnly == nil {
+			pod.Allocations[container].RawAllocationOnly = &kubecost.RawAllocationOnlyData{
+				CPUCoreUsageMax: res.Values[0].Value,
+			}
+		} else {
+			pod.Allocations[container].RawAllocationOnly.CPUCoreUsageMax = res.Values[0].Value
+		}
 	}
 }
 
@@ -844,7 +850,13 @@ func applyRAMBytesUsedMax(podMap map[podKey]*Pod, resRAMBytesUsedMax []*prom.Que
 			pod.AppendContainer(container)
 		}
 
-		pod.Allocations[container].RAMBytesUsageMax = res.Values[0].Value
+		if pod.Allocations[container].RawAllocationOnly == nil {
+			pod.Allocations[container].RawAllocationOnly = &kubecost.RawAllocationOnlyData{
+				RAMBytesUsageMax: res.Values[0].Value,
+			}
+		} else {
+			pod.Allocations[container].RawAllocationOnly.RAMBytesUsageMax = res.Values[0].Value
+		}
 	}
 }
 

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -17,13 +17,30 @@ import (
 )
 
 const (
-	queryFmtPods                  = `avg(kube_pod_container_status_running{}) by (pod, namespace, cluster_id)[%s:%s]%s`
-	queryFmtRAMBytesAllocated     = `avg(avg_over_time(container_memory_allocation_bytes{container!="", container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
-	queryFmtRAMRequests           = `avg(avg_over_time(kube_pod_container_resource_requests_memory_bytes{container!="", container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
-	queryFmtRAMUsage              = `avg(avg_over_time(container_memory_working_set_bytes{container_name!="", container_name!="POD", instance!=""}[%s]%s)) by (container_name, pod_name, namespace, instance, cluster_id)`
-	queryFmtCPUCoresAllocated     = `avg(avg_over_time(container_cpu_allocation{container!="", container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
-	queryFmtCPURequests           = `avg(avg_over_time(kube_pod_container_resource_requests_cpu_cores{container!="", container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
-	queryFmtCPUUsage              = `avg(rate(container_cpu_usage_seconds_total{container_name!="", container_name!="POD", instance!=""}[%s]%s)) by (container_name, pod_name, namespace, instance, cluster_id)`
+	queryFmtPods              = `avg(kube_pod_container_status_running{}) by (pod, namespace, cluster_id)[%s:%s]%s`
+	queryFmtRAMBytesAllocated = `avg(avg_over_time(container_memory_allocation_bytes{container!="", container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
+	queryFmtRAMRequests       = `avg(avg_over_time(kube_pod_container_resource_requests_memory_bytes{container!="", container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
+	queryFmtRAMUsageAvg       = `avg(avg_over_time(container_memory_working_set_bytes{container_name!="", container_name!="POD", instance!=""}[%s]%s)) by (container_name, pod_name, namespace, instance, cluster_id)`
+	queryFmtRAMUsageMax       = `max(max_over_time(container_memory_working_set_bytes{container_name!="", container_name!="POD", instance!=""}[%s]%s)) by (container_name, pod_name, namespace, instance, cluster_id)`
+	queryFmtCPUCoresAllocated = `avg(avg_over_time(container_cpu_allocation{container!="", container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
+	queryFmtCPURequests       = `avg(avg_over_time(kube_pod_container_resource_requests_cpu_cores{container!="", container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
+	queryFmtCPUUsageAvg       = `avg(rate(container_cpu_usage_seconds_total{container_name!="", container_name!="POD", instance!=""}[%s]%s)) by (container_name, pod_name, namespace, instance, cluster_id)`
+
+	// This query could be written without the recording rule
+	// "kubecost_savings_container_cpu_usage_seconds", but we should
+	// only do that when we're ready to incur the performance tradeoffs
+	// with subqueries which would probably be in the world of hourly
+	// ETL.
+	//
+	// See PromQL subquery documentation for a rate example:
+	// https://prometheus.io/blog/2019/01/28/subquery-support/#examples
+	queryFmtCPUUsageMax = `
+max(
+  max_over_time(
+    kubecost_savings_container_cpu_usage_seconds[%s]%s
+  )
+) by (container_name, pod_name, namespace, instance, cluster_id)`
+
 	queryFmtGPUsRequested         = `avg(avg_over_time(kube_pod_container_resource_requests{resource="nvidia_com_gpu", container!="",container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
 	queryFmtNodeCostPerCPUHr      = `avg(avg_over_time(node_cpu_hourly_cost[%s]%s)) by (node, cluster_id, instance_type)`
 	queryFmtNodeCostPerRAMGiBHr   = `avg(avg_over_time(node_ram_hourly_cost[%s]%s)) by (node, cluster_id, instance_type)`
@@ -107,8 +124,11 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time, resolution time.Dur
 	queryRAMRequests := fmt.Sprintf(queryFmtRAMRequests, durStr, offStr)
 	resChRAMRequests := ctx.Query(queryRAMRequests)
 
-	queryRAMUsage := fmt.Sprintf(queryFmtRAMUsage, durStr, offStr)
-	resChRAMUsage := ctx.Query(queryRAMUsage)
+	queryRAMUsageAvg := fmt.Sprintf(queryFmtRAMUsageAvg, durStr, offStr)
+	resChRAMUsageAvg := ctx.Query(queryRAMUsageAvg)
+
+	queryRAMUsageMax := fmt.Sprintf(queryFmtRAMUsageMax, durStr, offStr)
+	resChRAMUsageMax := ctx.Query(queryRAMUsageMax)
 
 	queryCPUCoresAllocated := fmt.Sprintf(queryFmtCPUCoresAllocated, durStr, offStr)
 	resChCPUCoresAllocated := ctx.Query(queryCPUCoresAllocated)
@@ -116,8 +136,11 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time, resolution time.Dur
 	queryCPURequests := fmt.Sprintf(queryFmtCPURequests, durStr, offStr)
 	resChCPURequests := ctx.Query(queryCPURequests)
 
-	queryCPUUsage := fmt.Sprintf(queryFmtCPUUsage, durStr, offStr)
-	resChCPUUsage := ctx.Query(queryCPUUsage)
+	queryCPUUsageAvg := fmt.Sprintf(queryFmtCPUUsageAvg, durStr, offStr)
+	resChCPUUsageAvg := ctx.Query(queryCPUUsageAvg)
+
+	queryCPUUsageMax := fmt.Sprintf(queryFmtCPUUsageMax, durStr, offStr)
+	resChCPUUsageMax := ctx.Query(queryCPUUsageMax)
 
 	queryGPUsRequested := fmt.Sprintf(queryFmtGPUsRequested, durStr, offStr)
 	resChGPUsRequested := ctx.Query(queryGPUsRequested)
@@ -202,10 +225,12 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time, resolution time.Dur
 
 	resCPUCoresAllocated, _ := resChCPUCoresAllocated.Await()
 	resCPURequests, _ := resChCPURequests.Await()
-	resCPUUsage, _ := resChCPUUsage.Await()
+	resCPUUsageAvg, _ := resChCPUUsageAvg.Await()
+	resCPUUsageMax, _ := resChCPUUsageMax.Await()
 	resRAMBytesAllocated, _ := resChRAMBytesAllocated.Await()
 	resRAMRequests, _ := resChRAMRequests.Await()
-	resRAMUsage, _ := resChRAMUsage.Await()
+	resRAMUsageAvg, _ := resChRAMUsageAvg.Await()
+	resRAMUsageMax, _ := resChRAMUsageMax.Await()
 	resGPUsRequested, _ := resChGPUsRequested.Await()
 
 	resNodeCostPerCPUHr, _ := resChNodeCostPerCPUHr.Await()
@@ -252,10 +277,12 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time, resolution time.Dur
 	// or equal to request.
 	applyCPUCoresAllocated(podMap, resCPUCoresAllocated)
 	applyCPUCoresRequested(podMap, resCPURequests)
-	applyCPUCoresUsed(podMap, resCPUUsage)
+	applyCPUCoresUsedAvg(podMap, resCPUUsageAvg)
+	applyCPUCoresUsedMax(podMap, resCPUUsageMax)
 	applyRAMBytesAllocated(podMap, resRAMBytesAllocated)
 	applyRAMBytesRequested(podMap, resRAMRequests)
-	applyRAMBytesUsed(podMap, resRAMUsage)
+	applyRAMBytesUsedAvg(podMap, resRAMUsageAvg)
+	applyRAMBytesUsedMax(podMap, resRAMUsageMax)
 	applyGPUsRequested(podMap, resGPUsRequested)
 	applyNetworkAllocation(podMap, resNetZoneGiB, resNetZoneCostPerGiB)
 	applyNetworkAllocation(podMap, resNetRegionGiB, resNetRegionCostPerGiB)
@@ -637,11 +664,11 @@ func applyCPUCoresRequested(podMap map[podKey]*Pod, resCPUCoresRequested []*prom
 	}
 }
 
-func applyCPUCoresUsed(podMap map[podKey]*Pod, resCPUCoresUsed []*prom.QueryResult) {
-	for _, res := range resCPUCoresUsed {
+func applyCPUCoresUsedAvg(podMap map[podKey]*Pod, resCPUCoresUsedAvg []*prom.QueryResult) {
+	for _, res := range resCPUCoresUsedAvg {
 		key, err := resultPodKey(res, "cluster_id", "namespace", "pod_name")
 		if err != nil {
-			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage avg result missing field: %s", err)
 			continue
 		}
 
@@ -652,7 +679,7 @@ func applyCPUCoresUsed(podMap map[podKey]*Pod, resCPUCoresUsed []*prom.QueryResu
 
 		container, err := res.GetString("container_name")
 		if err != nil {
-			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage query result missing 'container': %s", key)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage avg query result missing 'container': %s", key)
 			continue
 		}
 
@@ -661,6 +688,33 @@ func applyCPUCoresUsed(podMap map[podKey]*Pod, resCPUCoresUsed []*prom.QueryResu
 		}
 
 		pod.Allocations[container].CPUCoreUsageAverage = res.Values[0].Value
+	}
+}
+
+func applyCPUCoresUsedMax(podMap map[podKey]*Pod, resCPUCoresUsedMax []*prom.QueryResult) {
+	for _, res := range resCPUCoresUsedMax {
+		key, err := resultPodKey(res, "cluster_id", "namespace", "pod_name")
+		if err != nil {
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage max result missing field: %s", err)
+			continue
+		}
+
+		pod, ok := podMap[key]
+		if !ok {
+			continue
+		}
+
+		container, err := res.GetString("container_name")
+		if err != nil {
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: CPU usage max query result missing 'container': %s", key)
+			continue
+		}
+
+		if _, ok := pod.Allocations[container]; !ok {
+			pod.AppendContainer(container)
+		}
+
+		pod.Allocations[container].CPUCoreUsageMax = res.Values[0].Value
 	}
 }
 
@@ -740,11 +794,11 @@ func applyRAMBytesRequested(podMap map[podKey]*Pod, resRAMBytesRequested []*prom
 	}
 }
 
-func applyRAMBytesUsed(podMap map[podKey]*Pod, resRAMBytesUsed []*prom.QueryResult) {
-	for _, res := range resRAMBytesUsed {
+func applyRAMBytesUsedAvg(podMap map[podKey]*Pod, resRAMBytesUsedAvg []*prom.QueryResult) {
+	for _, res := range resRAMBytesUsedAvg {
 		key, err := resultPodKey(res, "cluster_id", "namespace", "pod_name")
 		if err != nil {
-			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM usage result missing field: %s", err)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM avg usage result missing field: %s", err)
 			continue
 		}
 
@@ -755,7 +809,7 @@ func applyRAMBytesUsed(podMap map[podKey]*Pod, resRAMBytesUsed []*prom.QueryResu
 
 		container, err := res.GetString("container_name")
 		if err != nil {
-			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM usage query result missing 'container': %s", key)
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM usage avg query result missing 'container': %s", key)
 			continue
 		}
 
@@ -764,6 +818,33 @@ func applyRAMBytesUsed(podMap map[podKey]*Pod, resRAMBytesUsed []*prom.QueryResu
 		}
 
 		pod.Allocations[container].RAMBytesUsageAverage = res.Values[0].Value
+	}
+}
+
+func applyRAMBytesUsedMax(podMap map[podKey]*Pod, resRAMBytesUsedMax []*prom.QueryResult) {
+	for _, res := range resRAMBytesUsedMax {
+		key, err := resultPodKey(res, "cluster_id", "namespace", "pod_name")
+		if err != nil {
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM usage max result missing field: %s", err)
+			continue
+		}
+
+		pod, ok := podMap[key]
+		if !ok {
+			continue
+		}
+
+		container, err := res.GetString("container_name")
+		if err != nil {
+			log.DedupedWarningf(10, "CostModel.ComputeAllocation: RAM usage max query result missing 'container': %s", key)
+			continue
+		}
+
+		if _, ok := pod.Allocations[container]; !ok {
+			pod.AppendContainer(container)
+		}
+
+		pod.Allocations[container].RAMBytesUsageMax = res.Values[0].Value
 	}
 }
 

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -34,13 +34,7 @@ const (
 	//
 	// See PromQL subquery documentation for a rate example:
 	// https://prometheus.io/blog/2019/01/28/subquery-support/#examples
-	queryFmtCPUUsageMax = `
-max(
-  max_over_time(
-    kubecost_savings_container_cpu_usage_seconds[%s]%s
-  )
-) by (container_name, pod_name, namespace, instance, cluster_id)`
-
+	queryFmtCPUUsageMax           = `max(max_over_time(kubecost_savings_container_cpu_usage_seconds[%s]%s)) by (container_name, pod_name, namespace, instance, cluster_id)`
 	queryFmtGPUsRequested         = `avg(avg_over_time(kube_pod_container_resource_requests{resource="nvidia_com_gpu", container!="",container!="POD", node!=""}[%s]%s)) by (container, pod, namespace, node, cluster_id)`
 	queryFmtNodeCostPerCPUHr      = `avg(avg_over_time(node_cpu_hourly_cost[%s]%s)) by (node, cluster_id, instance_type)`
 	queryFmtNodeCostPerRAMGiBHr   = `avg(avg_over_time(node_ram_hourly_cost[%s]%s)) by (node, cluster_id, instance_type)`

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -58,6 +58,7 @@ type Allocation struct {
 	CPUCoreHours           float64    `json:"cpuCoreHours"`
 	CPUCoreRequestAverage  float64    `json:"cpuCoreRequestAverage"`
 	CPUCoreUsageAverage    float64    `json:"cpuCoreUsageAverage"`
+	CPUCoreUsageMax        float64    `json:"cpuCoreUsageMax"`
 	CPUCost                float64    `json:"cpuCost"`
 	GPUHours               float64    `json:"gpuHours"`
 	GPUCost                float64    `json:"gpuCost"`
@@ -68,6 +69,7 @@ type Allocation struct {
 	RAMByteHours           float64    `json:"ramByteHours"`
 	RAMBytesRequestAverage float64    `json:"ramByteRequestAverage"`
 	RAMBytesUsageAverage   float64    `json:"ramByteUsageAverage"`
+	RAMBytesUsageMax       float64    `json:"ramByteUsageMax"`
 	RAMCost                float64    `json:"ramCost"`
 	SharedCost             float64    `json:"sharedCost"`
 	ExternalCost           float64    `json:"externalCost"`
@@ -111,6 +113,7 @@ func (a *Allocation) Clone() *Allocation {
 		CPUCoreHours:           a.CPUCoreHours,
 		CPUCoreRequestAverage:  a.CPUCoreRequestAverage,
 		CPUCoreUsageAverage:    a.CPUCoreUsageAverage,
+		CPUCoreUsageMax:        a.CPUCoreUsageMax,
 		CPUCost:                a.CPUCost,
 		GPUHours:               a.GPUHours,
 		GPUCost:                a.GPUCost,
@@ -121,6 +124,7 @@ func (a *Allocation) Clone() *Allocation {
 		RAMByteHours:           a.RAMByteHours,
 		RAMBytesRequestAverage: a.RAMBytesRequestAverage,
 		RAMBytesUsageAverage:   a.RAMBytesUsageAverage,
+		RAMBytesUsageMax:       a.RAMBytesUsageMax,
 		RAMCost:                a.RAMCost,
 		SharedCost:             a.SharedCost,
 		ExternalCost:           a.ExternalCost,
@@ -185,6 +189,12 @@ func (a *Allocation) Equal(that *Allocation) bool {
 		return false
 	}
 	if !util.IsApproximately(a.ExternalCost, that.ExternalCost) {
+		return false
+	}
+	if !util.IsApproximately(a.CPUCoreUsageMax, that.CPUCoreUsageMax) {
+		return false
+	}
+	if !util.IsApproximately(a.RAMBytesUsageMax, that.RAMBytesUsageMax) {
 		return false
 	}
 
@@ -274,6 +284,7 @@ func (a *Allocation) MarshalJSON() ([]byte, error) {
 	jsonEncodeFloat64(buffer, "cpuCores", a.CPUCores(), ",")
 	jsonEncodeFloat64(buffer, "cpuCoreRequestAverage", a.CPUCoreRequestAverage, ",")
 	jsonEncodeFloat64(buffer, "cpuCoreUsageAverage", a.CPUCoreUsageAverage, ",")
+	jsonEncodeFloat64(buffer, "cpuCoreUsageMax", a.CPUCoreUsageMax, ",")
 	jsonEncodeFloat64(buffer, "cpuCoreHours", a.CPUCoreHours, ",")
 	jsonEncodeFloat64(buffer, "cpuCost", a.CPUCost, ",")
 	jsonEncodeFloat64(buffer, "cpuEfficiency", a.CPUEfficiency(), ",")
@@ -288,6 +299,7 @@ func (a *Allocation) MarshalJSON() ([]byte, error) {
 	jsonEncodeFloat64(buffer, "ramByteRequestAverage", a.RAMBytesRequestAverage, ",")
 	jsonEncodeFloat64(buffer, "ramByteUsageAverage", a.RAMBytesUsageAverage, ",")
 	jsonEncodeFloat64(buffer, "ramByteHours", a.RAMByteHours, ",")
+	jsonEncodeFloat64(buffer, "ramByteUsageMax", a.RAMBytesUsageMax, ",")
 	jsonEncodeFloat64(buffer, "ramCost", a.RAMCost, ",")
 	jsonEncodeFloat64(buffer, "ramEfficiency", a.RAMEfficiency(), ",")
 	jsonEncodeFloat64(buffer, "sharedCost", a.SharedCost, ",")

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -3,6 +3,7 @@ package kubecost
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -79,10 +80,11 @@ type Allocation struct {
 // returning true for any given Allocation if a condition is met.
 type AllocationMatchFunc func(*Allocation) bool
 
-// Add returns the result of summing the two given Allocations, which sums the
-// summary fields (e.g. costs, resources) and recomputes efficiency. Neither of
-// the two original Allocations are mutated in the process.
-func (a *Allocation) Add(that *Allocation) (*Allocation, error) {
+// AddAccumulate returns the result of combining the two given Allocations,
+// under the assumption that they refer to the same resource. Costs (and
+// similar fields) are summed, usage maximums are MAXED, and efficiency is
+// recomputed. Neither of the original Allocations are mutated.
+func (a *Allocation) AddAccumulate(that *Allocation) (*Allocation, error) {
 	if a == nil {
 		return that.Clone(), nil
 	}
@@ -93,7 +95,33 @@ func (a *Allocation) Add(that *Allocation) (*Allocation, error) {
 
 	// Note: no need to clone "that", as add only mutates the receiver
 	agg := a.Clone()
-	agg.add(that)
+	agg.add(that, accumulation)
+
+	return agg, nil
+}
+
+// AddAggregate returns the result of combining the two given Allocations,
+// under the assumption that they refer to different resources. The intended
+// usage is e.g. "aggregate containers by namespace" where the resulting
+// allocation ultimately refers to a greater number of resources than either
+// of the original Allocations. Most fields, including usage maximums, are
+// summed. Neither of the original allocations are mutated.
+//
+// To explain why usage maximums are summed, consider using this method for
+// aggregating by pod. The maximum CPU usage of a pod can be roughly equated
+// to the sum of the maximum CPU usages of its containers.
+func (a *Allocation) AddAggregate(that *Allocation) (*Allocation, error) {
+	if a == nil {
+		return that.Clone(), nil
+	}
+
+	if that == nil {
+		return a.Clone(), nil
+	}
+
+	// Note: no need to clone "that", as add only mutates the receiver
+	agg := a.Clone()
+	agg.add(that, aggregation)
 
 	return agg, nil
 }
@@ -365,7 +393,21 @@ func (a *Allocation) String() string {
 	return fmt.Sprintf("%s%s=%.2f", a.Name, NewWindow(&a.Start, &a.End), a.TotalCost())
 }
 
-func (a *Allocation) add(that *Allocation) {
+// allocationCombinationType is an enum-like value for
+// flagging what mode an operation that combines allocations,
+// like add(), should operate in.
+//
+// Intentionally unexported - it should only be used by internal
+// methods. Exported methods should have a different variant,
+// like AddAccumulate and AddAggregate, for API clarity.
+type allocationCombinationType int
+
+const (
+	accumulation allocationCombinationType = iota
+	aggregation
+)
+
+func (a *Allocation) add(that *Allocation, addType allocationCombinationType) {
 	if a == nil {
 		log.Warningf("Allocation.AggregateBy: trying to add a nil receiver")
 		return
@@ -447,6 +489,19 @@ func (a *Allocation) add(that *Allocation) {
 	a.LoadBalancerCost += that.LoadBalancerCost
 	a.SharedCost += that.SharedCost
 	a.ExternalCost += that.ExternalCost
+
+	if addType == accumulation {
+		// Accumulation-type additions imply same resource, so the overall
+		// maximum is the correct resulting value.
+		a.CPUCoreUsageMax = math.Max(a.CPUCoreUsageMax, that.CPUCoreUsageMax)
+		a.RAMBytesUsageMax = math.Max(a.RAMBytesUsageMax, that.RAMBytesUsageMax)
+	} else if addType == aggregation {
+		// Aggregation-type additions imply different resources, same
+		// aggregation group, so the correct maximum is actually the sum
+		// of maxima.
+		a.CPUCoreUsageMax += that.CPUCoreUsageMax
+		a.RAMBytesUsageMax += that.RAMBytesUsageMax
+	}
 }
 
 // AllocationSet stores a set of Allocations, each with a unique name, that share
@@ -472,7 +527,7 @@ func NewAllocationSet(start, end time.Time, allocs ...*Allocation) *AllocationSe
 	}
 
 	for _, a := range allocs {
-		as.Insert(a)
+		as.InsertAccumulate(a)
 	}
 
 	return as
@@ -567,7 +622,7 @@ func (as *AllocationSet) AggregateBy(properties Properties, options *AllocationA
 		if alloc.IsExternal() {
 			delete(as.externalKeys, alloc.Name)
 			delete(as.allocations, alloc.Name)
-			externalSet.Insert(alloc)
+			externalSet.InsertAggregate(alloc)
 			continue
 		}
 
@@ -579,9 +634,9 @@ func (as *AllocationSet) AggregateBy(properties Properties, options *AllocationA
 			delete(as.allocations, alloc.Name)
 
 			if options.ShareIdle == ShareEven || options.ShareIdle == ShareWeighted {
-				idleSet.Insert(alloc)
+				idleSet.InsertAggregate(alloc)
 			} else {
-				aggSet.Insert(alloc)
+				aggSet.InsertAggregate(alloc)
 			}
 
 			continue
@@ -594,7 +649,7 @@ func (as *AllocationSet) AggregateBy(properties Properties, options *AllocationA
 			if sf(alloc) {
 				delete(as.idleKeys, alloc.Name)
 				delete(as.allocations, alloc.Name)
-				shareSet.Insert(alloc)
+				shareSet.InsertAggregate(alloc)
 				break
 			}
 		}
@@ -698,7 +753,7 @@ func (as *AllocationSet) AggregateBy(properties Properties, options *AllocationA
 
 			totalSharedCost := cost * hours
 
-			shareSet.Insert(&Allocation{
+			shareSet.InsertAggregate(&Allocation{
 				Name:       fmt.Sprintf("%s/%s", name, SharedSuffix),
 				Start:      as.Start(),
 				End:        as.End(),
@@ -800,7 +855,7 @@ func (as *AllocationSet) AggregateBy(properties Properties, options *AllocationA
 
 		// Inserting the allocation with the generated key for a name will
 		// perform the actual basic aggregation step.
-		aggSet.Insert(alloc)
+		aggSet.InsertAggregate(alloc)
 	}
 
 	// (6) If idle is shared and resources are shared, it's possible that some
@@ -927,7 +982,7 @@ func (as *AllocationSet) AggregateBy(properties Properties, options *AllocationA
 			key := alloc.generateKey(properties)
 
 			alloc.Name = key
-			aggSet.Insert(alloc)
+			aggSet.InsertAggregate(alloc)
 		}
 	}
 
@@ -936,7 +991,7 @@ func (as *AllocationSet) AggregateBy(properties Properties, options *AllocationA
 		for _, idleAlloc := range aggSet.IdleAllocations() {
 			aggSet.Delete(idleAlloc.Name)
 			idleAlloc.Name = IdleSuffix
-			aggSet.Insert(idleAlloc)
+			aggSet.InsertAggregate(idleAlloc)
 		}
 	}
 
@@ -1562,14 +1617,35 @@ func (as *AllocationSet) IdleAllocations() map[string]*Allocation {
 	return idles
 }
 
-// Insert aggregates the current entry in the AllocationSet by the given Allocation,
-// but only if the Allocation is valid, i.e. matches the AllocationSet's window. If
-// there is no existing entry, one is created. Nil error response indicates success.
-func (as *AllocationSet) Insert(that *Allocation) error {
-	return as.insert(that)
+// InsertAggregate aggregates the current entry in the AllocationSet by the given
+// Allocation, but only if the Allocation is valid, i.e. matches the AllocationSet's
+// window.
+// If there is no existing entry, one is created.
+// If there is an existing entry, the given Allocation is added to it using
+// aggregation logic, see Allocation.AddAggregate() for an explanation.
+// Nil error response indicates success.
+//
+// A good heuristic for whether you should use this method is:
+// Are you generating a new, less-specific key for a new Allocation from multiple
+// more specific Allocations?
+func (as *AllocationSet) InsertAggregate(that *Allocation) error {
+	return as.insert(that, aggregation)
 }
 
-func (as *AllocationSet) insert(that *Allocation) error {
+// InsertAccumulate aggregates the current entry in the AllocationSet by the given
+// Allocation, but only if the Allocation is valid, i.e. matches the AllocationSet's
+// window.
+// If there is no existing entry, one is created.
+// If there is an existing entry, the given Allocation is added to it using
+// accumulation logic, see Allocation.AddAccumulate() for an explanation.
+// Nil error response indicates success.
+//
+// If you don't know which insert to use, this is a safe default.
+func (as *AllocationSet) InsertAccumulate(that *Allocation) error {
+	return as.insert(that, accumulation)
+}
+
+func (as *AllocationSet) insert(that *Allocation, combType allocationCombinationType) error {
 	if as == nil {
 		return fmt.Errorf("cannot insert into nil AllocationSet")
 	}
@@ -1594,7 +1670,7 @@ func (as *AllocationSet) insert(that *Allocation) error {
 	if _, ok := as.allocations[that.Name]; !ok {
 		as.allocations[that.Name] = that
 	} else {
-		as.allocations[that.Name].add(that)
+		as.allocations[that.Name].add(that, combType)
 	}
 
 	// If the given Allocation is an external one, record that
@@ -1755,14 +1831,14 @@ func (as *AllocationSet) accumulate(that *AllocationSet) (*AllocationSet, error)
 	defer that.RUnlock()
 
 	for _, alloc := range as.allocations {
-		err := acc.insert(alloc)
+		err := acc.insert(alloc, accumulation)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	for _, alloc := range that.allocations {
-		err := acc.insert(alloc)
+		err := acc.insert(alloc, accumulation)
 		if err != nil {
 			return nil, err
 		}
@@ -1906,7 +1982,7 @@ func (asr *AllocationSetRange) InsertRange(that *AllocationSetRange) error {
 
 		// Insert each Allocation from the given set
 		thatAS.Each(func(k string, alloc *Allocation) {
-			err = as.Insert(alloc)
+			err = as.InsertAccumulate(alloc)
 			if err != nil {
 				err = fmt.Errorf("error inserting allocation: %s", err)
 				return

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -52,6 +52,10 @@ func NewUnitAllocation(name string, start time.Time, resolution time.Duration, p
 		RAMCost:                1,
 		RAMBytesRequestAverage: 1,
 		RAMBytesUsageAverage:   1,
+		RawAllocationOnly: &RawAllocationOnlyData{
+			CPUCoreUsageMax:  1,
+			RAMBytesUsageMax: 1,
+		},
 	}
 
 	// If idle allocation, remove non-idle costs, but maintain total cost
@@ -117,6 +121,7 @@ func TestAllocation_Add(t *testing.T) {
 		RAMCost:                8.0 * hrs1 * ramPrice,
 		SharedCost:             2.00,
 		ExternalCost:           1.00,
+		RawAllocationOnly:      &RawAllocationOnlyData{},
 	}
 	a1b := a1.Clone()
 
@@ -142,6 +147,7 @@ func TestAllocation_Add(t *testing.T) {
 		LoadBalancerCost:       0.05,
 		SharedCost:             0.00,
 		ExternalCost:           1.00,
+		RawAllocationOnly:      &RawAllocationOnlyData{},
 	}
 	a2b := a2.Clone()
 
@@ -236,6 +242,10 @@ func TestAllocation_Add(t *testing.T) {
 	}
 	if !util.IsApproximately(1.6493506, act.TotalEfficiency()) {
 		t.Fatalf("Allocation.Add: expected %f; actual %f", 1.6493506, act.TotalEfficiency())
+	}
+
+	if act.RawAllocationOnly != nil {
+		t.Errorf("Allocation.Add: Raw only data must be nil after an add")
 	}
 }
 
@@ -423,6 +433,7 @@ func TestAllocation_MarshalJSON(t *testing.T) {
 		RAMCost:                8.0 * hrs * ramPrice,
 		SharedCost:             2.00,
 		ExternalCost:           1.00,
+		RawAllocationOnly:      &RawAllocationOnlyData{},
 	}
 
 	data, err := json.Marshal(before)

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -69,59 +69,12 @@ func NewUnitAllocation(name string, start time.Time, resolution time.Duration, p
 	return alloc
 }
 
-// Because it is the standard case, the test for AddAccumulate is expected
-// to test all Add behavior except for Aggregate-specific behavior. This test
-// can therefore be somewhat minimal.
-func TestAllocation_AddAggregate(t *testing.T) {
-	s1 := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)
-	e1 := time.Date(2021, time.January, 1, 12, 0, 0, 0, time.UTC)
-	gib := 1024.0 * 1024.0 * 1024.0
-	a1 := &Allocation{
-		Start:            s1,
-		End:              e1,
-		CPUCoreUsageMax:  3.1,
-		RAMBytesUsageMax: 5.0 * gib,
-	}
-	a1b := a1.Clone()
-
-	s2 := time.Date(2021, time.January, 1, 6, 0, 0, 0, time.UTC)
-	e2 := time.Date(2021, time.January, 1, 24, 0, 0, 0, time.UTC)
-	a2 := &Allocation{
-		Start:            s2,
-		End:              e2,
-		CPUCoreUsageMax:  1.2,
-		RAMBytesUsageMax: 10.0 * gib,
-	}
-	a2b := a2.Clone()
-
-	act, err := a1.AddAggregate(a2)
-	if err != nil {
-		t.Fatalf("Allocation.AddAggregate: unexpected error: %s", err)
-	}
-
-	// Neither Allocation should be mutated
-	if !a1.Equal(a1b) {
-		t.Fatalf("Allocation.AddAccumulate: a1 illegally mutated")
-	}
-	if !a2.Equal(a2b) {
-		t.Fatalf("Allocation.AddAccumulate: a1 illegally mutated")
-	}
-
-	// Usage maximums should be added in the aggregate case
-	if !util.IsApproximately(3.1+1.2, act.CPUCoreUsageMax) {
-		t.Errorf("Allocation.AddAggregate: CPUCoreUsageMax: expected %f; actual %f", 3.1+1.2, act.CPUCoreUsageMax)
-	}
-	if !util.IsApproximately(10.0*gib+5.0*gib, act.RAMBytesUsageMax) {
-		t.Errorf("Allocation.AddAggregate: RAMBytesUsageMax: expected %f; actual %f", 10.0*gib+5.0*gib, act.RAMBytesUsageMax)
-	}
-}
-
-func TestAllocation_AddAccumulate(t *testing.T) {
+func TestAllocation_Add(t *testing.T) {
 	var nilAlloc *Allocation
 	zeroAlloc := &Allocation{}
 
 	// nil + nil == nil
-	nilNilSum, err := nilAlloc.AddAccumulate(nilAlloc)
+	nilNilSum, err := nilAlloc.Add(nilAlloc)
 	if err != nil {
 		t.Fatalf("Allocation.Add unexpected error: %s", err)
 	}
@@ -130,7 +83,7 @@ func TestAllocation_AddAccumulate(t *testing.T) {
 	}
 
 	// nil + zero == zero
-	nilZeroSum, err := nilAlloc.AddAccumulate(zeroAlloc)
+	nilZeroSum, err := nilAlloc.Add(zeroAlloc)
 	if err != nil {
 		t.Fatalf("Allocation.Add unexpected error: %s", err)
 	}
@@ -153,7 +106,6 @@ func TestAllocation_AddAccumulate(t *testing.T) {
 		CPUCoreHours:           2.0 * hrs1,
 		CPUCoreRequestAverage:  2.0,
 		CPUCoreUsageAverage:    1.0,
-		CPUCoreUsageMax:        3.1,
 		CPUCost:                2.0 * hrs1 * cpuPrice,
 		GPUHours:               1.0 * hrs1,
 		GPUCost:                1.0 * hrs1 * gpuPrice,
@@ -162,7 +114,6 @@ func TestAllocation_AddAccumulate(t *testing.T) {
 		RAMByteHours:           8.0 * gib * hrs1,
 		RAMBytesRequestAverage: 8.0 * gib,
 		RAMBytesUsageAverage:   4.0 * gib,
-		RAMBytesUsageMax:       5.0 * gib,
 		RAMCost:                8.0 * hrs1 * ramPrice,
 		SharedCost:             2.00,
 		ExternalCost:           1.00,
@@ -178,7 +129,6 @@ func TestAllocation_AddAccumulate(t *testing.T) {
 		CPUCoreHours:           1.0 * hrs2,
 		CPUCoreRequestAverage:  1.0,
 		CPUCoreUsageAverage:    1.0,
-		CPUCoreUsageMax:        1.2,
 		CPUCost:                1.0 * hrs2 * cpuPrice,
 		GPUHours:               0.0,
 		GPUCost:                0.0,
@@ -187,7 +137,6 @@ func TestAllocation_AddAccumulate(t *testing.T) {
 		RAMByteHours:           8.0 * gib * hrs2,
 		RAMBytesRequestAverage: 0.0,
 		RAMBytesUsageAverage:   8.0 * gib,
-		RAMBytesUsageMax:       10.0 * gib,
 		RAMCost:                8.0 * hrs2 * ramPrice,
 		NetworkCost:            0.01,
 		LoadBalancerCost:       0.05,
@@ -196,65 +145,65 @@ func TestAllocation_AddAccumulate(t *testing.T) {
 	}
 	a2b := a2.Clone()
 
-	act, err := a1.AddAccumulate(a2)
+	act, err := a1.Add(a2)
 	if err != nil {
-		t.Fatalf("Allocation.AddAccumulate: unexpected error: %s", err)
+		t.Fatalf("Allocation.Add: unexpected error: %s", err)
 	}
 
 	// Neither Allocation should be mutated
 	if !a1.Equal(a1b) {
-		t.Fatalf("Allocation.AddAccumulate: a1 illegally mutated")
+		t.Fatalf("Allocation.Add: a1 illegally mutated")
 	}
 	if !a2.Equal(a2b) {
-		t.Fatalf("Allocation.AddAccumulate: a1 illegally mutated")
+		t.Fatalf("Allocation.Add: a1 illegally mutated")
 	}
 
 	// Costs should be cumulative
 	if !util.IsApproximately(a1.TotalCost()+a2.TotalCost(), act.TotalCost()) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.TotalCost()+a2.TotalCost(), act.TotalCost())
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.TotalCost()+a2.TotalCost(), act.TotalCost())
 	}
 	if !util.IsApproximately(a1.CPUCost+a2.CPUCost, act.CPUCost) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.CPUCost+a2.CPUCost, act.CPUCost)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.CPUCost+a2.CPUCost, act.CPUCost)
 	}
 	if !util.IsApproximately(a1.GPUCost+a2.GPUCost, act.GPUCost) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.GPUCost+a2.GPUCost, act.GPUCost)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.GPUCost+a2.GPUCost, act.GPUCost)
 	}
 	if !util.IsApproximately(a1.RAMCost+a2.RAMCost, act.RAMCost) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.RAMCost+a2.RAMCost, act.RAMCost)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.RAMCost+a2.RAMCost, act.RAMCost)
 	}
 	if !util.IsApproximately(a1.PVCost+a2.PVCost, act.PVCost) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.PVCost+a2.PVCost, act.PVCost)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.PVCost+a2.PVCost, act.PVCost)
 	}
 	if !util.IsApproximately(a1.NetworkCost+a2.NetworkCost, act.NetworkCost) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.NetworkCost+a2.NetworkCost, act.NetworkCost)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.NetworkCost+a2.NetworkCost, act.NetworkCost)
 	}
 	if !util.IsApproximately(a1.LoadBalancerCost+a2.LoadBalancerCost, act.LoadBalancerCost) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.LoadBalancerCost+a2.LoadBalancerCost, act.LoadBalancerCost)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.LoadBalancerCost+a2.LoadBalancerCost, act.LoadBalancerCost)
 	}
 	if !util.IsApproximately(a1.SharedCost+a2.SharedCost, act.SharedCost) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.SharedCost+a2.SharedCost, act.SharedCost)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.SharedCost+a2.SharedCost, act.SharedCost)
 	}
 	if !util.IsApproximately(a1.ExternalCost+a2.ExternalCost, act.ExternalCost) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.ExternalCost+a2.ExternalCost, act.ExternalCost)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.ExternalCost+a2.ExternalCost, act.ExternalCost)
 	}
 
 	// ResourceHours should be cumulative
 	if !util.IsApproximately(a1.CPUCoreHours+a2.CPUCoreHours, act.CPUCoreHours) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.CPUCoreHours+a2.CPUCoreHours, act.CPUCoreHours)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.CPUCoreHours+a2.CPUCoreHours, act.CPUCoreHours)
 	}
 	if !util.IsApproximately(a1.RAMByteHours+a2.RAMByteHours, act.RAMByteHours) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.RAMByteHours+a2.RAMByteHours, act.RAMByteHours)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.RAMByteHours+a2.RAMByteHours, act.RAMByteHours)
 	}
 	if !util.IsApproximately(a1.PVByteHours+a2.PVByteHours, act.PVByteHours) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", a1.PVByteHours+a2.PVByteHours, act.PVByteHours)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.PVByteHours+a2.PVByteHours, act.PVByteHours)
 	}
 
 	// Minutes should be the duration between min(starts) and max(ends)
 	if !act.Start.Equal(a1.Start) || !act.End.Equal(a2.End) {
-		t.Fatalf("Allocation.AddAccumulate: expected %s; actual %s", NewWindow(&a1.Start, &a2.End), NewWindow(&act.Start, &act.End))
+		t.Fatalf("Allocation.Add: expected %s; actual %s", NewWindow(&a1.Start, &a2.End), NewWindow(&act.Start, &act.End))
 	}
 	if act.Minutes() != 1440.0 {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", 1440.0, act.Minutes())
+		t.Fatalf("Allocation.Add: expected %f; actual %f", 1440.0, act.Minutes())
 	}
 
 	// Requests and Usage should be averaged correctly
@@ -263,24 +212,16 @@ func TestAllocation_AddAccumulate(t *testing.T) {
 	// RAM requests = (8.0*12.0 + 0.0*18.0)/(24.0) = 4.00
 	// RAM usage = (4.0*12.0 + 8.0*18.0)/(24.0) = 8.00
 	if !util.IsApproximately(1.75, act.CPUCoreRequestAverage) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", 1.75, act.CPUCoreRequestAverage)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", 1.75, act.CPUCoreRequestAverage)
 	}
 	if !util.IsApproximately(1.25, act.CPUCoreUsageAverage) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", 1.25, act.CPUCoreUsageAverage)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", 1.25, act.CPUCoreUsageAverage)
 	}
 	if !util.IsApproximately(4.00*gib, act.RAMBytesRequestAverage) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", 4.00*gib, act.RAMBytesRequestAverage)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", 4.00*gib, act.RAMBytesRequestAverage)
 	}
 	if !util.IsApproximately(8.00*gib, act.RAMBytesUsageAverage) {
-		t.Fatalf("Allocation.AddAccumulate: expected %f; actual %f", 8.00*gib, act.RAMBytesUsageAverage)
-	}
-
-	// Usage maximums should be maxed in the accumulate case
-	if !util.IsApproximately(3.1, act.CPUCoreUsageMax) {
-		t.Errorf("Allocation.AddAccumulate: CPUCoreUsageMax: expected %f; actual %f", 3.1, act.CPUCoreUsageMax)
-	}
-	if !util.IsApproximately(10.0*gib, act.RAMBytesUsageMax) {
-		t.Errorf("Allocation.AddAccumulate: RAMBytesUsageMax: expected %f; actual %f", 10.0*gib, act.RAMBytesUsageMax)
+		t.Fatalf("Allocation.Add: expected %f; actual %f", 8.00*gib, act.RAMBytesUsageAverage)
 	}
 
 	// Efficiency should be computed accurately from new request/usage

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -20,5 +20,6 @@ package kubecost
 // @bingen:generate:Allocation
 // @bingen:generate:AllocationSet
 // @bingen:generate:AllocationSetRange
+// @bingen:generate:RawAllocationOnlyData
 
-//go:generate bingen -package=kubecost -version=9 -buffer=github.com/kubecost/cost-model/pkg/util
+//go:generate bingen -package=kubecost -version=10 -buffer=github.com/kubecost/cost-model/pkg/util


### PR DESCRIPTION
This PR adds CPU and RAM usage maximums to the `Allocation` type for eventual usage by a new version of Savings's request right-sizing.

## Getting Usage

RAM usage max was an easy edit to our current average usage query, changing `avg(avg_over_time())` to `max(max_over_time())`.

CPU usage max was a little more complicated. Because we use `rate` to calculate average CPU usage, we have to use a subquery or a recording rule to take a maximum of rate over time. Fortunately, we already have a recording rule called `kubecost_savings_container_cpu_usage_seconds` that has the necessary information. See code comments for more commentary on rationale.

## Adding Usage to `Allocation`

- I changed a few query, function, and parameter names to make clear what is average usage and what is max usage.
- I duplicated the relevant `apply` functions to convert Prom responses into struct fields
- I modified the behavior of `Allocation.add()` to consider two cases: accumulation and aggregation

## Accumulation and Aggregation

We have two sets of behavior that could previously be combined into the same logic.

Accumulation is the combination of `Allocation`s that refer to the same thing, without a loss of granularity. Imagine needing to combine two `Allocation`s that refer to the same container. In this case, usage maxima need to be maxed together. For example, if container C used a maximum of X CPU in allocation A1 and container C used a maximum of Y CPU in allocation A2, then the resulting allocation A3 should have container C's max CPU as `max(X, Y)`.

Aggregation is the combination of `Allocation`s that refer to different things under the same aggregation umbrella (i.e. with a loss of granularity). Imagine combining containers under the same namespace. In this case, usage maxima need to be added together. For example, if container C1 used a maximum of X CPU in A1 and container C2 used a maximum of Y CPU in A2 (and they are the only two containers in the namespace), then the allocation aggregated for C1 and C2's namespace should have a maximum CPU of `X + Y`.

Because most of the rest of the `Allocation.add()` logic did not need to change, I added a flag that tells `add()` whether it is performing an accumulating add or an aggregating add. Because `AllocationSet.insert()` uses `Allocation.add()`, it also has this flag. To make this clear in the public API, I removed `Allocation.Add()` and `AllocationSet.Insert()` and replaced them with `Allocation.AddAccumulate()`, `Allocation.AddAggregate()`, `AllocationSet.InsertAccumulate()`, and `AllocationSet.InsertAggregate()`. I think this is a pretty good way of handling this, but I'm absolutely open to better approaches.

# Tests

## No ETL, fields set
To check that the field was being set properly, I ran a query against `/allocation/compute` which hits `ComputeAllocation` directly without dealing with the ETL.

```
curl -G \
    --connect-timeout 3 \
    --max-time 5 \
    -d 'window=1d' \
    http://localhost:8080/api/v1/namespaces/kubecost/services/kubecost-cost-analyzer:model/proxy/allocation/compute | \
    jq '.data |
       map(
         map_values(
           {
             "cpuCoreUsageAverage": .cpuCoreUsageAverage,
             "cpuCoreUsageMax": .cpuCoreUsageMax,
             "ramByteUsageAverage": .ramByteUsageAverage,
             "ramByteUsageMax": .ramByteUsageMax,
           }
            )
        )'
```

[Results](https://gist.github.com/michaelmdresser/666ad543b25ade2fc280adebe546b897) (large)

## ETL, fields set

To also verify that the fields were being set in the ETL, I also had to force a rebuild:
```
curl -G \
    --connect-timeout 3 \
    --max-time 120 \
    -d 'window=7d' \
    -d 'commit=true' \
    http://localhost:8080/api/v1/namespaces/kubecost/services/kubecost-cost-analyzer:model/proxy/etl/allocation/rebuild
```

The test query:
```
curl -G \
    --connect-timeout 3 \
    --max-time 5 \
    -d 'window=1d' \
    http://localhost:8080/api/v1/namespaces/kubecost/services/kubecost-cost-analyzer:model/proxy/allocation | \
    jq '.data |
       map(
         map_values(
           {
             "cpuCoreUsageAverage": .cpuCoreUsageAverage,
             "cpuCoreUsageMax": .cpuCoreUsageMax,
             "ramByteUsageAverage": .ramByteUsageAverage,
             "ramByteUsageMax": .ramByteUsageMax,
           }
            )
        )'
```

[Results](https://gist.github.com/michaelmdresser/dd9e52e35cdd52c52215185c7aa17acd) (large)

## Non-ETL, aggregation logic

```
curl -G \
    --connect-timeout 3 \
    --max-time 5 \
    -d 'window=1d' \
    -d 'aggregate=namespace' \
    http://localhost:8080/api/v1/namespaces/kubecost/services/kubecost-cost-analyzer:model/proxy/allocation/compute | \
    jq '.data |
       map(
         map_values(
           {
             "cpuCoreUsageAverage": .cpuCoreUsageAverage,
             "cpuCoreUsageMax": .cpuCoreUsageMax,
             "ramByteUsageAverage": .ramByteUsageAverage,
             "ramByteUsageMax": .ramByteUsageMax,
           }
            )
        )'
```

```
[
  {
    "cost-model": {
      "cpuCoreUsageAverage": 0.003388,
      "cpuCoreUsageMax": 0.005153,
      "ramByteUsageAverage": 278031103.110494,
      "ramByteUsageMax": 284053504
    },
    "kube-system": {
      "cpuCoreUsageAverage": 0.051783,
      "cpuCoreUsageMax": 0.062117,
      "ramByteUsageAverage": 439955257.97804,
      "ramByteUsageMax": 451493888
    },
    "kubecost": {
      "cpuCoreUsageAverage": 0.029408,
      "cpuCoreUsageMax": 0.292005,
      "ramByteUsageAverage": 517551154.179154,
      "ramByteUsageMax": 710434816
    },
    "kubecost-staging": {
      "cpuCoreUsageAverage": 0.023558,
      "cpuCoreUsageMax": 0.044541,
      "ramByteUsageAverage": 399534795.95991,
      "ramByteUsageMax": 425254912
    }
  }
]
```

## ETL, aggregation logic

```
curl -G \
    --connect-timeout 3 \
    --max-time 5 \
    -d 'window=1d' \
    -d 'aggregate=namespace' \
    http://localhost:8080/api/v1/namespaces/kubecost/services/kubecost-cost-analyzer:model/proxy/allocation | \
    jq '.data |
       map(
         map_values(
           {
             "cpuCoreUsageAverage": .cpuCoreUsageAverage,
             "cpuCoreUsageMax": .cpuCoreUsageMax,
             "ramByteUsageAverage": .ramByteUsageAverage,
             "ramByteUsageMax": .ramByteUsageMax,
           }
            )
        )'
```

```
[
  {
    "__idle__": {
      "cpuCoreUsageAverage": 0,
      "cpuCoreUsageMax": 0,
      "ramByteUsageAverage": 0,
      "ramByteUsageMax": 0
    },
    "cost-model": {
      "cpuCoreUsageAverage": 0.003474,
      "cpuCoreUsageMax": 0.004702,
      "ramByteUsageAverage": 271591911.483692,
      "ramByteUsageMax": 276983808
    },
    "kube-system": {
      "cpuCoreUsageAverage": 0.051683,
      "cpuCoreUsageMax": 0.064119,
      "ramByteUsageAverage": 439029513.20743,
      "ramByteUsageMax": 453189632
    },
    "kubecost": {
      "cpuCoreUsageAverage": 0.025604,
      "cpuCoreUsageMax": 0.164336,
      "ramByteUsageAverage": 525091844.350198,
      "ramByteUsageMax": 923942912
    },
    "kubecost-staging": {
      "cpuCoreUsageAverage": 0.023704,
      "cpuCoreUsageMax": 0.044678,
      "ramByteUsageAverage": 396685146.036298,
      "ramByteUsageMax": 420511744
    }
  },
  {
    "__idle__": {
      "cpuCoreUsageAverage": 0,
      "cpuCoreUsageMax": 0,
      "ramByteUsageAverage": 0,
      "ramByteUsageMax": 0
    },
    "cost-model": {
      "cpuCoreUsageAverage": 0.003393,
      "cpuCoreUsageMax": 0.005153,
      "ramByteUsageAverage": 278466523.984012,
      "ramByteUsageMax": 284553216
    },
    "kube-system": {
      "cpuCoreUsageAverage": 0.051784,
      "cpuCoreUsageMax": 0.061107,
      "ramByteUsageAverage": 439987553.92533,
      "ramByteUsageMax": 451862528
    },
    "kubecost": {
      "cpuCoreUsageAverage": 0.029126,
      "cpuCoreUsageMax": 0.285256,
      "ramByteUsageAverage": 514780208.328162,
      "ramByteUsageMax": 694689792
    },
    "kubecost-staging": {
      "cpuCoreUsageAverage": 0.023542,
      "cpuCoreUsageMax": 0.043447,
      "ramByteUsageAverage": 399383724.328601,
      "ramByteUsageMax": 423763968
    }
  }
]
```