### PR TITLE
Node Allocation reconciliation

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -304,7 +304,6 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time, resolution time.Dur
 
 	// TODO breakdown network costs?
 
-
 	// Build out a map of Nodes with resource costs, discounts, and node types
 	// for converting resource allocation data to cumulative costs.
 	nodeMap := map[nodeKey]*NodePricing{}
@@ -1285,7 +1284,7 @@ func applyControllersToPods(podMap map[podKey]*Pod, podControllerMap map[podKey]
 }
 
 func applyNodeCostPerCPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerCPUHr []*prom.QueryResult,
-	providerIDParser func(string) string,) {
+	providerIDParser func(string) string) {
 	for _, res := range resNodeCostPerCPUHr {
 		cluster, err := res.GetString("cluster_id")
 		if err != nil {
@@ -1324,7 +1323,7 @@ func applyNodeCostPerCPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerCPUHr
 }
 
 func applyNodeCostPerRAMGiBHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerRAMGiBHr []*prom.QueryResult,
-	providerIDParser func(string) string,) {
+	providerIDParser func(string) string) {
 	for _, res := range resNodeCostPerRAMGiBHr {
 		cluster, err := res.GetString("cluster_id")
 		if err != nil {
@@ -1363,7 +1362,7 @@ func applyNodeCostPerRAMGiBHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerRA
 }
 
 func applyNodeCostPerGPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerGPUHr []*prom.QueryResult,
-	providerIDParser func(string) string,) {
+	providerIDParser func(string) string) {
 	for _, res := range resNodeCostPerGPUHr {
 		cluster, err := res.GetString("cluster_id")
 		if err != nil {

--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -304,13 +304,14 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time, resolution time.Dur
 
 	// TODO breakdown network costs?
 
+
 	// Build out a map of Nodes with resource costs, discounts, and node types
 	// for converting resource allocation data to cumulative costs.
 	nodeMap := map[nodeKey]*NodePricing{}
 
-	applyNodeCostPerCPUHr(nodeMap, resNodeCostPerCPUHr)
-	applyNodeCostPerRAMGiBHr(nodeMap, resNodeCostPerRAMGiBHr)
-	applyNodeCostPerGPUHr(nodeMap, resNodeCostPerGPUHr)
+	applyNodeCostPerCPUHr(nodeMap, resNodeCostPerCPUHr, cm.Provider.ParseID)
+	applyNodeCostPerRAMGiBHr(nodeMap, resNodeCostPerRAMGiBHr, cm.Provider.ParseID)
+	applyNodeCostPerGPUHr(nodeMap, resNodeCostPerGPUHr, cm.Provider.ParseID)
 	applyNodeSpot(nodeMap, resNodeIsSpot)
 	applyNodeDiscount(nodeMap, cm)
 
@@ -1283,7 +1284,8 @@ func applyControllersToPods(podMap map[podKey]*Pod, podControllerMap map[podKey]
 	}
 }
 
-func applyNodeCostPerCPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerCPUHr []*prom.QueryResult) {
+func applyNodeCostPerCPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerCPUHr []*prom.QueryResult,
+	providerIDParser func(string) string,) {
 	for _, res := range resNodeCostPerCPUHr {
 		cluster, err := res.GetString("cluster_id")
 		if err != nil {
@@ -1313,7 +1315,7 @@ func applyNodeCostPerCPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerCPUHr
 			nodeMap[key] = &NodePricing{
 				Name:       node,
 				NodeType:   instanceType,
-				ProviderID: providerID,
+				ProviderID: providerIDParser(providerID),
 			}
 		}
 
@@ -1321,7 +1323,8 @@ func applyNodeCostPerCPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerCPUHr
 	}
 }
 
-func applyNodeCostPerRAMGiBHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerRAMGiBHr []*prom.QueryResult) {
+func applyNodeCostPerRAMGiBHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerRAMGiBHr []*prom.QueryResult,
+	providerIDParser func(string) string,) {
 	for _, res := range resNodeCostPerRAMGiBHr {
 		cluster, err := res.GetString("cluster_id")
 		if err != nil {
@@ -1351,7 +1354,7 @@ func applyNodeCostPerRAMGiBHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerRA
 			nodeMap[key] = &NodePricing{
 				Name:       node,
 				NodeType:   instanceType,
-				ProviderID: providerID,
+				ProviderID: providerIDParser(providerID),
 			}
 		}
 
@@ -1359,7 +1362,8 @@ func applyNodeCostPerRAMGiBHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerRA
 	}
 }
 
-func applyNodeCostPerGPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerGPUHr []*prom.QueryResult) {
+func applyNodeCostPerGPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerGPUHr []*prom.QueryResult,
+	providerIDParser func(string) string,) {
 	for _, res := range resNodeCostPerGPUHr {
 		cluster, err := res.GetString("cluster_id")
 		if err != nil {
@@ -1389,7 +1393,7 @@ func applyNodeCostPerGPUHr(nodeMap map[nodeKey]*NodePricing, resNodeCostPerGPUHr
 			nodeMap[key] = &NodePricing{
 				Name:       node,
 				NodeType:   instanceType,
-				ProviderID: providerID,
+				ProviderID: providerIDParser(providerID),
 			}
 		}
 

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -59,8 +59,10 @@ type Allocation struct {
 	CPUCoreRequestAverage  float64               `json:"cpuCoreRequestAverage"`
 	CPUCoreUsageAverage    float64               `json:"cpuCoreUsageAverage"`
 	CPUCost                float64               `json:"cpuCost"`
+	CPUAdjustment          float64               `json:"cpuAdjustment"`
 	GPUHours               float64               `json:"gpuHours"`
 	GPUCost                float64               `json:"gpuCost"`
+	GPUAdjustment          float64               `json:"gpuAdjustment"`
 	NetworkCost            float64               `json:"networkCost"`
 	LoadBalancerCost       float64               `json:"loadBalancerCost"`
 	PVByteHours            float64               `json:"pvByteHours"`
@@ -69,6 +71,7 @@ type Allocation struct {
 	RAMBytesRequestAverage float64               `json:"ramByteRequestAverage"`
 	RAMBytesUsageAverage   float64               `json:"ramByteUsageAverage"`
 	RAMCost                float64               `json:"ramCost"`
+	RAMAdjustment          float64               `json:"ramAdjustment"`
 	SharedCost             float64               `json:"sharedCost"`
 	ExternalCost           float64               `json:"externalCost"`
 
@@ -144,8 +147,10 @@ func (a *Allocation) Clone() *Allocation {
 		CPUCoreRequestAverage:  a.CPUCoreRequestAverage,
 		CPUCoreUsageAverage:    a.CPUCoreUsageAverage,
 		CPUCost:                a.CPUCost,
+		CPUAdjustment:          a.CPUAdjustment,
 		GPUHours:               a.GPUHours,
 		GPUCost:                a.GPUCost,
+		GPUAdjustment:          a.GPUAdjustment,
 		NetworkCost:            a.NetworkCost,
 		LoadBalancerCost:       a.LoadBalancerCost,
 		PVByteHours:            a.PVByteHours,
@@ -154,6 +159,7 @@ func (a *Allocation) Clone() *Allocation {
 		RAMBytesRequestAverage: a.RAMBytesRequestAverage,
 		RAMBytesUsageAverage:   a.RAMBytesUsageAverage,
 		RAMCost:                a.RAMCost,
+		RAMAdjustment:          a.RAMAdjustment,
 		SharedCost:             a.SharedCost,
 		ExternalCost:           a.ExternalCost,
 		RawAllocationOnly:      a.RawAllocationOnly.Clone(),
@@ -202,10 +208,16 @@ func (a *Allocation) Equal(that *Allocation) bool {
 	if !util.IsApproximately(a.CPUCost, that.CPUCost) {
 		return false
 	}
+	if !util.IsApproximately(a.CPUAdjustment, that.CPUAdjustment) {
+		return false
+	}
 	if !util.IsApproximately(a.GPUHours, that.GPUHours) {
 		return false
 	}
 	if !util.IsApproximately(a.GPUCost, that.GPUCost) {
+		return false
+	}
+	if !util.IsApproximately(a.GPUAdjustment, that.GPUAdjustment) {
 		return false
 	}
 	if !util.IsApproximately(a.NetworkCost, that.NetworkCost) {
@@ -224,6 +236,9 @@ func (a *Allocation) Equal(that *Allocation) bool {
 		return false
 	}
 	if !util.IsApproximately(a.RAMCost, that.RAMCost) {
+		return false
+	}
+	if !util.IsApproximately(a.RAMAdjustment, that.RAMAdjustment) {
 		return false
 	}
 	if !util.IsApproximately(a.SharedCost, that.SharedCost) {
@@ -254,7 +269,19 @@ func (a *Allocation) Equal(that *Allocation) bool {
 
 // TotalCost is the total cost of the Allocation
 func (a *Allocation) TotalCost() float64 {
-	return a.CPUCost + a.GPUCost + a.RAMCost + a.PVCost + a.NetworkCost + a.SharedCost + a.ExternalCost + a.LoadBalancerCost
+	return a.CPUTotalCost() + a.GPUTotalCost() + a.RAMTotalCost() + a.PVCost + a.NetworkCost + a.SharedCost + a.ExternalCost + a.LoadBalancerCost
+}
+
+func (a *Allocation) CPUTotalCost() float64 {
+	return a.CPUCost + a.CPUAdjustment
+}
+
+func (a *Allocation) GPUTotalCost() float64 {
+	return a.GPUCost + a.GPUAdjustment
+}
+
+func (a *Allocation) RAMTotalCost() float64 {
+	return a.RAMCost + a.RAMAdjustment
 }
 
 // CPUEfficiency is the ratio of usage to request. If there is no request and
@@ -290,10 +317,10 @@ func (a *Allocation) RAMEfficiency() float64 {
 // TotalEfficiency is the cost-weighted average of CPU and RAM efficiency. If
 // there is no cost at all, then efficiency is zero.
 func (a *Allocation) TotalEfficiency() float64 {
-	if a.CPUCost+a.RAMCost > 0 {
-		ramCostEff := a.RAMEfficiency() * a.RAMCost
-		cpuCostEff := a.CPUEfficiency() * a.CPUCost
-		return (ramCostEff + cpuCostEff) / (a.CPUCost + a.RAMCost)
+	if a.RAMTotalCost()+a.CPUTotalCost() > 0 {
+		ramCostEff := a.RAMEfficiency() * a.RAMTotalCost()
+		cpuCostEff := a.CPUEfficiency() * a.CPUTotalCost()
+		return (ramCostEff + cpuCostEff) / (a.CPUTotalCost() + a.RAMTotalCost())
 	}
 
 	return 0.0
@@ -337,9 +364,11 @@ func (a *Allocation) MarshalJSON() ([]byte, error) {
 	jsonEncodeFloat64(buffer, "cpuCoreUsageAverage", a.CPUCoreUsageAverage, ",")
 	jsonEncodeFloat64(buffer, "cpuCoreHours", a.CPUCoreHours, ",")
 	jsonEncodeFloat64(buffer, "cpuCost", a.CPUCost, ",")
+	jsonEncodeFloat64(buffer, "cpuAdjustment", a.CPUAdjustment, ",")
 	jsonEncodeFloat64(buffer, "cpuEfficiency", a.CPUEfficiency(), ",")
 	jsonEncodeFloat64(buffer, "gpuHours", a.GPUHours, ",")
 	jsonEncodeFloat64(buffer, "gpuCost", a.GPUCost, ",")
+	jsonEncodeFloat64(buffer, "gpuAdjustment", a.GPUAdjustment, ",")
 	jsonEncodeFloat64(buffer, "networkCost", a.NetworkCost, ",")
 	jsonEncodeFloat64(buffer, "loadBalancerCost", a.LoadBalancerCost, ",")
 	jsonEncodeFloat64(buffer, "pvBytes", a.PVBytes(), ",")
@@ -350,6 +379,7 @@ func (a *Allocation) MarshalJSON() ([]byte, error) {
 	jsonEncodeFloat64(buffer, "ramByteUsageAverage", a.RAMBytesUsageAverage, ",")
 	jsonEncodeFloat64(buffer, "ramByteHours", a.RAMByteHours, ",")
 	jsonEncodeFloat64(buffer, "ramCost", a.RAMCost, ",")
+	jsonEncodeFloat64(buffer, "ramAdjustment", a.RAMAdjustment, ",")
 	jsonEncodeFloat64(buffer, "ramEfficiency", a.RAMEfficiency(), ",")
 	jsonEncodeFloat64(buffer, "sharedCost", a.SharedCost, ",")
 	jsonEncodeFloat64(buffer, "externalCost", a.ExternalCost, ",")
@@ -478,6 +508,11 @@ func (a *Allocation) add(that *Allocation) {
 	a.LoadBalancerCost += that.LoadBalancerCost
 	a.SharedCost += that.SharedCost
 	a.ExternalCost += that.ExternalCost
+
+	// Sum all cumulative adjustment fields
+	a.CPUAdjustment += that.CPUAdjustment
+	a.RAMAdjustment += that.RAMAdjustment
+	a.GPUAdjustment += that.GPUAdjustment
 
 	// Any data that is in a "raw allocation only" is not valid in any
 	// sort of cumulative Allocation (like one that is added).
@@ -1095,13 +1130,13 @@ func computeIdleCoeffs(options *AllocationAggregationOptions, as *AllocationSet,
 				totals[clusterID][r] += 1.0
 			}
 		} else {
-			coeffs[clusterID][name]["cpu"] += alloc.CPUCost
-			coeffs[clusterID][name]["gpu"] += alloc.GPUCost
-			coeffs[clusterID][name]["ram"] += alloc.RAMCost
+			coeffs[clusterID][name]["cpu"] += alloc.CPUTotalCost()
+			coeffs[clusterID][name]["gpu"] += alloc.GPUTotalCost()
+			coeffs[clusterID][name]["ram"] += alloc.RAMTotalCost()
 
-			totals[clusterID]["cpu"] += alloc.CPUCost
-			totals[clusterID]["gpu"] += alloc.GPUCost
-			totals[clusterID]["ram"] += alloc.RAMCost
+			totals[clusterID]["cpu"] += alloc.CPUTotalCost()
+			totals[clusterID]["gpu"] += alloc.GPUTotalCost()
+			totals[clusterID]["ram"] += alloc.RAMTotalCost()
 		}
 	}
 
@@ -1142,13 +1177,13 @@ func computeIdleCoeffs(options *AllocationAggregationOptions, as *AllocationSet,
 				totals[clusterID][r] += 1.0
 			}
 		} else {
-			coeffs[clusterID][name]["cpu"] += alloc.CPUCost
-			coeffs[clusterID][name]["gpu"] += alloc.GPUCost
+			coeffs[clusterID][name]["cpu"] += alloc.CPUTotalCost()
+			coeffs[clusterID][name]["gpu"] += alloc.GPUTotalCost()
 			coeffs[clusterID][name]["ram"] += alloc.RAMCost
 
-			totals[clusterID]["cpu"] += alloc.CPUCost
-			totals[clusterID]["gpu"] += alloc.GPUCost
-			totals[clusterID]["ram"] += alloc.RAMCost
+			totals[clusterID]["cpu"] += alloc.CPUTotalCost()
+			totals[clusterID]["gpu"] += alloc.GPUTotalCost()
+			totals[clusterID]["ram"] += alloc.RAMTotalCost()
 		}
 	}
 
@@ -1418,9 +1453,9 @@ func (as *AllocationSet) ComputeIdleAllocations(assetSet *AssetSet) (map[string]
 			clusterEnds[cluster] = a.End
 		}
 
-		assetClusterResourceCosts[cluster]["cpu"] -= a.CPUCost
-		assetClusterResourceCosts[cluster]["gpu"] -= a.GPUCost
-		assetClusterResourceCosts[cluster]["ram"] -= a.RAMCost
+		assetClusterResourceCosts[cluster]["cpu"] -= a.CPUTotalCost()
+		assetClusterResourceCosts[cluster]["gpu"] -= a.GPUTotalCost()
+		assetClusterResourceCosts[cluster]["ram"] -= a.RAMTotalCost()
 	})
 
 	// Turn remaining un-allocated asset costs into idle allocations
@@ -1458,6 +1493,97 @@ func (as *AllocationSet) ComputeIdleAllocations(assetSet *AssetSet) (map[string]
 	}
 
 	return idleAllocs, nil
+}
+
+// ReconcileAllocations calculate the exact cost of Allocation by resource(cpu, ram, gpu etc) based on Asset(s) on which
+// the Allocation depends.
+func (as *AllocationSet) ReconcileAllocations(assetSet *AssetSet) error {
+	if as == nil {
+		return fmt.Errorf("cannot reconcile allocation for nil AllocationSet")
+	}
+
+	if assetSet == nil {
+		return fmt.Errorf("cannot reconcile allocation with nil AssetSet")
+	}
+
+	if !as.Window.Equal(assetSet.Window) {
+		return fmt.Errorf("cannot reconcile allocation for sets with mismatched windows: %s != %s", as.Window, assetSet.Window)
+	}
+
+	// Build map of Assets with type Node by their ProviderId so that they can be matched to Allocations to determine
+	// proper CPU GPU and Ram prices
+	nodeByProviderID := map[string]*Node{}
+	assetSet.Each(func(key string, a Asset) {
+		if node, ok := a.(*Node); ok {
+			nodeByProviderID[node.properties.ProviderID] = node
+		}
+	})
+
+	// Match Assets against allocations and adjust allocation cost based on the proportion of the asset that they used
+	as.Each(func(name string, a *Allocation) {
+		providerId := a.Properties.ProviderID
+
+		// Reconcile with node Assets
+		node, ok := nodeByProviderID[providerId]
+		if ok {
+			// Failed to find node for allocation
+			return
+		}
+
+		// adjustmentRate is used to scale resource costs proportionally
+		// by the adjustment. This is necessary because we only get one
+		// adjustment per Node, not one per-resource-per-Node.
+		//
+		// e.g. total cost = $90, adjustment = -$10 => 0.9
+		// e.g. total cost = $150, adjustment = -$300 => 0.3333
+		// e.g. total cost = $150, adjustment = $50 => 1.5
+		adjustmentRate := 1.0
+		if node.TotalCost()-node.Adjustment() == 0 {
+			// If (totalCost - adjustment) is 0.0 then adjustment cancels
+			// the entire node cost and we should make everything 0
+			// without dividing by 0.
+			adjustmentRate = 0.0
+		} else if node.Adjustment() != 0.0 {
+			// adjustmentRate is the ratio of cost-with-adjustment (i.e. TotalCost)
+			// to cost-without-adjustment (i.e. TotalCost - Adjustment).
+			adjustmentRate = node.TotalCost() / (node.TotalCost() - node.Adjustment())
+		}
+
+		// Find total cost of each node resource for the window
+		cpuCost := node.CPUCost * (1.0 - node.Discount) * adjustmentRate
+		ramCost := node.RAMCost * (1.0 - node.Discount) * adjustmentRate
+		gpuCost := node.GPUCost * adjustmentRate
+
+		// Find the proportion of resource hours used by the allocation, checking for 0 denominators
+		cpuUsageProportion := 0.0
+		if node.CPUCoreHours != 0 {
+			cpuUsageProportion = a.CPUCoreHours / node.CPUCoreHours
+		} else {
+			log.Warningf("Missing CPU Hours for node Provider ID: %s", providerId)
+		}
+		ramUsageProportion := 0.0
+		if node.RAMByteHours != 0 {
+			ramUsageProportion = a.RAMByteHours / node.RAMByteHours
+		} else {
+			log.Warningf("Missing Ram Byte Hours for node Provider ID: %s", providerId)
+		}
+		gpuUsageProportion := 0.0
+		if node.GPUCount != 0 && node.Minutes() != 0 {
+			gpuUsageProportion = a.GPUHours / (node.GPUCount * node.Minutes() / 60)
+		}
+		// No log for GPU because not all nodes have GPU
+
+		// Calculate the allocation's resource costs by the proportion of resources used and total costs
+		allocCPUCost := cpuUsageProportion * cpuCost
+		allocRAMCost := ramUsageProportion * ramCost
+		allocGPUCost := gpuUsageProportion * gpuCost
+
+		a.CPUAdjustment = allocCPUCost - a.CPUCost
+		a.RAMAdjustment = allocRAMCost - a.RAMCost
+		a.GPUAdjustment = allocGPUCost - a.GPUCost
+	})
+
+	return nil
 }
 
 // Delete removes the allocation with the given name from the set

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1525,7 +1525,7 @@ func (as *AllocationSet) ReconcileAllocations(assetSet *AssetSet) error {
 
 		// Reconcile with node Assets
 		node, ok := nodeByProviderID[providerId]
-		if ok {
+		if !ok {
 			// Failed to find node for allocation
 			return
 		}

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -537,8 +537,8 @@ func TestNewAllocationSet(t *testing.T) {
 func generateAllocationSet(start time.Time) *AllocationSet {
 	// Idle allocations
 	a1i := NewUnitAllocation(fmt.Sprintf("cluster1/%s", IdleSuffix), start, day, &AllocationProperties{
-		Cluster: "cluster1",
-		Node:    "node1",
+		Cluster:    "cluster1",
+		Node:       "node1",
 		ProviderID: "c1nodes",
 	})
 	a1i.CPUCost = 5.0
@@ -554,99 +554,99 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 
 	// Active allocations
 	a1111 := NewUnitAllocation("cluster1/namespace1/pod1/container1", start, day, &AllocationProperties{
-		Cluster:   "cluster1",
-		Namespace: "namespace1",
-		Pod:       "pod1",
-		Container: "container1",
+		Cluster:    "cluster1",
+		Namespace:  "namespace1",
+		Pod:        "pod1",
+		Container:  "container1",
 		ProviderID: "c1nodes",
 	})
 	a1111.RAMCost = 11.00
 
 	a11abc2 := NewUnitAllocation("cluster1/namespace1/pod-abc/container2", start, day, &AllocationProperties{
-		Cluster:   "cluster1",
-		Namespace: "namespace1",
-		Pod:       "pod-abc",
-		Container: "container2",
+		Cluster:    "cluster1",
+		Namespace:  "namespace1",
+		Pod:        "pod-abc",
+		Container:  "container2",
 		ProviderID: "c1nodes",
 	})
 
 	a11def3 := NewUnitAllocation("cluster1/namespace1/pod-def/container3", start, day, &AllocationProperties{
-		Cluster:   "cluster1",
-		Namespace: "namespace1",
-		Pod:       "pod-def",
-		Container: "container3",
+		Cluster:    "cluster1",
+		Namespace:  "namespace1",
+		Pod:        "pod-def",
+		Container:  "container3",
 		ProviderID: "c1nodes",
 	})
 
 	a12ghi4 := NewUnitAllocation("cluster1/namespace2/pod-ghi/container4", start, day, &AllocationProperties{
-		Cluster:   "cluster1",
-		Namespace: "namespace2",
-		Pod:       "pod-ghi",
-		Container: "container4",
+		Cluster:    "cluster1",
+		Namespace:  "namespace2",
+		Pod:        "pod-ghi",
+		Container:  "container4",
 		ProviderID: "c1nodes",
 	})
 
 	a12ghi5 := NewUnitAllocation("cluster1/namespace2/pod-ghi/container5", start, day, &AllocationProperties{
-		Cluster:   "cluster1",
-		Namespace: "namespace2",
-		Pod:       "pod-ghi",
-		Container: "container5",
+		Cluster:    "cluster1",
+		Namespace:  "namespace2",
+		Pod:        "pod-ghi",
+		Container:  "container5",
 		ProviderID: "c1nodes",
 	})
 
 	a12jkl6 := NewUnitAllocation("cluster1/namespace2/pod-jkl/container6", start, day, &AllocationProperties{
-		Cluster:   "cluster1",
-		Namespace: "namespace2",
-		Pod:       "pod-jkl",
-		Container: "container6",
+		Cluster:    "cluster1",
+		Namespace:  "namespace2",
+		Pod:        "pod-jkl",
+		Container:  "container6",
 		ProviderID: "c1nodes",
 	})
 
 	a22mno4 := NewUnitAllocation("cluster2/namespace2/pod-mno/container4", start, day, &AllocationProperties{
-		Cluster:   "cluster2",
-		Namespace: "namespace2",
-		Pod:       "pod-mno",
-		Container: "container4",
+		Cluster:    "cluster2",
+		Namespace:  "namespace2",
+		Pod:        "pod-mno",
+		Container:  "container4",
 		ProviderID: "node1",
 	})
 
 	a22mno5 := NewUnitAllocation("cluster2/namespace2/pod-mno/container5", start, day, &AllocationProperties{
-		Cluster:   "cluster2",
-		Namespace: "namespace2",
-		Pod:       "pod-mno",
-		Container: "container5",
+		Cluster:    "cluster2",
+		Namespace:  "namespace2",
+		Pod:        "pod-mno",
+		Container:  "container5",
 		ProviderID: "node1",
 	})
 
 	a22pqr6 := NewUnitAllocation("cluster2/namespace2/pod-pqr/container6", start, day, &AllocationProperties{
-		Cluster:   "cluster2",
-		Namespace: "namespace2",
-		Pod:       "pod-pqr",
-		Container: "container6",
+		Cluster:    "cluster2",
+		Namespace:  "namespace2",
+		Pod:        "pod-pqr",
+		Container:  "container6",
 		ProviderID: "node2",
 	})
 
 	a23stu7 := NewUnitAllocation("cluster2/namespace3/pod-stu/container7", start, day, &AllocationProperties{
-		Cluster:   "cluster2",
-		Namespace: "namespace3",
-		Pod:       "pod-stu",
-		Container: "container7",
+		Cluster:    "cluster2",
+		Namespace:  "namespace3",
+		Pod:        "pod-stu",
+		Container:  "container7",
 		ProviderID: "node2",
 	})
 
 	a23vwx8 := NewUnitAllocation("cluster2/namespace3/pod-vwx/container8", start, day, &AllocationProperties{
-		Cluster:   "cluster2",
-		Namespace: "namespace3",
-		Pod:       "pod-vwx",
-		Container: "container8",
+		Cluster:    "cluster2",
+		Namespace:  "namespace3",
+		Pod:        "pod-vwx",
+		Container:  "container8",
 		ProviderID: "node3",
 	})
 
 	a23vwx9 := NewUnitAllocation("cluster2/namespace3/pod-vwx/container9", start, day, &AllocationProperties{
-		Cluster:   "cluster2",
-		Namespace: "namespace3",
-		Pod:       "pod-vwx",
-		Container: "container9",
+		Cluster:    "cluster2",
+		Namespace:  "namespace3",
+		Pod:        "pod-vwx",
+		Container:  "container9",
 		ProviderID: "node3",
 	})
 
@@ -711,7 +711,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 	)
 }
 
-func generateAssetSets(start, end time.Time) []*AssetSet{
+func generateAssetSets(start, end time.Time) []*AssetSet {
 	var assetSets []*AssetSet
 
 	// Create an AssetSet representing cluster costs for two clusters (cluster1
@@ -1669,13 +1669,12 @@ func TestAllocationSet_ComputeIdleAllocations(t *testing.T) {
 
 	cases := map[string]struct {
 		allocationSet *AllocationSet
-		assetSet *AssetSet
-		clusters map[string]Allocation
-
+		assetSet      *AssetSet
+		clusters      map[string]Allocation
 	}{
-		"1a" : {
+		"1a": {
 			allocationSet: as,
-			assetSet: assetSets[0],
+			assetSet:      assetSets[0],
 			clusters: map[string]Allocation{
 				"cluster1": {
 					CPUCost: 44.0,
@@ -1689,9 +1688,9 @@ func TestAllocationSet_ComputeIdleAllocations(t *testing.T) {
 				},
 			},
 		},
-		"1b" : {
+		"1b": {
 			allocationSet: as,
-			assetSet: assetSets[1],
+			assetSet:      assetSets[1],
 			clusters: map[string]Allocation{
 				"cluster1": {
 					CPUCost: 44.0,
@@ -1757,13 +1756,12 @@ func TestAllocationSet_ReconcileAllocations(t *testing.T) {
 
 	cases := map[string]struct {
 		allocationSet *AllocationSet
-		assetSet *AssetSet
-		allocations map[string]Allocation
-
+		assetSet      *AssetSet
+		allocations   map[string]Allocation
 	}{
-		"1a" : {
+		"1a": {
 			allocationSet: as,
-			assetSet: assetSets[0],
+			assetSet:      assetSets[0],
 			allocations: map[string]Allocation{
 				// Allocation adjustments are found with the formula:
 				// ADJUSTMENT_RATE * NODE_COST * (ALLOC_HOURS / NODE_HOURS) - ALLOC_COST
@@ -1854,9 +1852,9 @@ func TestAllocationSet_ReconcileAllocations(t *testing.T) {
 				},
 			},
 		},
-		"1b" : {
+		"1b": {
 			allocationSet: as,
-			assetSet: assetSets[1],
+			assetSet:      assetSets[1],
 			allocations: map[string]Allocation{
 				// ADJUSTMENT_RATE: 10
 				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -112,14 +112,17 @@ func TestAllocation_Add(t *testing.T) {
 		CPUCoreRequestAverage:  2.0,
 		CPUCoreUsageAverage:    1.0,
 		CPUCost:                2.0 * hrs1 * cpuPrice,
+		CPUAdjustment:          3.0,
 		GPUHours:               1.0 * hrs1,
 		GPUCost:                1.0 * hrs1 * gpuPrice,
+		GPUAdjustment:          2.0,
 		PVByteHours:            100.0 * gib * hrs1,
 		PVCost:                 100.0 * hrs1 * pvPrice,
 		RAMByteHours:           8.0 * gib * hrs1,
 		RAMBytesRequestAverage: 8.0 * gib,
 		RAMBytesUsageAverage:   4.0 * gib,
 		RAMCost:                8.0 * hrs1 * ramPrice,
+		RAMAdjustment:          1.0,
 		SharedCost:             2.00,
 		ExternalCost:           1.00,
 		RawAllocationOnly:      &RawAllocationOnlyData{},
@@ -173,11 +176,20 @@ func TestAllocation_Add(t *testing.T) {
 	if !util.IsApproximately(a1.CPUCost+a2.CPUCost, act.CPUCost) {
 		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.CPUCost+a2.CPUCost, act.CPUCost)
 	}
+	if !util.IsApproximately(a1.CPUAdjustment+a2.CPUAdjustment, act.CPUAdjustment) {
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.CPUAdjustment+a2.CPUAdjustment, act.CPUAdjustment)
+	}
 	if !util.IsApproximately(a1.GPUCost+a2.GPUCost, act.GPUCost) {
 		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.GPUCost+a2.GPUCost, act.GPUCost)
 	}
+	if !util.IsApproximately(a1.GPUAdjustment+a2.GPUAdjustment, act.GPUAdjustment) {
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.GPUAdjustment+a2.GPUAdjustment, act.GPUAdjustment)
+	}
 	if !util.IsApproximately(a1.RAMCost+a2.RAMCost, act.RAMCost) {
 		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.RAMCost+a2.RAMCost, act.RAMCost)
+	}
+	if !util.IsApproximately(a1.RAMAdjustment+a2.RAMAdjustment, act.RAMAdjustment) {
+		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.RAMAdjustment+a2.RAMAdjustment, act.RAMAdjustment)
 	}
 	if !util.IsApproximately(a1.PVCost+a2.PVCost, act.PVCost) {
 		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.PVCost+a2.PVCost, act.PVCost)
@@ -242,8 +254,8 @@ func TestAllocation_Add(t *testing.T) {
 	if !util.IsApproximately(2.0000000, act.RAMEfficiency()) {
 		t.Fatalf("Allocation.Add: expected %f; actual %f", 2.0000000, act.RAMEfficiency())
 	}
-	if !util.IsApproximately(1.6493506, act.TotalEfficiency()) {
-		t.Fatalf("Allocation.Add: expected %f; actual %f", 1.6493506, act.TotalEfficiency())
+	if !util.IsApproximately(1.279690, act.TotalEfficiency()) {
+		t.Fatalf("Allocation.Add: expected %f; actual %f", 1.279690, act.TotalEfficiency())
 	}
 
 	if act.RawAllocationOnly != nil {
@@ -269,14 +281,17 @@ func TestAllocation_Share(t *testing.T) {
 		CPUCoreRequestAverage:  2.0,
 		CPUCoreUsageAverage:    1.0,
 		CPUCost:                2.0 * hrs1 * cpuPrice,
+		CPUAdjustment:          3.0,
 		GPUHours:               1.0 * hrs1,
 		GPUCost:                1.0 * hrs1 * gpuPrice,
+		GPUAdjustment:          2.0,
 		PVByteHours:            100.0 * gib * hrs1,
 		PVCost:                 100.0 * hrs1 * pvPrice,
 		RAMByteHours:           8.0 * gib * hrs1,
 		RAMBytesRequestAverage: 8.0 * gib,
 		RAMBytesUsageAverage:   4.0 * gib,
 		RAMCost:                8.0 * hrs1 * ramPrice,
+		RAMAdjustment:          1.0,
 		SharedCost:             2.00,
 		ExternalCost:           1.00,
 	}
@@ -330,14 +345,14 @@ func TestAllocation_Share(t *testing.T) {
 	}
 
 	// Costs should match before (expect TotalCost and SharedCost)
-	if !util.IsApproximately(a1.CPUCost, act.CPUCost) {
-		t.Fatalf("Allocation.Share: expected %f; actual %f", a1.CPUCost, act.CPUCost)
+	if !util.IsApproximately(a1.CPUTotalCost(), act.CPUTotalCost()) {
+		t.Fatalf("Allocation.Share: expected %f; actual %f", a1.CPUTotalCost(), act.CPUTotalCost())
 	}
-	if !util.IsApproximately(a1.GPUCost, act.GPUCost) {
-		t.Fatalf("Allocation.Share: expected %f; actual %f", a1.GPUCost, act.GPUCost)
+	if !util.IsApproximately(a1.GPUTotalCost(), act.GPUTotalCost()) {
+		t.Fatalf("Allocation.Share: expected %f; actual %f", a1.GPUTotalCost(), act.GPUTotalCost())
 	}
-	if !util.IsApproximately(a1.RAMCost, act.RAMCost) {
-		t.Fatalf("Allocation.Share: expected %f; actual %f", a1.RAMCost, act.RAMCost)
+	if !util.IsApproximately(a1.RAMTotalCost(), act.RAMTotalCost()) {
+		t.Fatalf("Allocation.Share: expected %f; actual %f", a1.RAMTotalCost(), act.RAMTotalCost())
 	}
 	if !util.IsApproximately(a1.PVCost, act.PVCost) {
 		t.Fatalf("Allocation.Share: expected %f; actual %f", a1.PVCost, act.PVCost)
@@ -425,8 +440,10 @@ func TestAllocation_MarshalJSON(t *testing.T) {
 		CPUCoreRequestAverage:  2.0,
 		CPUCoreUsageAverage:    1.0,
 		CPUCost:                2.0 * hrs * cpuPrice,
+		CPUAdjustment:          3.0,
 		GPUHours:               1.0 * hrs,
 		GPUCost:                1.0 * hrs * gpuPrice,
+		GPUAdjustment:          2.0,
 		NetworkCost:            0.05,
 		LoadBalancerCost:       0.02,
 		PVByteHours:            100.0 * gib * hrs,
@@ -435,6 +452,7 @@ func TestAllocation_MarshalJSON(t *testing.T) {
 		RAMBytesRequestAverage: 8.0 * gib,
 		RAMBytesUsageAverage:   4.0 * gib,
 		RAMCost:                8.0 * hrs * ramPrice,
+		RAMAdjustment:          1.0,
 		SharedCost:             2.00,
 		ExternalCost:           1.00,
 		RawAllocationOnly:      &RawAllocationOnlyData{},
@@ -521,6 +539,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 	a1i := NewUnitAllocation(fmt.Sprintf("cluster1/%s", IdleSuffix), start, day, &AllocationProperties{
 		Cluster: "cluster1",
 		Node:    "node1",
+		ProviderID: "c1nodes",
 	})
 	a1i.CPUCost = 5.0
 	a1i.RAMCost = 15.0
@@ -539,6 +558,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace1",
 		Pod:       "pod1",
 		Container: "container1",
+		ProviderID: "c1nodes",
 	})
 	a1111.RAMCost = 11.00
 
@@ -547,6 +567,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace1",
 		Pod:       "pod-abc",
 		Container: "container2",
+		ProviderID: "c1nodes",
 	})
 
 	a11def3 := NewUnitAllocation("cluster1/namespace1/pod-def/container3", start, day, &AllocationProperties{
@@ -554,6 +575,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace1",
 		Pod:       "pod-def",
 		Container: "container3",
+		ProviderID: "c1nodes",
 	})
 
 	a12ghi4 := NewUnitAllocation("cluster1/namespace2/pod-ghi/container4", start, day, &AllocationProperties{
@@ -561,6 +583,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace2",
 		Pod:       "pod-ghi",
 		Container: "container4",
+		ProviderID: "c1nodes",
 	})
 
 	a12ghi5 := NewUnitAllocation("cluster1/namespace2/pod-ghi/container5", start, day, &AllocationProperties{
@@ -568,6 +591,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace2",
 		Pod:       "pod-ghi",
 		Container: "container5",
+		ProviderID: "c1nodes",
 	})
 
 	a12jkl6 := NewUnitAllocation("cluster1/namespace2/pod-jkl/container6", start, day, &AllocationProperties{
@@ -575,6 +599,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace2",
 		Pod:       "pod-jkl",
 		Container: "container6",
+		ProviderID: "c1nodes",
 	})
 
 	a22mno4 := NewUnitAllocation("cluster2/namespace2/pod-mno/container4", start, day, &AllocationProperties{
@@ -582,6 +607,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace2",
 		Pod:       "pod-mno",
 		Container: "container4",
+		ProviderID: "node1",
 	})
 
 	a22mno5 := NewUnitAllocation("cluster2/namespace2/pod-mno/container5", start, day, &AllocationProperties{
@@ -589,6 +615,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace2",
 		Pod:       "pod-mno",
 		Container: "container5",
+		ProviderID: "node1",
 	})
 
 	a22pqr6 := NewUnitAllocation("cluster2/namespace2/pod-pqr/container6", start, day, &AllocationProperties{
@@ -596,6 +623,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace2",
 		Pod:       "pod-pqr",
 		Container: "container6",
+		ProviderID: "node2",
 	})
 
 	a23stu7 := NewUnitAllocation("cluster2/namespace3/pod-stu/container7", start, day, &AllocationProperties{
@@ -603,6 +631,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace3",
 		Pod:       "pod-stu",
 		Container: "container7",
+		ProviderID: "node2",
 	})
 
 	a23vwx8 := NewUnitAllocation("cluster2/namespace3/pod-vwx/container8", start, day, &AllocationProperties{
@@ -610,6 +639,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace3",
 		Pod:       "pod-vwx",
 		Container: "container8",
+		ProviderID: "node3",
 	})
 
 	a23vwx9 := NewUnitAllocation("cluster2/namespace3/pod-vwx/container9", start, day, &AllocationProperties{
@@ -617,6 +647,7 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		Namespace: "namespace3",
 		Pod:       "pod-vwx",
 		Container: "container9",
+		ProviderID: "node3",
 	})
 
 	// Controllers
@@ -678,6 +709,149 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 		// cluster 2, namespace 3
 		a23stu7, a23vwx8, a23vwx9,
 	)
+}
+
+func generateAssetSets(start, end time.Time) []*AssetSet{
+	var assetSets []*AssetSet
+
+	// Create an AssetSet representing cluster costs for two clusters (cluster1
+	// and cluster2). Include Nodes and Disks for both, even though only
+	// Nodes will be counted. Whereas in practice, Assets should be aggregated
+	// by type, here we will provide multiple Nodes for one of the clusters to
+	// make sure the function still holds.
+
+	// NOTE: we're re-using generateAllocationSet so this has to line up with
+	// the allocated node costs from that function. See table above.
+
+	// | Hierarchy                               | Cost |  CPU |  RAM |  GPU | Adjustment |
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster1:
+	//     nodes                                  100.00  55.00  44.00  11.00      -10.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster1 subtotal (adjusted)             100.00  50.00  40.00  10.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster1 allocated                        48.00   6.00  16.00   6.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster1 idle                             72.00  44.00  24.00   4.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster2:
+	//     node1                                   35.00  20.00  15.00   0.00        0.00
+	//     node2                                   35.00  20.00  15.00   0.00        0.00
+	//     node3                                   30.00  10.00  10.00  10.00        0.00
+	//     (disks should not matter for idle)
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster2 subtotal                        100.00  50.00  40.00  10.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster2 allocated                        28.00   6.00   6.00   6.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster2 idle                             82.00  44.00  34.00   4.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+
+	cluster1Nodes := NewNode("", "cluster1", "c1nodes", start, end, NewWindow(&start, &end))
+	cluster1Nodes.CPUCost = 55.0
+	cluster1Nodes.RAMCost = 44.0
+	cluster1Nodes.GPUCost = 11.0
+	cluster1Nodes.adjustment = -10.00
+	cluster1Nodes.CPUCoreHours = 8
+	cluster1Nodes.RAMByteHours = 6
+	cluster1Nodes.GPUCount = 1
+
+	cluster2Node1 := NewNode("node1", "cluster2", "node1", start, end, NewWindow(&start, &end))
+	cluster2Node1.CPUCost = 20.0
+	cluster2Node1.RAMCost = 15.0
+	cluster2Node1.GPUCost = 0.0
+	cluster2Node1.CPUCoreHours = 4
+	cluster2Node1.RAMByteHours = 3
+	cluster2Node1.GPUCount = 0
+
+	cluster2Node2 := NewNode("node2", "cluster2", "node2", start, end, NewWindow(&start, &end))
+	cluster2Node2.CPUCost = 20.0
+	cluster2Node2.RAMCost = 15.0
+	cluster2Node2.GPUCost = 0.0
+	cluster2Node2.CPUCoreHours = 3
+	cluster2Node2.RAMByteHours = 2
+	cluster2Node2.GPUCount = 0
+
+	cluster2Node3 := NewNode("node3", "cluster2", "node3", start, end, NewWindow(&start, &end))
+	cluster2Node3.CPUCost = 10.0
+	cluster2Node3.RAMCost = 10.0
+	cluster2Node3.GPUCost = 10.0
+	cluster2Node3.CPUCoreHours = 2
+	cluster2Node3.RAMByteHours = 2
+	cluster2Node3.GPUCount = 1
+
+	cluster2Disk1 := NewDisk("disk1", "cluster2", "disk1", start, end, NewWindow(&start, &end))
+	cluster2Disk1.Cost = 5.0
+
+	assetSet1 := NewAssetSet(start, end, cluster1Nodes, cluster2Node1, cluster2Node2, cluster2Node3, cluster2Disk1)
+	assetSets = append(assetSets, assetSet1)
+
+	// NOTE: we're re-using generateAllocationSet so this has to line up with
+	// the allocated node costs from that function. See table above.
+
+	// | Hierarchy                               | Cost |  CPU |  RAM |  GPU | Adjustment |
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster1:
+	//     nodes                                  100.00   5.00   4.00   1.00       90.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster1 subtotal (adjusted)             100.00  50.00  40.00  10.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster1 allocated                        48.00   6.00  16.00   6.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster1 idle                             72.00  44.00  24.00   4.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster2:
+	//     node1                                   35.00  20.00  15.00   0.00        0.00
+	//     node2                                   35.00  20.00  15.00   0.00        0.00
+	//     node3                                   30.00  10.00  10.00  10.00        0.00
+	//     (disks should not matter for idle)
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster2 subtotal                        100.00  50.00  40.00  10.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster2 allocated                        28.00   6.00   6.00   6.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+	//   cluster2 idle                             82.00  44.00  34.00   4.00        0.00
+	// +-----------------------------------------+------+------+------+------+------------+
+
+	cluster1Nodes = NewNode("", "cluster1", "c1nodes", start, end, NewWindow(&start, &end))
+	cluster1Nodes.CPUCost = 5.0
+	cluster1Nodes.RAMCost = 4.0
+	cluster1Nodes.GPUCost = 1.0
+	cluster1Nodes.adjustment = 90.00
+	cluster1Nodes.CPUCoreHours = 8
+	cluster1Nodes.RAMByteHours = 6
+	cluster1Nodes.GPUCount = 1
+
+	cluster2Node1 = NewNode("node1", "cluster2", "node1", start, end, NewWindow(&start, &end))
+	cluster2Node1.CPUCost = 20.0
+	cluster2Node1.RAMCost = 15.0
+	cluster2Node1.GPUCost = 0.0
+	cluster2Node1.CPUCoreHours = 4
+	cluster2Node1.RAMByteHours = 3
+	cluster2Node1.GPUCount = 0
+
+	cluster2Node2 = NewNode("node2", "cluster2", "node2", start, end, NewWindow(&start, &end))
+	cluster2Node2.CPUCost = 20.0
+	cluster2Node2.RAMCost = 15.0
+	cluster2Node2.GPUCost = 0.0
+	cluster2Node2.CPUCoreHours = 3
+	cluster2Node2.RAMByteHours = 2
+	cluster2Node2.GPUCount = 0
+
+	cluster2Node3 = NewNode("node3", "cluster2", "node3", start, end, NewWindow(&start, &end))
+	cluster2Node3.CPUCost = 10.0
+	cluster2Node3.RAMCost = 10.0
+	cluster2Node3.GPUCost = 10.0
+	cluster2Node3.CPUCoreHours = 2
+	cluster2Node3.RAMByteHours = 2
+	cluster2Node3.GPUCount = 1
+
+	cluster2Disk1 = NewDisk("disk1", "cluster2", "disk1", start, end, NewWindow(&start, &end))
+	cluster2Disk1.Cost = 5.0
+
+	assetSet2 := NewAssetSet(start, end, cluster1Nodes, cluster2Node1, cluster2Node2, cluster2Node3, cluster2Disk1)
+	assetSets = append(assetSets, assetSet2)
+	return assetSets
 }
 
 func assertAllocationSetTotals(t *testing.T, as *AllocationSet, msg string, err error, length int, totalCost float64) {
@@ -1491,187 +1665,313 @@ func TestAllocationSet_ComputeIdleAllocations(t *testing.T) {
 		as.Delete(key)
 	}
 
-	// Create an AssetSet representing cluster costs for two clusters (cluster1
-	// and cluster2). Include Nodes and Disks for both, even though only
-	// Nodes will be counted. Whereas in practice, Assets should be aggregated
-	// by type, here we will provide multiple Nodes for one of the clusters to
-	// make sure the function still holds.
+	assetSets := generateAssetSets(start, end)
 
-	// NOTE: we're re-using generateAllocationSet so this has to line up with
-	// the allocated node costs from that function. See table above.
+	cases := map[string]struct {
+		allocationSet *AllocationSet
+		assetSet *AssetSet
+		clusters map[string]Allocation
 
-	// | Hierarchy                               | Cost |  CPU |  RAM |  GPU | Adjustment |
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster1:
-	//     nodes                                  100.00  55.00  44.00  11.00      -10.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster1 subtotal (adjusted)             100.00  50.00  40.00  10.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster1 allocated                        48.00   6.00  16.00   6.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster1 idle                             72.00  44.00  24.00   4.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster2:
-	//     node1                                   35.00  20.00  15.00   0.00        0.00
-	//     node2                                   35.00  20.00  15.00   0.00        0.00
-	//     node3                                   30.00  10.00  10.00  10.00        0.00
-	//     (disks should not matter for idle)
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster2 subtotal                        100.00  50.00  40.00  10.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster2 allocated                        28.00   6.00   6.00   6.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster2 idle                             82.00  44.00  34.00   4.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-
-	cluster1Nodes := NewNode("", "cluster1", "", start, end, NewWindow(&start, &end))
-	cluster1Nodes.CPUCost = 55.0
-	cluster1Nodes.RAMCost = 44.0
-	cluster1Nodes.GPUCost = 11.0
-	cluster1Nodes.adjustment = -10.00
-
-	cluster2Node1 := NewNode("node1", "cluster2", "node1", start, end, NewWindow(&start, &end))
-	cluster2Node1.CPUCost = 20.0
-	cluster2Node1.RAMCost = 15.0
-	cluster2Node1.GPUCost = 0.0
-
-	cluster2Node2 := NewNode("node2", "cluster2", "node2", start, end, NewWindow(&start, &end))
-	cluster2Node2.CPUCost = 20.0
-	cluster2Node2.RAMCost = 15.0
-	cluster2Node2.GPUCost = 0.0
-
-	cluster2Node3 := NewNode("node3", "cluster2", "node3", start, end, NewWindow(&start, &end))
-	cluster2Node3.CPUCost = 10.0
-	cluster2Node3.RAMCost = 10.0
-	cluster2Node3.GPUCost = 10.0
-
-	cluster2Disk1 := NewDisk("disk1", "cluster2", "disk1", start, end, NewWindow(&start, &end))
-	cluster2Disk1.Cost = 5.0
-
-	assetSet := NewAssetSet(start, end, cluster1Nodes, cluster2Node1, cluster2Node2, cluster2Node3, cluster2Disk1)
-
-	idles, err = as.ComputeIdleAllocations(assetSet)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	}{
+		"1a" : {
+			allocationSet: as,
+			assetSet: assetSets[0],
+			clusters: map[string]Allocation{
+				"cluster1": {
+					CPUCost: 44.0,
+					RAMCost: 24.0,
+					GPUCost: 4.0,
+				},
+				"cluster2": {
+					CPUCost: 44.0,
+					RAMCost: 34.0,
+					GPUCost: 4.0,
+				},
+			},
+		},
+		"1b" : {
+			allocationSet: as,
+			assetSet: assetSets[1],
+			clusters: map[string]Allocation{
+				"cluster1": {
+					CPUCost: 44.0,
+					RAMCost: 24.0,
+					GPUCost: 4.0,
+				},
+				"cluster2": {
+					CPUCost: 44.0,
+					RAMCost: 34.0,
+					GPUCost: 4.0,
+				},
+			},
+		},
 	}
 
-	if len(idles) != 2 {
-		t.Fatalf("idles: expected length %d; got length %d", 2, len(idles))
+	for name, testcase := range cases {
+		t.Run(name, func(t *testing.T) {
+			idles, err = as.ComputeIdleAllocations(testcase.assetSet)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if len(idles) != len(testcase.clusters) {
+				t.Fatalf("idles: expected length %d; got length %d", len(testcase.clusters), len(idles))
+			}
+
+			for clusterName, cluster := range testcase.clusters {
+				if idle, ok := idles[clusterName]; !ok {
+					t.Fatalf("expected idle cost for %s", clusterName)
+				} else {
+					if !util.IsApproximately(idle.TotalCost(), cluster.TotalCost()) {
+						t.Fatalf("%s idle: expected total cost %f; got total cost %f", clusterName, cluster.TotalCost(), idle.TotalCost())
+					}
+				}
+				if !util.IsApproximately(idles[clusterName].CPUCost, cluster.CPUCost) {
+					t.Fatalf("expected idle CPU cost for %s to be %.2f; got %.2f", clusterName, cluster.CPUCost, idles[clusterName].CPUCost)
+				}
+				if !util.IsApproximately(idles[clusterName].RAMCost, cluster.RAMCost) {
+					t.Fatalf("expected idle RAM cost for %s to be %.2f; got %.2f", clusterName, cluster.RAMCost, idles[clusterName].RAMCost)
+				}
+				if !util.IsApproximately(idles[clusterName].GPUCost, cluster.GPUCost) {
+					t.Fatalf("expected idle GPU cost for %s to be %.2f; got %.2f", clusterName, cluster.GPUCost, idles[clusterName].GPUCost)
+				}
+			}
+		})
+	}
+}
+
+func TestAllocationSet_ReconcileAllocations(t *testing.T) {
+	var as *AllocationSet
+	var err error
+
+	end := time.Now().UTC().Truncate(day)
+	start := end.Add(-day)
+
+	// Generate AllocationSet and strip out any existing idle allocations
+	as = generateAllocationSet(start)
+	for key := range as.idleKeys {
+		as.Delete(key)
 	}
 
-	if idle, ok := idles["cluster1"]; !ok {
-		t.Fatalf("expected idle cost for %s", "cluster1")
-	} else {
-		if !util.IsApproximately(idle.TotalCost(), 72.0) {
-			t.Fatalf("%s idle: expected total cost %f; got total cost %f", "cluster1", 72.0, idle.TotalCost())
-		}
+	assetSets := generateAssetSets(start, end)
+
+	cases := map[string]struct {
+		allocationSet *AllocationSet
+		assetSet *AssetSet
+		allocations map[string]Allocation
+
+	}{
+		"1a" : {
+			allocationSet: as,
+			assetSet: assetSets[0],
+			allocations: map[string]Allocation{
+				// Allocation adjustments are found with the formula:
+				// ADJUSTMENT_RATE * NODE_COST * (ALLOC_HOURS / NODE_HOURS) - ALLOC_COST
+				// ADJUSTMENT_RATE: 0.90909090909
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|    55	    |	  8	     |     1 	  |	  1
+				// RAM	|    44	    |	  6	     |     11 	  |	  1
+				// GPU	|    11	    |	 24      |     1 	  |	  1
+				"cluster1/namespace1/pod1/container1": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: -4.333333,
+					GPUAdjustment: -0.583333,
+				},
+				// ADJUSTMENT_RATE: 0.90909090909
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|    55	    |	  8	     |     1 	  |	  1
+				// RAM	|    44	    |	  6	     |     1 	  |	  1
+				// GPU	|    11	    |	 24      |     1 	  |	  1
+				"cluster1/namespace1/pod-abc/container2": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.666667,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster1/namespace1/pod-def/container3": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.666667,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster1/namespace2/pod-ghi/container4": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.666667,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster1/namespace2/pod-ghi/container5": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.666667,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster1/namespace2/pod-jkl/container6": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.666667,
+					GPUAdjustment: -0.583333,
+				},
+				// ADJUSTMENT_RATE: 1.0
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|    20	    |	  4	     |     1 	  |	  1
+				// RAM	|    15	    |	  3	     |     1 	  |	  1
+				// GPU	|    0	    |	  0      |     1 	  |	  1
+				"cluster2/namespace2/pod-mno/container4": {
+					CPUAdjustment: 4.0,
+					RAMAdjustment: 4.0,
+					GPUAdjustment: -1.0,
+				},
+				"cluster2/namespace2/pod-mno/container5": {
+					CPUAdjustment: 4.0,
+					RAMAdjustment: 4.0,
+					GPUAdjustment: -1.0,
+				},
+				// ADJUSTMENT_RATE: 1.0
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|    20	    |	  3	     |     1 	  |	  1
+				// RAM	|    15	    |	  2	     |     1 	  |	  1
+				// GPU	|    0	    |	  0      |     1 	  |	  1
+				"cluster2/namespace2/pod-pqr/container6": {
+					CPUAdjustment: 5.666667,
+					RAMAdjustment: 6.5,
+					GPUAdjustment: -1.0,
+				},
+				"cluster2/namespace3/pod-stu/container7": {
+					CPUAdjustment: 5.666667,
+					RAMAdjustment: 6.5,
+					GPUAdjustment: -1.0,
+				},
+				// ADJUSTMENT_RATE: 1.0
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|    10	    |	  2	     |     1 	  |	  1
+				// RAM	|    10	    |	  2	     |     1 	  |	  1
+				// GPU	|    10	    |	 24      |     1 	  |	  1
+				"cluster2/namespace3/pod-vwx/container8": {
+					CPUAdjustment: 4.0,
+					RAMAdjustment: 4.0,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster2/namespace3/pod-vwx/container9": {
+					CPUAdjustment: 4.0,
+					RAMAdjustment: 4.0,
+					GPUAdjustment: -0.583333,
+				},
+			},
+		},
+		"1b" : {
+			allocationSet: as,
+			assetSet: assetSets[1],
+			allocations: map[string]Allocation{
+				// ADJUSTMENT_RATE: 10
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|     5	    |	  8	     |     1 	  |	  1
+				// RAM	|     4	    |	  6	     |    11 	  |	  1
+				// GPU	|     1	    |	 24      |     1 	  |	  1
+				"cluster1/namespace1/pod1/container1": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: -4.333333,
+					GPUAdjustment: -0.583333,
+				},
+				// ADJUSTMENT_RATE: 10
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|     5	    |	  8	     |     1 	  |	  1
+				// RAM	|     4	    |	  6	     |     1 	  |	  1
+				// GPU	|     1	    |	 24      |     1 	  |	  1
+				"cluster1/namespace1/pod-abc/container2": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.6666667,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster1/namespace1/pod-def/container3": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.6666667,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster1/namespace2/pod-ghi/container4": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.6666667,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster1/namespace2/pod-ghi/container5": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.6666667,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster1/namespace2/pod-jkl/container6": {
+					CPUAdjustment: 5.25,
+					RAMAdjustment: 5.6666667,
+					GPUAdjustment: -0.583333,
+				},
+				// ADJUSTMENT_RATE: 1.0
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|    20	    |	  4	     |     1 	  |	  1
+				// RAM	|    15	    |	  3	     |     1 	  |	  1
+				// GPU	|    0	    |	  0      |     1 	  |	  1
+				"cluster2/namespace2/pod-mno/container4": {
+					CPUAdjustment: 4.0,
+					RAMAdjustment: 4.0,
+					GPUAdjustment: -1.0,
+				},
+				"cluster2/namespace2/pod-mno/container5": {
+					CPUAdjustment: 4.0,
+					RAMAdjustment: 4.0,
+					GPUAdjustment: -1.0,
+				},
+				// ADJUSTMENT_RATE: 1.0
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|    20	    |	  3	     |     1 	  |	  1
+				// RAM	|    15	    |	  2	     |     1 	  |	  1
+				// GPU	|    0	    |	  0      |     1 	  |	  1
+				"cluster2/namespace2/pod-pqr/container6": {
+					CPUAdjustment: 5.666667,
+					RAMAdjustment: 6.5,
+					GPUAdjustment: -1.0,
+				},
+				"cluster2/namespace3/pod-stu/container7": {
+					CPUAdjustment: 5.666667,
+					RAMAdjustment: 6.5,
+					GPUAdjustment: -1.0,
+				},
+				// ADJUSTMENT_RATE: 1.0
+				// Type | NODE_COST | NODE_HOURs | ALLOC_COST | ALLOC_HOURS
+				// CPU	|    10	    |	  2	     |     1 	  |	  1
+				// RAM	|    10	    |	  2	     |     1 	  |	  1
+				// GPU	|    10	    |	 24      |     1 	  |	  1
+				"cluster2/namespace3/pod-vwx/container8": {
+					CPUAdjustment: 4.0,
+					RAMAdjustment: 4.0,
+					GPUAdjustment: -0.583333,
+				},
+				"cluster2/namespace3/pod-vwx/container9": {
+					CPUAdjustment: 4.0,
+					RAMAdjustment: 4.0,
+					GPUAdjustment: -0.583333,
+				},
+			},
+		},
 	}
-	if !util.IsApproximately(idles["cluster1"].CPUCost, 44.0) {
-		t.Fatalf("expected idle CPU cost for %s to be %.2f; got %.2f", "cluster1", 44.0, idles["cluster1"].CPUCost)
+
+	for name, testcase := range cases {
+		t.Run(name, func(t *testing.T) {
+			err = as.ReconcileAllocations(testcase.assetSet)
+			reconAllocs := as.allocations
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			for allocationName, testAlloc := range testcase.allocations {
+				if _, ok := reconAllocs[allocationName]; !ok {
+					t.Fatalf("expected allocation %s", allocationName)
+				}
+
+				if !util.IsApproximately(reconAllocs[allocationName].CPUAdjustment, testAlloc.CPUAdjustment) {
+					t.Fatalf("expected CPU Adjustment for %s to be %f; got %f", allocationName, testAlloc.CPUAdjustment, reconAllocs[allocationName].CPUAdjustment)
+				}
+				if !util.IsApproximately(reconAllocs[allocationName].RAMAdjustment, testAlloc.RAMAdjustment) {
+					t.Fatalf("expected RAM Adjustment for %s to be %f; got %f", allocationName, testAlloc.RAMAdjustment, reconAllocs[allocationName].RAMAdjustment)
+				}
+				if !util.IsApproximately(reconAllocs[allocationName].GPUAdjustment, testAlloc.GPUAdjustment) {
+					t.Fatalf("expected GPU Adjustment for %s to be %f; got %f", allocationName, testAlloc.GPUAdjustment, reconAllocs[allocationName].GPUAdjustment)
+				}
+			}
+		})
 	}
-	if !util.IsApproximately(idles["cluster1"].RAMCost, 24.0) {
-		t.Fatalf("expected idle RAM cost for %s to be %.2f; got %.2f", "cluster1", 24.0, idles["cluster1"].RAMCost)
-	}
-	if !util.IsApproximately(idles["cluster1"].GPUCost, 4.0) {
-		t.Fatalf("expected idle GPU cost for %s to be %.2f; got %.2f", "cluster1", 4.0, idles["cluster1"].GPUCost)
-	}
-
-	if idle, ok := idles["cluster2"]; !ok {
-		t.Fatalf("expected idle cost for %s", "cluster2")
-	} else {
-		if !util.IsApproximately(idle.TotalCost(), 82.0) {
-			t.Fatalf("%s idle: expected total cost %f; got total cost %f", "cluster2", 82.0, idle.TotalCost())
-		}
-	}
-
-	// NOTE: we're re-using generateAllocationSet so this has to line up with
-	// the allocated node costs from that function. See table above.
-
-	// | Hierarchy                               | Cost |  CPU |  RAM |  GPU | Adjustment |
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster1:
-	//     nodes                                  100.00   5.00   4.00   1.00       90.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster1 subtotal (adjusted)             100.00  50.00  40.00  10.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster1 allocated                        48.00   6.00  16.00   6.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster1 idle                             72.00  44.00  24.00   4.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster2:
-	//     node1                                   35.00  20.00  15.00   0.00        0.00
-	//     node2                                   35.00  20.00  15.00   0.00        0.00
-	//     node3                                   30.00  10.00  10.00  10.00        0.00
-	//     (disks should not matter for idle)
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster2 subtotal                        100.00  50.00  40.00  10.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster2 allocated                        28.00   6.00   6.00   6.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-	//   cluster2 idle                             82.00  44.00  34.00   4.00        0.00
-	// +-----------------------------------------+------+------+------+------+------------+
-
-	cluster1Nodes = NewNode("", "cluster1", "", start, end, NewWindow(&start, &end))
-	cluster1Nodes.CPUCost = 5.0
-	cluster1Nodes.RAMCost = 4.0
-	cluster1Nodes.GPUCost = 1.0
-	cluster1Nodes.adjustment = 90.00
-
-	cluster2Node1 = NewNode("node1", "cluster2", "node1", start, end, NewWindow(&start, &end))
-	cluster2Node1.CPUCost = 20.0
-	cluster2Node1.RAMCost = 15.0
-	cluster2Node1.GPUCost = 0.0
-
-	cluster2Node2 = NewNode("node2", "cluster2", "node2", start, end, NewWindow(&start, &end))
-	cluster2Node2.CPUCost = 20.0
-	cluster2Node2.RAMCost = 15.0
-	cluster2Node2.GPUCost = 0.0
-
-	cluster2Node3 = NewNode("node3", "cluster2", "node3", start, end, NewWindow(&start, &end))
-	cluster2Node3.CPUCost = 10.0
-	cluster2Node3.RAMCost = 10.0
-	cluster2Node3.GPUCost = 10.0
-
-	cluster2Disk1 = NewDisk("disk1", "cluster2", "disk1", start, end, NewWindow(&start, &end))
-	cluster2Disk1.Cost = 5.0
-
-	assetSet = NewAssetSet(start, end, cluster1Nodes, cluster2Node1, cluster2Node2, cluster2Node3, cluster2Disk1)
-
-	idles, err = as.ComputeIdleAllocations(assetSet)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	if len(idles) != 2 {
-		t.Fatalf("idles: expected length %d; got length %d", 2, len(idles))
-	}
-
-	if idle, ok := idles["cluster1"]; !ok {
-		t.Fatalf("expected idle cost for %s", "cluster1")
-	} else {
-		if !util.IsApproximately(idle.TotalCost(), 72.0) {
-			t.Fatalf("%s idle: expected total cost %f; got total cost %f", "cluster1", 72.0, idle.TotalCost())
-		}
-	}
-	if !util.IsApproximately(idles["cluster1"].CPUCost, 44.0) {
-		t.Fatalf("expected idle CPU cost for %s to be %.2f; got %.2f", "cluster1", 44.0, idles["cluster1"].CPUCost)
-	}
-	if !util.IsApproximately(idles["cluster1"].RAMCost, 24.0) {
-		t.Fatalf("expected idle RAM cost for %s to be %.2f; got %.2f", "cluster1", 24.0, idles["cluster1"].RAMCost)
-	}
-	if !util.IsApproximately(idles["cluster1"].GPUCost, 4.0) {
-		t.Fatalf("expected idle GPU cost for %s to be %.2f; got %.2f", "cluster1", 4.0, idles["cluster1"].GPUCost)
-	}
-
-	if idle, ok := idles["cluster2"]; !ok {
-		t.Fatalf("expected idle cost for %s", "cluster2")
-	} else {
-		if !util.IsApproximately(idle.TotalCost(), 82.0) {
-			t.Fatalf("%s idle: expected total cost %f; got total cost %f", "cluster2", 82.0, idle.TotalCost())
-		}
-	}
-
-	// TODO assert value of each resource cost precisely
 }
 
 // TODO niko/etl

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -1,12 +1,14 @@
 package json
 
 import (
-    "encoding/json"
+	"encoding/json"
 
-    jsoniter "github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var Marshal = jsoniter.ConfigCompatibleWithStandardLibrary.Marshal
 var Unmarshal = jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal
+
 type Marshaler json.Marshaler
+
 var NewDecoder = json.NewDecoder


### PR DESCRIPTION
Closed-Source PR: https://github.com/kubecost/kubecost-cost-model/pull/382
Add Query time reconciliation from Asset ETL to Allocation ETL. By matching ProviderId of Node Asset with the provider id of an Allocation's node pulled from Prometheus metric, pull reconciled CPU, GPU and RAM data into allocations based on usage hours of the Allocation. This reconciled cost data is then saved in new fields in the Allocation struct called cpuAdjustment, ramAdjustment and gpuAdjustment. Reconciliation requires that the flag `reconciliation` is set to true on the in queries to the Allocation ETL. This value is by default set to false
Methodology: 
Nodes have available usage stats in the form of cpuCoreHours, ramByteHours which are derived from the amount of cpuCore and ramBytes and the run time of the node within the window of the asset. the metric GPUHours can be derived in a similar way using gpuCount. Allocations have the same metrics that show their resource usage over the window (cpuCoreHours, ramByteHours, gpuHours) Given that an allocation runs on a single node and its run time must be a subset of that of the node that it runs on, and its resource (CPU, GPU, RAM) usage a subset of the resources available on the node which it runs on within a given window. Then the ratio of allocation resource hours by node resource hours multiplied by the total cost of that resource on the node within that window is the correct cost for that resource on the Allocation. The difference between this price and the previously predicted price is set to the resource adjustment field of the Allocation and passed along to the front end for use.
Testing:
Added additional Unit tests which measure the adjustments made on resources after the allocation reconciliation method is run.
Tested On AWS cluster:
Set reconciliation flag to always true and explored results for various aggregations of allocations. At the node level adjustments were not displayed because of accurate original pricing prediction on on-demand nodes. This was verified by calculating value using methodology. One case of an adjustment being applied was 4/16/21 when the allocation for deployment:kubecost-cost-analyzer had its cpu price over estimated. The adjustment brought it back down to the appropriate value. Which is approximately equal to the correct values which continued the next day allowing for slight differences in the other values.
![Screen Shot 2021-04-22 at 3 44 06 PM](https://user-images.githubusercontent.com/12225425/115794575-126b5780-a383-11eb-9686-c4e314294378.png)
![Screen Shot 2021-04-22 at 3 45 09 PM](https://user-images.githubusercontent.com/12225425/115794576-1303ee00-a383-11eb-9fca-315606200afa.png)

