### PR TITLE
deal with prometheus client init error and fatal exit when there has error

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -832,7 +832,10 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) *Accesses {
 	keepAlive := 120 * time.Second
 	scrapeInterval, _ := time.ParseDuration("1m")
 
-	promCli, _ := prom.NewPrometheusClient(address, timeout, keepAlive, queryConcurrency, "")
+	promCli, err := prom.NewPrometheusClient(address, timeout, keepAlive, queryConcurrency, "")
+	if err != nil {
+		klog.Fatalf("Failed to create prometheus client, Error: %v", err)
+	}
 
 	api := prometheusAPI.NewAPI(promCli)
 	pcfg, err := api.Config(context.Background())


### PR DESCRIPTION
deal with prometheus client init error and fatal exit when there has error; when no prometheus, the server should exit and show reasons or it will crash when requests some api when server started