### PR TITLE
Added Chinese pricing url for Chinese region

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -587,7 +587,6 @@ func (aws *AWS) getRegionPricing(nodeList []*v1.Node) (*http.Response, string, e
 		currentNodeRegion := ""
 		if r, ok := util.GetRegion(labels); ok {
 			currentNodeRegion = r
-			//currentNodeRegion = "cn-north-1"
 			// Switch to Chinese endpoint for regions with the Chinese prefix
 			if strings.HasPrefix(currentNodeRegion, "cn-") {
 				pricingURL = "https://pricing.cn-north-1.amazonaws.com.cn/offers/v1.0/cn/AmazonEC2/current/"
@@ -745,6 +744,9 @@ func (aws *AWS) DownloadPricingData() error {
 		if err == io.EOF {
 			klog.V(2).Infof("done loading \"%s\"\n", pricingURL)
 			break
+		} else if err != nil {
+			klog.V(2).Infof("error parsing response json %v", resp.Body)
+			break
 		}
 		if t == "products" {
 			_, err := dec.Token() // this should parse the opening "{""
@@ -879,10 +881,6 @@ func (aws *AWS) DownloadPricingData() error {
 		}
 	}
 	klog.V(2).Infof("Finished downloading \"%s\"", pricingURL)
-	klog.Infof("Pricing Data:")
-	for k, p := range aws.Pricing {
-		klog.Infof("%v: %v", k, *p)
-	}
 
 	// Always run spot pricing refresh when performing download
 	aws.refreshSpotPricing(true)

--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -565,7 +565,6 @@ func (aws *AWS) ClusterManagementPricing() (string, float64, error) {
 func (aws *AWS) getRegionPricing(nodeList []*v1.Node) (*http.Response, string, error) {
 
 	pricingURL := "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/"
-
 	region := ""
 	multiregion := false
 	for _, n := range nodeList {
@@ -573,6 +572,10 @@ func (aws *AWS) getRegionPricing(nodeList []*v1.Node) (*http.Response, string, e
 		currentNodeRegion := ""
 		if r, ok := util.GetRegion(labels); ok {
 			currentNodeRegion = r
+			// Switch to Chinese endpoint for regions with the Chinese prefix
+			if strings.Contains(currentNodeRegion, "cn-") {
+				pricingURL = "https://pricing.cn-north-1.amazonaws.com.cn/offers/v1.0/cn/AmazonEC2/current/"
+			}
 		} else {
 			multiregion = true // We weren't able to detect the node's region, so pull all data.
 			break
@@ -585,6 +588,7 @@ func (aws *AWS) getRegionPricing(nodeList []*v1.Node) (*http.Response, string, e
 		}
 	}
 
+	// Chinese multiregion endpoint only contains data for Chinese regions and Chinese regions are excluded from other endpoint
 	if region != "" && !multiregion {
 		pricingURL += region + "/"
 	}


### PR DESCRIPTION
Update AWS pricing so nodes in Chinese regions use Chinese pricing URL. It is worth mentioning that the multi-region pricing endpoint for china only includes the two Chinese regions cn-north-1 and cn-northwest-1, while the other multi-region endpoint includes all other regions but not the Chinese ones. One edge cast of note here is that if no region is detected on any nodes then it will default to the non-Chinese multi-region endpoint, which could cause issues for a multi-region Chinese cluster. It is not clear at this point if this is an actual concern though.

Testing:
To test this I hard coded the Chinese regions and checked that the pricing api was being hit correctly.
No hard coding:
![Screen Shot 2021-04-13 at 11 06 43 AM](https://user-images.githubusercontent.com/12225425/114603926-2c9f8a00-9c4d-11eb-9696-a9c6fbc95e75.png)

Hard coded "cn-north-1"
![Screen Shot 2021-04-13 at 11 07 28 AM](https://user-images.githubusercontent.com/12225425/114603986-3fb25a00-9c4d-11eb-8af0-2ee223fddfa5.png)

While this did work here it does cause issues down the line when the nodes are actually looking for their pricing data in the returned json:
![Screen Shot 2021-04-13 at 11 13 41 AM](https://user-images.githubusercontent.com/12225425/114604149-6ec8cb80-9c4d-11eb-9049-d992d3aa6011.png)

Hard coded "cn-northwest-1"
![Screen Shot 2021-04-13 at 11 15 06 AM](https://user-images.githubusercontent.com/12225425/114604208-7e481480-9c4d-11eb-8b86-62faf81fc8f6.png)

Hard coded "cn-northwest-"
This is an invalid region and causes Kubecost to crash. In this case the above queries hung without completing and this was show when visiting Kubecost
![Screen Shot 2021-04-13 at 11 21 51 AM](https://user-images.githubusercontent.com/12225425/114604388-ab94c280-9c4d-11eb-8f5b-ad40553c0178.png)

Edit:
Returned prices for Chinese regions are in CNY