### PR TITLE
Emit kube_node_status_capacity_TYPE metrics

### DIFF
--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -35,8 +35,10 @@ const (
 	ConfigPathEnvVar               = "CONFIG_PATH"
 	CloudProviderAPIKeyEnvVar      = "CLOUD_PROVIDER_API_KEY"
 
-	EmitPodAnnotationsMetricEnvVar       = "EMIT_POD_ANNOTATIONS_METRIC"
-	EmitNamespaceAnnotationsMetricEnvVar = "EMIT_NAMESPACE_ANNOTATIONS_METRIC"
+	EmitPodAnnotationsMetricEnvVar                    = "EMIT_POD_ANNOTATIONS_METRIC"
+	EmitNamespaceAnnotationsMetricEnvVar              = "EMIT_NAMESPACE_ANNOTATIONS_METRIC"
+	EmitKubeNodeStatusCapacityMemoryBytesMetricEnvVar = "EMIT_KUBE_NODE_STATUS_CAPACITY_MEMORY_BYTES_METRIC"
+	EmitKubeNodeStatusCapacityCPUCoresMetricEnvVar    = "EMIT_KUBE_NODE_STATUS_CAPACITY_CPU_CORES_METRIC"
 
 	ThanosEnabledEnvVar      = "THANOS_ENABLED"
 	ThanosQueryUrlEnvVar     = "THANOS_QUERY_URL"
@@ -87,6 +89,18 @@ func IsEmitNamespaceAnnotationsMetric() bool {
 // pod annotations.
 func IsEmitPodAnnotationsMetric() bool {
 	return GetBool(EmitPodAnnotationsMetricEnvVar, false)
+}
+
+// IsEmitKubeNodeStatusCapacityMemoryBytesMetric returns true if cost-model is configured
+// to emit the kube_node_status_capacity_memory_bytes metric.
+func IsEmitKubeNodeStatusCapacityMemoryBytesMetric() bool {
+	return GetBool(EmitKubeNodeStatusCapacityMemoryBytesMetricEnvVar, false)
+}
+
+// IsEmitKubeNodeStatusCapacityCPUCoresMetric returns true if cost-model is configured
+// to emit the kube_node_status_capacity_cpu_cores metric.
+func IsEmitKubeNodeStatusCapacityCPUCoresMetric() bool {
+	return GetBool(EmitKubeNodeStatusCapacityCPUCoresMetricEnvVar, false)
 }
 
 // GetAWSAccessKeyID returns the environment variable value for AWSAccessKeyIDEnvVar which represents

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -94,13 +94,13 @@ func IsEmitPodAnnotationsMetric() bool {
 // IsEmitKubeNodeStatusCapacityMemoryBytesMetric returns true if cost-model is configured
 // to emit the kube_node_status_capacity_memory_bytes metric.
 func IsEmitKubeNodeStatusCapacityMemoryBytesMetric() bool {
-	return GetBool(EmitKubeNodeStatusCapacityMemoryBytesMetricEnvVar, false)
+	return GetBool(EmitKubeNodeStatusCapacityMemoryBytesMetricEnvVar, true)
 }
 
 // IsEmitKubeNodeStatusCapacityCPUCoresMetric returns true if cost-model is configured
 // to emit the kube_node_status_capacity_cpu_cores metric.
 func IsEmitKubeNodeStatusCapacityCPUCoresMetric() bool {
-	return GetBool(EmitKubeNodeStatusCapacityCPUCoresMetricEnvVar, false)
+	return GetBool(EmitKubeNodeStatusCapacityCPUCoresMetricEnvVar, true)
 }
 
 // GetAWSAccessKeyID returns the environment variable value for AWSAccessKeyIDEnvVar which represents


### PR DESCRIPTION
kube-state-metrics has removed `kube_node_status_capacity_memory_bytes`
and `kube_node_status_capacity_cpu_cores` as of v2.0. Our users have
persisted metrics that go back to pre-2.0 and we have not had the proper
replacement metric `kube_node_status_capacity` whitelisted until recently.
To maintain functionality, we are choosing to emit the removed metrics
ourselves. At some later date we can likely remove this code and
translate our Prometheus queries to use `kube_node_status_capacity`.

These metrics are critically important for Assets data via `ClusterNodes`
which is then used by `ComputeAssets`.

This PR adds the ability for cost-model to emit
- `kube_node_status_capacity_cpu_cores`
- `kube_node_status_capacity_memory_bytes`

When the respective env vars are true:
- `EMIT_KUBE_NODE_STATUS_CAPACITY_MEMORY_BYTES_METRIC`
- `EMIT_KUBE_NODE_STATUS_CAPACITY_CPU_CORES_METRIC`

[Design documentation](https://docs.google.com/document/d/1Mr0JpZ4PTjrOMQtOMgTo2PeveB1s2Ukd646uP3tJ3Cw/edit#bookmark=id.av3ct1xkudrf) (internal)

## Testing
I don't expect difficulties from emitting a duplicate metric. I have previously had a cluster with an installation of `kubecost` and `kubecost-staging` which both deploy KSM (and `kube_node_status_capacity_TYPE` from both KSM's metrics can be seen in Prometheus) without issue.

Tested on a cluster that still had KSM v1.9.x installed to confirm that
Kubecost still behaved as expected. Validation tests with KSM v2.0 will
occur later alongside a helm chart change.

### Integration Tests
I ran the integration tests against the deployment and got only one failure:
```

(⎈ |gke_guestbook-227502_us-east1-b_michael-p

  Running:  cost_allocation_spec.js                                                        (7 of 20)


  Cost allocation drill down
    1) Can drill down from Namespace
    ✓ Can aggregate by label (4031ms)
    ✓ Can drill down by controller kind (7861ms)
    ✓ can return to upper level with breadcrumbs (7573ms)


  3 passing (27s)
  1 failing

  1) Cost allocation drill down
       Can drill down from Namespace:
     AssertionError: Timed out retrying after 4000ms: Expected to find content: 'deployment:kubecost-cost-analyzer' within the selector: 'td' but never did.
      at Context.eval (http://localhost:9090/__cypress/tests?p=cypress/integration/cost_allocation_spec.js:168:10)
  Running:  cost_allocation_spec.js                                                        (7 of 20)


  Cost allocation drill down
    1) Can drill down from Namespace
    ✓ Can aggregate by label (4031ms)
    ✓ Can drill down by controller kind (7861ms)
    ✓ can return to upper level with breadcrumbs (7573ms)


  3 passing (27s)
  1 failing

  1) Cost allocation drill down
       Can drill down from Namespace:
     AssertionError: Timed out retrying after 4000ms: Expected to find content: 'deployment:kubecost-cost-analyzer' within the selector: 'td' but never did.
      at Context.eval (http://localhost:9090/__cypress/tests?p=cypress/integration/cost_allocation_spec.js:168:10)
```

I believe this is a flake -- a manual inspection of the namespace drilldown for `kubecost` in Cost Allocation shows a `deployment:kubecost-cost-analyzer`.

### PromQL queries to see metrics
These queries were run on the cluster with both a regular install of Kubecost (updated with this PR) and an install of the staging Helm chart.

#### `kube_node_status_capacity_memory_bytes`
```sh
read -r -d '' PROMQL << EndOfMessage
kube_node_status_capacity_memory_bytes
EndOfMessage

curl -XPOST 'http://localhost:9003/api/v1/query' \
    -d "query=${PROMQL}" | jq
```

```json
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "kube_node_status_capacity_memory_bytes",
          "app_kubernetes_io_instance": "kubecost",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.5.14:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-kube-state-metrics",
          "kubernetes_namespace": "kubecost",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-gqvn",
          "node": "gke-michael-pv-test-default-pool-41a89917-gqvn"
        },
        "value": [
          1623170323.752,
          "4130848768"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_memory_bytes",
          "app_kubernetes_io_instance": "kubecost",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.5.14:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-kube-state-metrics",
          "kubernetes_namespace": "kubecost",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-gqvn",
          "node": "gke-michael-pv-test-default-pool-41a89917-mod3"
        },
        "value": [
          1623170323.752,
          "4130848768"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_memory_bytes",
          "app_kubernetes_io_instance": "kubecost",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.5.14:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-kube-state-metrics",
          "kubernetes_namespace": "kubecost",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-gqvn",
          "node": "gke-michael-pv-test-default-pool-41a89917-p9xq"
        },
        "value": [
          1623170323.752,
          "4130856960"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_memory_bytes",
          "app_kubernetes_io_instance": "kubecost-staging",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.4.9:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-staging-kube-state-metrics",
          "kubernetes_namespace": "kubecost-staging",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-p9xq",
          "node": "gke-michael-pv-test-default-pool-41a89917-gqvn"
        },
        "value": [
          1623170323.752,
          "4130848768"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_memory_bytes",
          "app_kubernetes_io_instance": "kubecost-staging",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.4.9:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-staging-kube-state-metrics",
          "kubernetes_namespace": "kubecost-staging",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-p9xq",
          "node": "gke-michael-pv-test-default-pool-41a89917-mod3"
        },
        "value": [
          1623170323.752,
          "4130848768"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_memory_bytes",
          "app_kubernetes_io_instance": "kubecost-staging",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.4.9:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-staging-kube-state-metrics",
          "kubernetes_namespace": "kubecost-staging",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-p9xq",
          "node": "gke-michael-pv-test-default-pool-41a89917-p9xq"
        },
        "value": [
          1623170323.752,
          "4130856960"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_memory_bytes",
          "instance": "10.47.242.191:9003",
          "job": "kubecost",
          "node": "gke-michael-pv-test-default-pool-41a89917-gqvn"
        },
        "value": [
          1623170323.752,
          "4130848768"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_memory_bytes",
          "instance": "10.47.242.191:9003",
          "job": "kubecost",
          "node": "gke-michael-pv-test-default-pool-41a89917-mod3"
        },
        "value": [
          1623170323.752,
          "4130848768"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_memory_bytes",
          "instance": "10.47.242.191:9003",
          "job": "kubecost",
          "node": "gke-michael-pv-test-default-pool-41a89917-p9xq"
        },
        "value": [
          1623170323.752,
          "4130856960"
        ]
      }
    ]
  }
}
```

#### `kube_node_status_capacity_cpu_cores`
```sh
read -r -d '' PROMQL << EndOfMessage
kube_node_status_capacity_cpu_cores
EndOfMessage

curl -XPOST 'http://localhost:9003/api/v1/query' \
    -d "query=${PROMQL}" | jq
```

```json
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "kube_node_status_capacity_cpu_cores",
          "app_kubernetes_io_instance": "kubecost",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.5.14:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-kube-state-metrics",
          "kubernetes_namespace": "kubecost",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-gqvn",
          "node": "gke-michael-pv-test-default-pool-41a89917-gqvn"
        },
        "value": [
          1623171914.907,
          "2"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_cpu_cores",
          "app_kubernetes_io_instance": "kubecost",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.5.14:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-kube-state-metrics",
          "kubernetes_namespace": "kubecost",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-gqvn",
          "node": "gke-michael-pv-test-default-pool-41a89917-mod3"
        },
        "value": [
          1623171914.907,
          "2"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_cpu_cores",
          "app_kubernetes_io_instance": "kubecost",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.5.14:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-kube-state-metrics",
          "kubernetes_namespace": "kubecost",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-gqvn",
          "node": "gke-michael-pv-test-default-pool-41a89917-p9xq"
        },
        "value": [
          1623171914.907,
          "2"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_cpu_cores",
          "app_kubernetes_io_instance": "kubecost-staging",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.4.9:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-staging-kube-state-metrics",
          "kubernetes_namespace": "kubecost-staging",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-p9xq",
          "node": "gke-michael-pv-test-default-pool-41a89917-gqvn"
        },
        "value": [
          1623171914.907,
          "2"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_cpu_cores",
          "app_kubernetes_io_instance": "kubecost-staging",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.4.9:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-staging-kube-state-metrics",
          "kubernetes_namespace": "kubecost-staging",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-p9xq",
          "node": "gke-michael-pv-test-default-pool-41a89917-mod3"
        },
        "value": [
          1623171914.907,
          "2"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_cpu_cores",
          "app_kubernetes_io_instance": "kubecost-staging",
          "app_kubernetes_io_managed_by": "Helm",
          "app_kubernetes_io_name": "kube-state-metrics",
          "helm_sh_chart": "kube-state-metrics-2.7.2",
          "instance": "10.44.4.9:8080",
          "job": "kubernetes-service-endpoints",
          "kubernetes_name": "kubecost-staging-kube-state-metrics",
          "kubernetes_namespace": "kubecost-staging",
          "kubernetes_node": "gke-michael-pv-test-default-pool-41a89917-p9xq",
          "node": "gke-michael-pv-test-default-pool-41a89917-p9xq"
        },
        "value": [
          1623171914.907,
          "2"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_cpu_cores",
          "instance": "10.47.242.191:9003",
          "job": "kubecost",
          "node": "gke-michael-pv-test-default-pool-41a89917-gqvn"
        },
        "value": [
          1623171914.907,
          "2"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_cpu_cores",
          "instance": "10.47.242.191:9003",
          "job": "kubecost",
          "node": "gke-michael-pv-test-default-pool-41a89917-mod3"
        },
        "value": [
          1623171914.907,
          "2"
        ]
      },
      {
        "metric": {
          "__name__": "kube_node_status_capacity_cpu_cores",
          "instance": "10.47.242.191:9003",
          "job": "kubecost",
          "node": "gke-michael-pv-test-default-pool-41a89917-p9xq"
        },
        "value": [
          1623171914.907,
          "2"
        ]
      }
    ]
  }
}
```
