### PR TITLE
Fix panic by checking key existence in ClusterLoadBalancers

### DIFF
--- a/pkg/costmodel/cluster.go
+++ b/pkg/costmodel/cluster.go
@@ -687,14 +687,16 @@ func ClusterLoadBalancers(cp cloud.Provider, client prometheus.Client, duration,
 			continue
 		}
 
-		s := time.Unix(int64(result.Values[0].Timestamp), 0)
-		e := time.Unix(int64(result.Values[len(result.Values)-1].Timestamp), 0)
-		mins := e.Sub(s).Minutes()
+		if lb, ok := loadBalancerMap[key]; ok {
+			s := time.Unix(int64(result.Values[0].Timestamp), 0)
+			e := time.Unix(int64(result.Values[len(result.Values)-1].Timestamp), 0)
+			mins := e.Sub(s).Minutes()
 
-		// TODO niko/assets if mins >= threshold, interpolate for missing data?
-
-		loadBalancerMap[key].Start = s
-		loadBalancerMap[key].Minutes = mins
+			lb.Start = s
+			lb.Minutes = mins
+		} else {
+			log.DedupedWarningf(20, "ClusterLoadBalancers: found minutes for key that does not exist: %s", key)
+		}
 	}
 	return loadBalancerMap, nil
 }


### PR DESCRIPTION
Fixes https://github.com/kubecost/cost-model/issues/849
Closes https://github.com/kubecost/cost-model/pull/850

## Changes
- Only try to set fields on a member of a map after checking it exists

## Testing
- Unable to reproduce, but manually regression tested