### PR TITLE
Sean/pv alloc recon

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -390,10 +390,10 @@ func (cm *CostModel) ComputeAllocation(start, end time.Time, resolution time.Dur
 					alloc.PVCost += cost / count
 
 					// record the amount of total PVBytes Hours attributable to a given PV
-					if alloc.Properties.PVBreakDown == nil {
-						alloc.Properties.PVBreakDown = map[string]kubecost.PVUsage{}
+					if alloc.Properties.PVBreakdown == nil {
+						alloc.Properties.PVBreakdown = map[string]kubecost.PVUsage{}
 					}
-					alloc.Properties.PVBreakDown[pvc.Volume.Name] = kubecost.PVUsage{
+					alloc.Properties.PVBreakdown[pvc.Volume.Name] = kubecost.PVUsage{
 						ByteHours: pvc.Bytes * hrs / count,
 						Cost:      cost / count,
 					}

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1615,14 +1615,14 @@ func (a *Allocation) reconcileNodes(nodeByProviderID map[string]*Node) {
 }
 
 func (a *Allocation) reconcileDisks(diskByName map[string]*Disk) {
-	pvBreakDown := a.Properties.PVBreakDown
-	if pvBreakDown == nil {
+	pvBreakdown := a.Properties.PVBreakdown
+	if pvBreakdown == nil {
 		// No PV usage to reconcile
 		return
 	}
 	// Set PV Adjustment for allocation to 0 for idempotency
 	a.PVCostAdjustment = 0.0
-	for pvName, pvUsage := range pvBreakDown {
+	for pvName, pvUsage := range pvBreakdown {
 		disk, ok := diskByName[pvName]
 		if !ok {
 			// Failed to find disk in assets

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -701,8 +701,8 @@ func generateAllocationSet(start time.Time) *AllocationSet {
 	a22pqr6.Properties.Services = []string{"service1"}
 
 	// PV BreakDown
-	a22mno4.Properties.PVBreakDown = map[string]PVUsage{"disk1": {Cost: 2.5, ByteHours: 2.5 * gb}, "disk2": {Cost: 5, ByteHours: 5 * gb}}
-	a22mno5.Properties.PVBreakDown = map[string]PVUsage{"disk1": {Cost: 2.5, ByteHours: 2.5 * gb}, "disk2": {Cost: 5, ByteHours: 5 * gb}}
+	a22mno4.Properties.PVBreakdown = map[string]PVUsage{"disk1": {Cost: 2.5, ByteHours: 2.5 * gb}, "disk2": {Cost: 5, ByteHours: 5 * gb}}
+	a22mno5.Properties.PVBreakdown = map[string]PVUsage{"disk1": {Cost: 2.5, ByteHours: 2.5 * gb}, "disk2": {Cost: 5, ByteHours: 5 * gb}}
 
 	return NewAllocationSet(start, start.Add(day),
 		// idle

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -74,6 +74,7 @@ type AllocationProperties struct {
 	ProviderID     string                `json:"providerID,omitempty"`
 	Labels         AllocationLabels      `json:"allocationLabels,omitempty"`
 	Annotations    AllocationAnnotations `json:"allocationAnnotations,omitempty"`
+	PVBreakDown    map[string]PVUsage    `json:"pvBreakDown,omitempty"`
 }
 
 // AllocationLabels is a schema-free mapping of key/value pairs that can be
@@ -83,6 +84,13 @@ type AllocationLabels map[string]string
 // AllocationAnnotations is a schema-free mapping of key/value pairs that can be
 // attributed to an Allocation
 type AllocationAnnotations map[string]string
+
+// PVUsage is a mapping between the name of the PV and the byte hour usage
+// and cost of an Allocation
+type PVUsage struct {
+	ByteHours float64
+	Cost      float64
+}
 
 func (p *AllocationProperties) Clone() *AllocationProperties {
 	if p == nil {

--- a/pkg/kubecost/allocationprops.go
+++ b/pkg/kubecost/allocationprops.go
@@ -74,7 +74,7 @@ type AllocationProperties struct {
 	ProviderID     string                `json:"providerID,omitempty"`
 	Labels         AllocationLabels      `json:"allocationLabels,omitempty"`
 	Annotations    AllocationAnnotations `json:"allocationAnnotations,omitempty"`
-	PVBreakDown    map[string]PVUsage    `json:"pvBreakDown,omitempty"`
+	PVBreakdown    map[string]PVUsage    `json:"pvBreakDown,omitempty"`
 }
 
 // AllocationLabels is a schema-free mapping of key/value pairs that can be
@@ -124,6 +124,12 @@ func (p *AllocationProperties) Clone() *AllocationProperties {
 		annotations[k] = v
 	}
 	clone.Annotations = annotations
+
+	pvBreakdown := make(map[string]PVUsage)
+	for k, v := range p.PVBreakdown {
+		pvBreakdown[k] = v
+	}
+	clone.PVBreakdown = pvBreakdown
 
 	return clone
 }
@@ -183,6 +189,19 @@ func (p *AllocationProperties) Equal(that *AllocationProperties) bool {
 	if len(pAnnotations) == len(thatAnnotations) {
 		for k, pv := range pAnnotations {
 			tv, ok := thatAnnotations[k]
+			if !ok || tv != pv {
+				return false
+			}
+		}
+	} else {
+		return false
+	}
+
+	pPVBreakdown := p.PVBreakdown
+	thatPVBreakdown := that.PVBreakdown
+	if len(pPVBreakdown) == len(thatPVBreakdown) {
+		for k, pv := range pPVBreakdown {
+			tv, ok := thatPVBreakdown[k]
 			if !ok || tv != pv {
 				return false
 			}

--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -25,5 +25,6 @@ package kubecost
 // @bingen:generate:AllocationLabels
 // @bingen:generate:AllocationAnnotations
 // @bingen:generate:RawAllocationOnlyData
+// @bingen:generate:PVUsage
 
-//go:generate bingen -package=kubecost -version=12 -buffer=github.com/kubecost/cost-model/pkg/util
+//go:generate bingen -package=kubecost -version=13 -buffer=github.com/kubecost/cost-model/pkg/util


### PR DESCRIPTION
This PR Updates the Allocation Reconciliation process to read in Disk assets and adjust PV costs of allocation accordingly.

Methodology:
PV usage is distributed evenly to the containers within the pods that they are attached to via PVC. This is reflected in an Allocation's PVByteHour value. However given that a Pods can have multiple PVCs more information is needed on which PV is responsible for what usage and cost of an Allocation. To address this I have added the PVBreakdown field to the Allocation Properties which is a map of PV name to byteHours and cost that PV is responsible for. Using this addition information, a proper adjustment can be made to the cost of the Allocation for each PV it has byteHours for. The equation is ALLOC_PVADJUSTMENT = (PV_COST + PV_ADJUSTMENT) * ALLOC_PVBYTEHOURS / PV_BYTEHOURS - ALLOC_PVCOST

Testing:
Added Unit tests for multiple PV attachments
![Screen Shot 2021-05-04 at 6 13 21 PM](https://user-images.githubusercontent.com/12225425/117087485-71768800-ad04-11eb-97c1-a802be0e7329.png)
