### PR TITLE
Omit PV Hourly Metrics for !Available and !Bound

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -1381,8 +1381,8 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 
 			pvs := cmme.KubeClusterCache.GetAllPersistentVolumes()
 			for _, pv := range pvs {
-				// Omit pv_hourly_cost if the volume status is not available or unbound
-				if pv.Status.Phase != v1.VolumeAvailable && pv.Status.Phase != v1.VolumeBound {
+				// Omit pv_hourly_cost if the volume status is failed
+				if pv.Status.Phase == v1.VolumeFailed {
 					continue
 				}
 

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -1381,6 +1381,11 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 
 			pvs := cmme.KubeClusterCache.GetAllPersistentVolumes()
 			for _, pv := range pvs {
+				// Omit pv_hourly_cost if the volume status is not available or unbound
+				if pv.Status.Phase != v1.VolumeAvailable && pv.Status.Phase != v1.VolumeBound {
+					continue
+				}
+
 				parameters, ok := storageClassMap[pv.Spec.StorageClassName]
 				if !ok {
 					klog.V(4).Infof("Unable to find parameters for storage class \"%s\". Does pv \"%s\" have a storageClassName?", pv.Spec.StorageClassName, pv.Name)


### PR DESCRIPTION
Fairly easy filter to avoid including PV Hourly Cost metrics when the status is anything other than Available or Bound