### PR TITLE
Sean/azure spot clean up

### DIFF
--- a/configs/azure.json
+++ b/configs/azure.json
@@ -9,6 +9,8 @@
     "zoneNetworkEgress": "0.01",
     "regionNetworkEgress": "0.01",
     "internetNetworkEgress": "0.0725",
+    "spotLabel": "kubernetes.azure.com/scalesetpriority",
+    "spotLabelValue": "spot",
     "azureSubscriptionID": "",
     "azureClientID": "" ,
     "azureClientSecret": "" ,

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -837,8 +837,6 @@ func (az *Azure) DownloadPricingData() error {
 }
 
 func (az *Azure) addPricing(features string, azurePricing *AzurePricing) {
-	az.DownloadPricingDataLock.Lock()
-	defer az.DownloadPricingDataLock.Unlock()
 	if az.Pricing == nil {
 		az.Pricing = map[string]*AzurePricing{}
 	}

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -837,8 +837,8 @@ func (az *Azure) DownloadPricingData() error {
 }
 
 func (az *Azure) addPricing(features string, azurePricing *AzurePricing) {
-	az.DownloadPricingDataLock.RLock()
-	defer az.DownloadPricingDataLock.RUnlock()
+	az.DownloadPricingDataLock.Lock()
+	defer az.DownloadPricingDataLock.Unlock()
 	if az.Pricing == nil {
 		az.Pricing = map[string]*AzurePricing{}
 	}
@@ -890,7 +890,7 @@ func (az *Azure) NodePricing(key Key) (*Node, error) {
 				UsageType: "spot",
 				GPU:       gpu,
 			}
-			
+
 			az.addPricing(spotFeatures, &AzurePricing{
 				Node: spotNode,
 			})

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -178,15 +178,15 @@ func getRetailPrice(region string, skuName string, currencyCode string, spot boo
 		pricingURL += fmt.Sprintf("&$filter=%s", filterParamsEscaped)
 	}
 
-	klog.V(4).Infof("starting download retail price payload from \"%s\"", pricingURL)
+	log.Infof("starting download retail price payload from \"%s\"", pricingURL)
 	resp, err := http.Get(pricingURL)
 
 	if err != nil {
 		return "", fmt.Errorf("bogus fetch of \"%s\": %v", pricingURL, err)
 	}
 
-	if resp.StatusCode != 200 {
-		log.DedupedInfof(5, "retail price responded with status code %d", resp.StatusCode)
+	if resp.StatusCode < 200 && resp.StatusCode > 299 {
+		return "", fmt.Errorf("retail price responded with error status code %d", resp.StatusCode)
 	}
 
 	pricingPayload := AzureRetailPricing{}


### PR DESCRIPTION
Apply code suggestions from Kubecost team to @subreptivus 's PR [832](https://github.com/kubecost/cost-model/pull/832)
to improve spot pricing estimates by using the Azure retail price.

Testing: 
Created new cluster with a spot vmss with an A2 instance and progressively applied configurations and this PR to see the effect on the price of the node being emitted. The result were mixed as adding these changes actually increased the price of the spot node being reported. In the below graph the first step is when the pricing API for the Azure cluster is configured and you can see the A2 instance remains much lower than the DS2 instance. The second increase in price happens when the changes from this PR are applied as the A2 price increases almost to the same as the Ds2
![Screen Shot 2021-07-19 at 5 12 54 PM](https://user-images.githubusercontent.com/12225425/126363654-df880df9-ce0c-42f9-a80d-21abfe2566d5.png)
![Screen Shot 2021-07-19 at 5 13 05 PM](https://user-images.githubusercontent.com/12225425/126363655-64e3d2ee-5f08-4ec9-8787-3654f5bcb160.png)

Looking at the logs I am able to confirm that the retail pricing API is successfully being hit.
![Screen Shot 2021-07-19 at 5 23 45 PM](https://user-images.githubusercontent.com/12225425/126363656-61c6a2db-1e06-4fcf-9979-6c05e65aa659.png)


To test further I created a non-spot A2 VMSS which remained at the initial price after api configuration. Before moving on with this PR I would like to see how this new A2 node's cost is adjusted. And also see how the pricing for the spot node looks in the Azure cost analyzer to confirm if the price jump was accurate or not.