### PR TITLE
Reduce unneeded logs on storage class query

### DIFF
--- a/pkg/costmodel/promparsers.go
+++ b/pkg/costmodel/promparsers.go
@@ -62,7 +62,7 @@ func GetPVInfo(qrs []*prom.QueryResult, defaultClusterID string) (map[string]*Pe
 		pvClass, err := val.GetString("storageclass")
 		if err != nil {
 			// TODO: We need to look up the actual PV and PV capacity. For now just proceed with "".
-			log.Warningf("Storage Class not found for claim \"%s/%s\".", ns, pvcName)
+			log.DedupedWarningf(5, "Storage Class not found for claim \"%s/%s\".", ns, pvcName)
 			pvClass = ""
 		}
 


### PR DESCRIPTION
Reduce volume of this query, which can happen for storage classes of type "default"

