### PR TITLE
Support external allocations by label aliases

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -156,8 +156,6 @@ func AssetToExternalAllocation(asset Asset, aggregateBy []string, labelConfig *L
 	for _, aggBy := range aggregateBy {
 		name := labelConfig.GetExternalAllocationName(asset.Labels(), aggBy)
 
-		log.Infof("External: %s => %s", asset.Properties().Name, name)
-
 		if name == "" {
 			// No matching label has been defined in the cost-analyzer label config
 			// relating to the given aggregateBy property.

--- a/pkg/kubecost/config.go
+++ b/pkg/kubecost/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kubecost/cost-model/pkg/log"
 	"github.com/kubecost/cost-model/pkg/prom"
 	"github.com/kubecost/cost-model/pkg/util/cloudutil"
 )
@@ -235,8 +234,6 @@ func (lc *LabelConfig) GetExternalAllocationName(labels map[string]string, aggre
 		}
 	}
 
-	log.Infof("External: aggregate by %s: labelNames: %v", aggregateBy, labelNames)
-
 	// No label is set for the given aggregation property.
 	if len(labelNames) == 0 {
 		return ""
@@ -264,8 +261,6 @@ func (lc *LabelConfig) GetExternalAllocationName(labels map[string]string, aggre
 			}
 		}
 	}
-
-	log.Infof("External: aggregate by %s: %s = %s", aggregateBy, labelName, labelValue)
 
 	// No match found
 	if labelName == "" {

--- a/pkg/kubecost/config.go
+++ b/pkg/kubecost/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubecost/cost-model/pkg/log"
 	"github.com/kubecost/cost-model/pkg/prom"
 	"github.com/kubecost/cost-model/pkg/util/cloudutil"
 )
@@ -234,6 +235,8 @@ func (lc *LabelConfig) GetExternalAllocationName(labels map[string]string, aggre
 		}
 	}
 
+	log.Infof("External: aggregate by %s: labelNames: %v", aggregateBy, labelNames)
+
 	// No label is set for the given aggregation property.
 	if len(labelNames) == 0 {
 		return ""
@@ -261,6 +264,8 @@ func (lc *LabelConfig) GetExternalAllocationName(labels map[string]string, aggre
 			}
 		}
 	}
+
+	log.Infof("External: aggregate by %s: %s = %s", aggregateBy, labelName, labelValue)
 
 	// No match found
 	if labelName == "" {


### PR DESCRIPTION
## Changes
- In `AssetToExternalAllocation` we were occasionally getting correct external allocation names, then dropping them accidentally by not setting the proper fields on the `Allocation` that was generated. This fixes that for label aliases.

## Testing
- New unit test
- Manual testing (see below)

Before: costs were all unallocated because of the missing properties.
![Screenshot from 2021-08-17 18-44-12](https://user-images.githubusercontent.com/8070055/129818794-eb3b33bc-f11f-4cb2-8586-47bee087c539.png)

After: the same total cost is now fully allocated because the properties are present.
![Screenshot from 2021-08-17 18-44-35](https://user-images.githubusercontent.com/8070055/129818796-53c0ac38-ba6e-4684-b234-8b52f426ad75.png)
