### PR TITLE
Fix overreporting gpu requests for vgpus

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -943,7 +943,7 @@ func (cm *CostModel) GetNodeCost(cp costAnalyzerCloud.Provider) (map[string]*cos
 	vgpuCount, err := getAllocatableVGPUs(cm.Cache)
 	vgpuCoeff := 1.0
 	if err != nil {
-		log.Warningf("GetNodeCost: unable to get allocable vgpus from daemonset: " + err.Error())
+		klog.Infof("unable to get allocable vgpus from daemonset: " + err.Error())
 	}
 	if vgpuCount > 0.0 {
 		vgpuCoeff = vgpuCount
@@ -2225,7 +2225,7 @@ func getAllocatableVGPUs(cache clustercache.ClusterCache) (float64, error) {
 					if strings.Contains(arg, "--vgpu=") {
 						vgpus, err := strconv.ParseFloat(arg[strings.IndexByte(arg, '=')+1:], 64)
 						if err != nil {
-							return 0.0, fmt.Errorf("cannot parse vgpu allocation string %s: %v", arg, err)
+							return 10.0, fmt.Errorf("cannot parse vgpu allocation string %s: %v", arg, err)
 						}
 						vgpuCount = vgpus
 						return vgpuCount, nil

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -315,9 +315,6 @@ func (cm *CostModel) ComputeCostData(cli prometheusClient.Client, cp costAnalyze
 	// If there are no vgpus, the coefficient is set to 1.0
 	vgpuCount, err := getAllocatableVGPUs(cm.Cache)
 	vgpuCoeff := 10.0
-	if err != nil {
-		log.Warningf("ComputeCostData: unable to set allocable vgpus from daemonset: " + err.Error())
-	}
 	if vgpuCount > 0.0 {
 		vgpuCoeff = vgpuCount
 	}
@@ -942,9 +939,6 @@ func (cm *CostModel) GetNodeCost(cp costAnalyzerCloud.Provider) (map[string]*cos
 
 	vgpuCount, err := getAllocatableVGPUs(cm.Cache)
 	vgpuCoeff := 10.0
-	if err != nil {
-		klog.Infof("unable to get allocable vgpus from daemonset: " + err.Error())
-	}
 	if vgpuCount > 0.0 {
 		vgpuCoeff = vgpuCount
 	}
@@ -2225,7 +2219,8 @@ func getAllocatableVGPUs(cache clustercache.ClusterCache) (float64, error) {
 					if strings.Contains(arg, "--vgpu=") {
 						vgpus, err := strconv.ParseFloat(arg[strings.IndexByte(arg, '=')+1:], 64)
 						if err != nil {
-							return 10.0, fmt.Errorf("cannot parse vgpu allocation string %s: %v", arg, err)
+							klog.V(1).Infof("failed to parse vgpu allocation string %s: %v", arg, err)
+							continue
 						}
 						vgpuCount = vgpus
 						return vgpuCount, nil

--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -314,7 +314,7 @@ func (cm *CostModel) ComputeCostData(cli prometheusClient.Client, cp costAnalyze
 	// Determine if there are vgpus configured and if so get the total allocatable number
 	// If there are no vgpus, the coefficient is set to 1.0
 	vgpuCount, err := getAllocatableVGPUs(cm.Cache)
-	vgpuCoeff := 1.0
+	vgpuCoeff := 10.0
 	if err != nil {
 		log.Warningf("ComputeCostData: unable to set allocable vgpus from daemonset: " + err.Error())
 	}
@@ -941,7 +941,7 @@ func (cm *CostModel) GetNodeCost(cp costAnalyzerCloud.Provider) (map[string]*cos
 	nodes := make(map[string]*costAnalyzerCloud.Node)
 
 	vgpuCount, err := getAllocatableVGPUs(cm.Cache)
-	vgpuCoeff := 1.0
+	vgpuCoeff := 10.0
 	if err != nil {
 		klog.Infof("unable to get allocable vgpus from daemonset: " + err.Error())
 	}

--- a/test/cloud_test.go
+++ b/test/cloud_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubecost/cost-model/pkg/costmodel"
 	"github.com/kubecost/cost-model/pkg/costmodel/clusters"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -246,6 +247,10 @@ type FakeCache struct {
 
 func (f FakeCache) GetAllNodes() []*v1.Node {
 	return f.nodes
+}
+
+func (f FakeCache) GetAllDaemonSets() []*appsv1.DaemonSet {
+	return nil
 }
 
 func NewFakeNodeCache(nodes []*v1.Node) FakeCache {


### PR DESCRIPTION
Ref: https://github.com/kubecost/cost-model/issues/884

Changes to vgpu logic to prevent over-allocation. Now, if there are vgpu requests, we divide gpu count by a coefficient, which is the total number of allocable vgpus in the `aws-virtual-gpu-device-plugin-daemonset` to get the proportion of physical gpu used.

If the vgpu count can't be parsed, the coefficient defaults to `10.0`, the default [here](https://github.com/awslabs/aws-virtual-gpu-device-plugin/blob/master/manifests/device-plugin.yml).

Tested locally on an aws cluster with multiple replicas of pods requesting vgpus and observing `\model\metrics` endpoint as well as changes on frontend.