### PR TITLE
better logging in query. mirrors queryrange logging but adds req.URL

### DIFF
--- a/pkg/prom/query.go
+++ b/pkg/prom/query.go
@@ -186,6 +186,12 @@ func (ctx *Context) query(query string) (interface{}, prometheus.Warnings, error
 
 		return nil, warnings, fmt.Errorf("query error %d: '%s' fetching query '%s'", resp.StatusCode, err.Error(), query)
 	}
+	// Unsuccessful Status Code, log body and status
+	statusCode := resp.StatusCode
+	statusText := http.StatusText(statusCode)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, warnings, fmt.Errorf("%d (%s) URL: '%s' Headers: '%s', Body: '%s' Query: '%s'", statusCode, statusText, req.URL, util.HeaderString(resp.Header), body, query)
+	}
 
 	var toReturn interface{}
 	err = json.Unmarshal(body, &toReturn)


### PR DESCRIPTION
As we support more promql providers, we should harden some of this error code. This seems like an oversight as this was in the queryrange logic but not in query logic and we migrated a bunch of things away from queryrange.