### PR TITLE
Add ShareTenancyCosts to configuration, defaulting to true

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"github.com/kubecost/cost-model/pkg/kubecost"
 	"io"
 	"io/ioutil"
 	"regexp"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/kubecost/cost-model/pkg/clustercache"
 	"github.com/kubecost/cost-model/pkg/env"
+	"github.com/kubecost/cost-model/pkg/kubecost"
 	"github.com/kubecost/cost-model/pkg/util"
 	"github.com/kubecost/cost-model/pkg/util/json"
 
@@ -943,6 +943,9 @@ func (az *Azure) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, e
 }
 func (az *Azure) GetConfig() (*CustomPricing, error) {
 	c, err := az.Config.GetCustomPricingData()
+	if err != nil {
+		return nil, err
+	}
 	if c.Discount == "" {
 		c.Discount = "0%"
 	}
@@ -955,8 +958,8 @@ func (az *Azure) GetConfig() (*CustomPricing, error) {
 	if c.AzureBillingRegion == "" {
 		c.AzureBillingRegion = "US"
 	}
-	if err != nil {
-		return nil, err
+	if c.ShareTenancyCosts == "" {
+		c.ShareTenancyCosts = defaultShareTenancyCost
 	}
 	return c, nil
 }

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -3,7 +3,6 @@ package cloud
 import (
 	"context"
 	"fmt"
-	"github.com/kubecost/cost-model/pkg/util/timeutil"
 	"io"
 	"io/ioutil"
 	"math"
@@ -14,22 +13,21 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog"
-
-	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/compute/metadata"
-
 	"github.com/kubecost/cost-model/pkg/clustercache"
 	"github.com/kubecost/cost-model/pkg/env"
 	"github.com/kubecost/cost-model/pkg/log"
 	"github.com/kubecost/cost-model/pkg/util"
 	"github.com/kubecost/cost-model/pkg/util/json"
+	"github.com/kubecost/cost-model/pkg/util/timeutil"
 
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/iterator"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
 )
 
 const GKE_GPU_TAG = "cloud.google.com/gke-accelerator"
@@ -167,6 +165,9 @@ func (gcp *GCP) GetConfig() (*CustomPricing, error) {
 	}
 	if c.CurrencyCode == "" {
 		c.CurrencyCode = "USD"
+	}
+	if c.ShareTenancyCosts == "" {
+		c.ShareTenancyCosts = defaultShareTenancyCost
 	}
 	return c, nil
 }

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -21,6 +21,7 @@ import (
 
 const authSecretPath = "/var/secrets/service-key.json"
 const storageConfigSecretPath = "/var/azure-storage-config/azure-storage-config.json"
+const defaultShareTenancyCost = "true"
 
 var createTableStatements = []string{
 	`CREATE TABLE IF NOT EXISTS names (
@@ -176,6 +177,7 @@ type CustomPricing struct {
 	SharedNamespaces             string            `json:"sharedNamespaces"`
 	SharedLabelNames             string            `json:"sharedLabelNames"`
 	SharedLabelValues            string            `json:"sharedLabelValues"`
+	ShareTenancyCosts            string            `json:"shareTenancyCosts"` // TODO clean up configuration so we can use a type other that string (this should be a bool, but the app panics if it's not a string)
 	ReadOnly                     string            `json:"readOnly"`
 	KubecostToken                string            `json:"kubecostToken"`
 }
@@ -332,6 +334,17 @@ func SharedLabels(p Provider) ([]string, []string) {
 	}
 
 	return names, values
+}
+
+// ShareTenancyCosts returns true if the application settings specify to share
+// tenancy costs by default.
+func ShareTenancyCosts(p Provider) bool {
+	config, err := p.GetConfig()
+	if err != nil {
+		return false
+	}
+
+	return config.ShareTenancyCosts == "true"
 }
 
 func NewCrossClusterProvider(ctype string, overrideConfigPath string, cache clustercache.ClusterCache) (Provider, error) {

--- a/pkg/cloud/providerconfig.go
+++ b/pkg/cloud/providerconfig.go
@@ -92,6 +92,11 @@ func (pc *ProviderConfig) loadConfig(writeIfNotExists bool) (*CustomPricing, err
 	if pc.customPricing.SpotGPU == "" {
 		pc.customPricing.SpotGPU = DefaultPricing().SpotGPU // Migration for users without this value set by default.
 	}
+
+	if pc.customPricing.ShareTenancyCosts == "" {
+		pc.customPricing.ShareTenancyCosts = defaultShareTenancyCost
+	}
+
 	return pc.customPricing, nil
 }
 
@@ -177,6 +182,7 @@ func DefaultPricing() *CustomPricing {
 		RegionNetworkEgress:   "0.01",
 		InternetNetworkEgress: "0.12",
 		CustomPricesEnabled:   "false",
+		ShareTenancyCosts:     "true",
 	}
 }
 


### PR DESCRIPTION
Requires https://github.com/kubecost/kubecost-cost-model/pull/471
Requires https://github.com/kubecost/cost-analyzer-frontend/pull/328
Requires https://github.com/kubecost/cost-analyzer-helm-chart/pull/973

## Changes
- Add `ShareTenancyCosts` to configuration, with default value of `"true"` until it is set manually.

## Testing
In conjunction with the other PRs, the experience should look like this:

Default to sharing tenancy costs, with a chip in the UI denoting that. A tooltip explains what it means and indicates that it can be disabled in the Settings page.
![Screenshot from 2021-07-13 13-47-33](https://user-images.githubusercontent.com/8070055/125516720-ab9be127-b69e-4ab2-95cc-2e188208aa27.png)

Visiting the Settings page surfaces this setting and allows it to be turned off.
![Screenshot from 2021-07-13 13-42-07](https://user-images.githubusercontent.com/8070055/125516716-f53628d8-6bd2-4375-b1f0-7325bfc1ff08.png)
![Screenshot from 2021-07-13 13-44-09](https://user-images.githubusercontent.com/8070055/125516717-f286876d-eddd-4b89-8af4-df0bd2bd33da.png)

With the setting turned off, sharing tenancy costs stops, allowing us to get $0 in shared cost with none of the sharing features enabled, which is not possible today.
![Screenshot from 2021-07-13 13-44-26](https://user-images.githubusercontent.com/8070055/125516719-0cfb8d05-308a-467e-ae89-865d8d8ff1a0.png)