### PR TITLE
Fix label alias aggregation on sanitized labels

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1463,7 +1463,7 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := strings.TrimPrefix(agg, "label:")
+				labelName := labelConfig.Sanitize(strings.TrimPrefix(agg, "label:"))
 				if labelValue, ok := labels[labelName]; ok {
 					names = append(names, fmt.Sprintf("%s=%s", labelName, labelValue))
 				} else {
@@ -1475,7 +1475,7 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if annotations == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				annotationName := strings.TrimPrefix(agg, "annotation:")
+				annotationName := labelConfig.Sanitize(strings.TrimPrefix(agg, "annotation:"))
 				if annotationValue, ok := annotations[annotationName]; ok {
 					names = append(names, fmt.Sprintf("%s=%s", annotationName, annotationValue))
 				} else {

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1487,7 +1487,7 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.DepartmentLabel
+				labelName := labelConfig.Sanitize(labelConfig.DepartmentLabel)
 				if labelValue, ok := labels[labelName]; ok {
 					names = append(names, labelValue)
 				} else {
@@ -1499,7 +1499,7 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.EnvironmentLabel
+				labelName := labelConfig.Sanitize(labelConfig.EnvironmentLabel)
 				if labelValue, ok := labels[labelName]; ok {
 					names = append(names, labelValue)
 				} else {
@@ -1511,7 +1511,7 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.OwnerLabel
+				labelName := labelConfig.Sanitize(labelConfig.OwnerLabel)
 				if labelValue, ok := labels[labelName]; ok {
 					names = append(names, labelValue)
 				} else {
@@ -1523,7 +1523,7 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.ProductLabel
+				labelName := labelConfig.Sanitize(labelConfig.ProductLabel)
 				if labelValue, ok := labels[labelName]; ok {
 					names = append(names, labelValue)
 				} else {
@@ -1535,7 +1535,7 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.TeamLabel
+				labelName := labelConfig.Sanitize(labelConfig.TeamLabel)
 				if labelValue, ok := labels[labelName]; ok {
 					names = append(names, labelValue)
 				} else {
@@ -1551,18 +1551,6 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 	}
 
 	return strings.Join(names, "/")
-}
-
-// TODO:CLEANUP get rid of this
-// Helper function to check for slice membership. Not sure if repeated elsewhere in our codebase.
-func indexOf(v string, arr []string) int {
-	for i, s := range arr {
-		// This is caseless equivalence
-		if strings.EqualFold(v, s) {
-			return i
-		}
-	}
-	return -1
 }
 
 // Clone returns a new AllocationSet with a deep copy of the given

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -503,6 +503,34 @@ func TestAllocationSet_generateKey(t *testing.T) {
 	if key != "dept1/envt1/ownr1/prod1/team1" {
 		t.Fatalf("generateKey: expected \"dept1/envt1/ownr1/prod1/team1\"; actual \"%s\"", key)
 	}
+
+	// Ensure that labels with illegal Prometheus characters in LabelConfig
+	// still match their sanitized values.
+
+	labelConfig.DepartmentLabel = "prom/illegal-department"
+	labelConfig.EnvironmentLabel = " env "
+	labelConfig.OwnerLabel = "$owner%"
+
+	alloc.Properties = &AllocationProperties{
+		Cluster:   "cluster1",
+		Namespace: "namespace1",
+		Labels: map[string]string{
+			"prom_illegal_department": "dept1",
+			"env":                     "envt1",
+			"_owner_":                 "ownr1",
+		},
+	}
+
+	props = []string{
+		AllocationDepartmentProp,
+		AllocationEnvironmentProp,
+		AllocationOwnerProp,
+	}
+
+	key = alloc.generateKey(props, labelConfig)
+	if key != "dept1/envt1/ownr1" {
+		t.Fatalf("generateKey: expected \"dept1/envt1/ownr1\"; actual \"%s\"", key)
+	}
 }
 
 func TestNewAllocationSet(t *testing.T) {

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -510,6 +510,7 @@ func TestAllocationSet_generateKey(t *testing.T) {
 	labelConfig.DepartmentLabel = "prom/illegal-department"
 	labelConfig.EnvironmentLabel = " env "
 	labelConfig.OwnerLabel = "$owner%"
+	labelConfig.ProductLabel = "app.kubernetes.io/app"
 
 	alloc.Properties = &AllocationProperties{
 		Cluster:   "cluster1",
@@ -518,6 +519,7 @@ func TestAllocationSet_generateKey(t *testing.T) {
 			"prom_illegal_department": "dept1",
 			"env":                     "envt1",
 			"_owner_":                 "ownr1",
+			"app_kubernetes_io_app":   "prod1",
 		},
 	}
 
@@ -525,11 +527,12 @@ func TestAllocationSet_generateKey(t *testing.T) {
 		AllocationDepartmentProp,
 		AllocationEnvironmentProp,
 		AllocationOwnerProp,
+		AllocationProductProp,
 	}
 
 	key = alloc.generateKey(props, labelConfig)
-	if key != "dept1/envt1/ownr1" {
-		t.Fatalf("generateKey: expected \"dept1/envt1/ownr1\"; actual \"%s\"", key)
+	if key != "dept1/envt1/ownr1/prod1" {
+		t.Fatalf("generateKey: expected \"dept1/envt1/ownr1/prod\"; actual \"%s\"", key)
 	}
 }
 

--- a/pkg/kubecost/config.go
+++ b/pkg/kubecost/config.go
@@ -169,6 +169,13 @@ func (lc *LabelConfig) Map() map[string]string {
 	return m
 }
 
+// Sanitize returns a sanitized version of the given string, which converts
+// all illegal characters to underscores. Illegal characters are those that
+// Prometheus does not support; i.e. [^a-zA-Z0-9_]
+func (lc *LabelConfig) Sanitize(label string) string {
+	return prom.SanitizeLabelName(strings.TrimSpace(label))
+}
+
 // GetExternalAllocationName derives an external allocation name from a set of
 // labels, given an aggregation property. If the aggregation property is,
 // itself, a label (e.g. label:app) then this function looks for a

--- a/pkg/kubecost/config_test.go
+++ b/pkg/kubecost/config_test.go
@@ -104,7 +104,7 @@ func TestLabelConfig_GetExternalAllocationName(t *testing.T) {
 
 	// Change the external label for namespace and confirm it still works
 	lc.NamespaceExternalLabel = "kubens"
-	lc.ServiceExternalLabel = "prom-sanitization-test"
+	lc.ServiceExternalLabel = "prom/sanitization-test"
 	lc.PodExternalLabel = "Non__GlueFormattedLabel"
 	lc.OwnerExternalLabel = "kubeowner"
 	lc.DepartmentExternalLabel = "doesntexist,env"
@@ -127,6 +127,26 @@ func TestLabelConfig_GetExternalAllocationName(t *testing.T) {
 		actual := lc.GetExternalAllocationName(labels, tc.aggBy)
 		if actual != tc.expected {
 			t.Fatalf("GetExternalAllocationName failed; expected '%s'; got '%s'", tc.expected, actual)
+		}
+	}
+}
+
+func TestLabelConfig_Sanitize(t *testing.T) {
+	testCases := []struct {
+		label    string
+		expected string
+	}{
+		{"", ""},
+		{"simple", "simple"},
+		{"prom/sanitization-test", "prom_sanitization_test"},
+		{" prom/sanitization-test$  ", "prom_sanitization_test_"},
+	}
+
+	lc := NewLabelConfig()
+	for _, tc := range testCases {
+		actual := lc.Sanitize(tc.label)
+		if actual != tc.expected {
+			t.Fatalf("Sanitize failed; expected '%s'; got '%s'", tc.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
## Changes
- In `AggregateBy`, sanitize the label name behind the alias before finding a label match in `Allocation` properties.

## Testing
- Unit tests
- Manual testing (see below)

### Manual testing
Changed Product to `app.kubernetes.io/name` and tested that aggregating by Product works:
![Screenshot from 2021-08-16 10-56-51](https://user-images.githubusercontent.com/8070055/129600998-5557103a-203f-4e3f-ba89-549ebb1a9a56.png)
![Screenshot from 2021-08-16 10-56-39](https://user-images.githubusercontent.com/8070055/129601015-effe1ad9-905a-4e08-85b4-27d81d6b3ef5.png)
