### PR TITLE
Exclude unmounted PVs from shared costs

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -563,6 +563,11 @@ func (a *Allocation) IsUnallocated() bool {
 	return strings.Contains(a.Name, UnallocatedSuffix)
 }
 
+// IsUnmounted is true if the given Allocation represents unmounted volume costs.
+func (a *Allocation) IsUnmounted() bool {
+	return strings.Contains(a.Name, UnmountedSuffix)
+}
+
 // Minutes returns the number of minutes the Allocation represents, as defined
 // by the difference between the end and start times.
 func (a *Allocation) Minutes() float64 {
@@ -1182,6 +1187,10 @@ func computeShareCoeffs(aggregateBy []string, options *AllocationAggregationOpti
 	for _, alloc := range as.allocations {
 		if alloc.IsIdle() {
 			// Skip idle allocations in coefficient calculation
+			continue
+		}
+		if alloc.IsUnmounted() {
+			// Skip unmounted allocations in coefficient calculation
 			continue
 		}
 

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -1498,8 +1498,8 @@ func TestAllocationSet_AggregateBy(t *testing.T) {
 			start: start,
 			aggBy: []string{AllocationNamespaceProp},
 			aggOpts: &AllocationAggregationOptions{
-				ShareIdle:   ShareEven,
-				IdleByNode:  true,
+				ShareIdle:  ShareEven,
+				IdleByNode: true,
 			},
 			numResults: 3,
 			totalCost:  112.00,


### PR DESCRIPTION
Small change excluding allocations representing unmounted PVs from the calculation of shared costs; this should mean that the shared costs column for the Unmounted PVs row should always be zero. Total costs should still remain consistent.