### PR TITLE
Fixed a bad URL in the allocations UI

### DIFF
--- a/ui/src/services/allocation.js
+++ b/ui/src/services/allocation.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 class AllocationService {
-  BASE_URL = 'http://localhost:9090/model/allocation';
+  BASE_URL = 'http://localhost:9090/allocation';
 
   async fetchAllocation(win, aggregate, options) {
     const { accumulate, filters, } = options;


### PR DESCRIPTION
URL was pointing at `/model/allocation/compute` but needs `/allocation/compute`