### PR TITLE
Alternate source for PV provider ID on aws

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -516,6 +516,8 @@ func (aws *AWS) GetPVKey(pv *v1.PersistentVolume, parameters map[string]string, 
 	providerID := ""
 	if pv.Spec.AWSElasticBlockStore != nil {
 		providerID = pv.Spec.AWSElasticBlockStore.VolumeID
+	} else if pv.Spec.CSI != nil {
+		providerID = pv.Spec.CSI.VolumeHandle
 	}
 	return &awsPVKey{
 		Labels:                 pv.Labels,


### PR DESCRIPTION
Check PV spec for alternate location of Provider ID. `pv.Spec.CSI.VolumeHandle` is specified in the AWS API so there should be no problem accessing the value described in https://github.com/kubecost/cost-model/issues/771 