### PR TITLE
Add quotes around dataset

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -361,16 +361,17 @@ func (gcp *GCP) ExternalAllocations(start string, end string, aggregators []stri
 		s = append(s, gcpOOC...)
 		qerr = err
 		*/
-		queryString := fmt.Sprintf(`(
+		queryString := `(
 			SELECT
 				service.description as service,
 				TO_JSON_STRING(labels) as keys,
 				SUM(cost) as cost
-			FROM  "%s"
-			WHERE EXISTS (SELECT * FROM UNNEST(labels) AS l2 WHERE l2.key IN (%s))
+			FROM` +
+			fmt.Sprintf(" `%s` ", c.BillingDataDataset) +
+			fmt.Sprintf(`WHERE EXISTS (SELECT * FROM UNNEST(labels) AS l2 WHERE l2.key IN (%s))
 			AND usage_start_time >= "%s" AND usage_start_time < "%s"
 			GROUP BY service, keys
-		)`, c.BillingDataDataset, aggregator, start, end)
+		)`, aggregator, start, end)
 		klog.V(3).Infof("Querying \"%s\" with : %s", c.ProjectID, queryString)
 		gcpOOC, err := gcp.multiLabelQuery(queryString, aggregators)
 		s = append(s, gcpOOC...)

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -366,7 +366,7 @@ func (gcp *GCP) ExternalAllocations(start string, end string, aggregators []stri
 				service.description as service,
 				TO_JSON_STRING(labels) as keys,
 				SUM(cost) as cost
-			FROM  %s
+			FROM  "%s"
 			WHERE EXISTS (SELECT * FROM UNNEST(labels) AS l2 WHERE l2.key IN (%s))
 			AND usage_start_time >= "%s" AND usage_start_time < "%s"
 			GROUP BY service, keys
@@ -392,7 +392,7 @@ func (gcp *GCP) ExternalAllocations(start string, end string, aggregators []stri
 				service.description as service,
 				TO_JSON_STRING(labels) as keys,
 				SUM(cost) as cost
-		  	FROM  %s
+		  	FROM  "%s"
 		 	WHERE EXISTS (SELECT * FROM UNNEST(labels) AS l2 WHERE l2.key IN (%s))
 			AND EXISTS (SELECT * FROM UNNEST(labels) AS l WHERE l.key = "%s" AND l.value = "%s")
 			AND usage_start_time >= "%s" AND usage_start_time < "%s"

--- a/pkg/costmodel/clusters/clustermap.go
+++ b/pkg/costmodel/clusters/clustermap.go
@@ -183,7 +183,7 @@ func (pcm *PrometheusClusterMap) refreshClusters() {
 	updated, err := pcm.loadClusters()
 	if err != nil {
 		log.Errorf("Failed to load cluster info via query after %d retries", LoadRetries)
-		return
+		updated = make(map[string]*ClusterInfo) // If we fail to query prometheus, register no clusters, as we use this to gauge availability of clusters.
 	}
 
 	pcm.lock.Lock()

--- a/pkg/costmodel/clusters/clustermap.go
+++ b/pkg/costmodel/clusters/clustermap.go
@@ -183,7 +183,7 @@ func (pcm *PrometheusClusterMap) refreshClusters() {
 	updated, err := pcm.loadClusters()
 	if err != nil {
 		log.Errorf("Failed to load cluster info via query after %d retries", LoadRetries)
-		updated = make(map[string]*ClusterInfo) // If we fail to query prometheus, register no clusters, as we use this to gauge availability of clusters.
+		return
 	}
 
 	pcm.lock.Lock()


### PR DESCRIPTION
If your GCP dataset starts with a number, I believe the query parser does not interpret the dataset as a string. Should fix

```I0512 23:57:24.127986       1 gcpprovider.go:407] Error querying gcp:
googleapi: Error 400: Syntax error: Missing whitespace between literal
and alias at [6:32], invalidQuery
```

repro:
<img width="1792" alt="Screen Shot 2021-05-12 at 8 24 02 PM" src="https://user-images.githubusercontent.com/453512/118073237-4d4c2400-b360-11eb-8d6a-58f72f00955a.png">


and after, expected since I made up a dataset:

<img width="1792" alt="Screen Shot 2021-05-12 at 10 01 16 PM" src="https://user-images.githubusercontent.com/453512/118079857-c4d48000-b36d-11eb-8d7f-6811754d3eb7.png">
