### PR TITLE
Communications Error on Status Code != 2XX

### DIFF
--- a/pkg/prom/error.go
+++ b/pkg/prom/error.go
@@ -260,6 +260,11 @@ func NewCommError(messages ...string) CommError {
 	return CommError{messages: messages}
 }
 
+// CommErrorf creates a new CommError using a string formatter
+func CommErrorf(format string, args ...interface{}) CommError {
+	return NewCommError(fmt.Sprintf(format, args...))
+}
+
 // IsCommError returns true if the given error is a CommError
 func IsCommError(err error) bool {
 	_, ok := err.(CommError)

--- a/pkg/prom/query.go
+++ b/pkg/prom/query.go
@@ -190,7 +190,7 @@ func (ctx *Context) query(query string) (interface{}, prometheus.Warnings, error
 	statusCode := resp.StatusCode
 	statusText := http.StatusText(statusCode)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, warnings, fmt.Errorf("%d (%s) URL: '%s' Headers: '%s', Body: '%s' Query: '%s'", statusCode, statusText, req.URL, util.HeaderString(resp.Header), body, query)
+		return nil, warnings, CommErrorf("%d (%s) URL: '%s' Headers: '%s', Body: '%s' Query: '%s'", statusCode, statusText, req.URL, util.HeaderString(resp.Header), body, query)
 	}
 
 	var toReturn interface{}
@@ -293,7 +293,7 @@ func (ctx *Context) queryRange(query string, start, end time.Time, step time.Dur
 	statusCode := resp.StatusCode
 	statusText := http.StatusText(statusCode)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, warnings, fmt.Errorf("%d (%s) Headers: %s, Body: %s Query: %s", statusCode, statusText, util.HeaderString(resp.Header), body, query)
+		return nil, warnings, CommErrorf("%d (%s) Headers: %s, Body: %s Query: %s", statusCode, statusText, util.HeaderString(resp.Header), body, query)
 	}
 
 	var toReturn interface{}


### PR DESCRIPTION
Only use a communications error when the response status code is not a 200. This is a more refined version of an earlier PR. 