### PR TITLE
Support multi-agg for comma-separated label aliases

### DIFF
--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -1487,11 +1487,14 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.Sanitize(labelConfig.DepartmentLabel)
-				if labelValue, ok := labels[labelName]; ok {
-					names = append(names, labelValue)
-				} else {
-					names = append(names, UnallocatedSuffix)
+				labelNames := strings.Split(labelConfig.DepartmentLabel, ",")
+				for _, labelName := range labelNames {
+					labelName = labelConfig.Sanitize(labelName)
+					if labelValue, ok := labels[labelName]; ok {
+						names = append(names, labelValue)
+					} else {
+						names = append(names, UnallocatedSuffix)
+					}
 				}
 			}
 		case agg == AllocationEnvironmentProp:
@@ -1499,11 +1502,14 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.Sanitize(labelConfig.EnvironmentLabel)
-				if labelValue, ok := labels[labelName]; ok {
-					names = append(names, labelValue)
-				} else {
-					names = append(names, UnallocatedSuffix)
+				labelNames := strings.Split(labelConfig.EnvironmentLabel, ",")
+				for _, labelName := range labelNames {
+					labelName = labelConfig.Sanitize(labelName)
+					if labelValue, ok := labels[labelName]; ok {
+						names = append(names, labelValue)
+					} else {
+						names = append(names, UnallocatedSuffix)
+					}
 				}
 			}
 		case agg == AllocationOwnerProp:
@@ -1511,11 +1517,14 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.Sanitize(labelConfig.OwnerLabel)
-				if labelValue, ok := labels[labelName]; ok {
-					names = append(names, labelValue)
-				} else {
-					names = append(names, UnallocatedSuffix)
+				labelNames := strings.Split(labelConfig.OwnerLabel, ",")
+				for _, labelName := range labelNames {
+					labelName = labelConfig.Sanitize(labelName)
+					if labelValue, ok := labels[labelName]; ok {
+						names = append(names, labelValue)
+					} else {
+						names = append(names, UnallocatedSuffix)
+					}
 				}
 			}
 		case agg == AllocationProductProp:
@@ -1523,11 +1532,14 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.Sanitize(labelConfig.ProductLabel)
-				if labelValue, ok := labels[labelName]; ok {
-					names = append(names, labelValue)
-				} else {
-					names = append(names, UnallocatedSuffix)
+				labelNames := strings.Split(labelConfig.ProductLabel, ",")
+				for _, labelName := range labelNames {
+					labelName = labelConfig.Sanitize(labelName)
+					if labelValue, ok := labels[labelName]; ok {
+						names = append(names, labelValue)
+					} else {
+						names = append(names, UnallocatedSuffix)
+					}
 				}
 			}
 		case agg == AllocationTeamProp:
@@ -1535,11 +1547,14 @@ func (a *Allocation) generateKey(aggregateBy []string, labelConfig *LabelConfig)
 			if labels == nil {
 				names = append(names, UnallocatedSuffix)
 			} else {
-				labelName := labelConfig.Sanitize(labelConfig.TeamLabel)
-				if labelValue, ok := labels[labelName]; ok {
-					names = append(names, labelValue)
-				} else {
-					names = append(names, UnallocatedSuffix)
+				labelNames := strings.Split(labelConfig.TeamLabel, ",")
+				for _, labelName := range labelNames {
+					labelName = labelConfig.Sanitize(labelName)
+					if labelValue, ok := labels[labelName]; ok {
+						names = append(names, labelValue)
+					} else {
+						names = append(names, UnallocatedSuffix)
+					}
 				}
 			}
 		default:

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -505,12 +505,14 @@ func TestAllocationSet_generateKey(t *testing.T) {
 	}
 
 	// Ensure that labels with illegal Prometheus characters in LabelConfig
-	// still match their sanitized values.
+	// still match their sanitized values. Ensure also that multiple comma-
+	// separated values work.
 
 	labelConfig.DepartmentLabel = "prom/illegal-department"
 	labelConfig.EnvironmentLabel = " env "
 	labelConfig.OwnerLabel = "$owner%"
 	labelConfig.ProductLabel = "app.kubernetes.io/app"
+	labelConfig.TeamLabel = "team,app.kubernetes.io/team,k8s-team"
 
 	alloc.Properties = &AllocationProperties{
 		Cluster:   "cluster1",
@@ -519,7 +521,9 @@ func TestAllocationSet_generateKey(t *testing.T) {
 			"prom_illegal_department": "dept1",
 			"env":                     "envt1",
 			"_owner_":                 "ownr1",
+			"team":                    "team1",
 			"app_kubernetes_io_app":   "prod1",
+			"app_kubernetes_io_team":  "team2",
 		},
 	}
 
@@ -528,11 +532,12 @@ func TestAllocationSet_generateKey(t *testing.T) {
 		AllocationEnvironmentProp,
 		AllocationOwnerProp,
 		AllocationProductProp,
+		AllocationTeamProp,
 	}
 
 	key = alloc.generateKey(props, labelConfig)
-	if key != "dept1/envt1/ownr1/prod1" {
-		t.Fatalf("generateKey: expected \"dept1/envt1/ownr1/prod\"; actual \"%s\"", key)
+	if key != "dept1/envt1/ownr1/prod1/team1/team2/__unallocated__" {
+		t.Fatalf("generateKey: expected \"dept1/envt1/ownr1/prod1/team1/team2/__unallocated__\"; actual \"%s\"", key)
 	}
 }
 


### PR DESCRIPTION
## Changes
- Support label aliases containing comma-separated values, representing an ordered set of label names that should be treated in a multi-agg way.

## Testing
- Unit tests included
- Manual testing (see below)

![Screenshot from 2021-08-17 16-23-51](https://user-images.githubusercontent.com/8070055/129808617-68412e9a-b307-453c-a93c-61ff1669c7c2.png)
![Screenshot from 2021-08-17 16-24-05](https://user-images.githubusercontent.com/8070055/129808620-3eb46c8e-1595-4231-b16c-ce1e14581b8d.png)
