### PR TITLE
Expand cloud diagnostic variable and export gcp status variable

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -54,7 +54,7 @@ type GCP struct {
 	DownloadPricingDataLock sync.RWMutex
 	ReservedInstances       []*GCPReservedInstance
 	Config                  *ProviderConfig
-	serviceKeyProvided      bool
+	ServiceKeyProvided      bool
 	ValidPricingKeys        map[string]bool
 	clusterManagementPrice  float64
 	clusterProvisioner      string
@@ -254,7 +254,7 @@ func (gcp *GCP) UpdateConfig(r io.Reader, updateType string) (*CustomPricing, er
 				if err != nil {
 					return err
 				}
-				gcp.serviceKeyProvided = true
+				gcp.ServiceKeyProvided = true
 			}
 		} else if updateType == AthenaInfoUpdateType {
 			a := AwsAthenaInfo{}
@@ -405,7 +405,7 @@ func (gcp *GCP) ExternalAllocations(start string, end string, aggregators []stri
 		s = append(s, gcpOOC...)
 		qerr = err
 	}
-	if qerr != nil && gcp.serviceKeyProvided {
+	if qerr != nil && gcp.ServiceKeyProvided {
 		klog.Infof("Error querying gcp: %s", qerr)
 	}
 	return s, qerr

--- a/pkg/kubecost/status.go
+++ b/pkg/kubecost/status.go
@@ -36,28 +36,29 @@ type FileStatus struct {
 
 // CloudStatus describes CloudStore metadata
 type CloudStatus struct {
-	CloudAssets    *CloudAssetStatus     `json:"cloudAssets,omitempty`
-	Reconciliation *ReconciliationStatus `json:"reconciliation,omitempty"`
+	CloudConnectionStatus string                `json:"cloudConnectionStatus"`
+	CloudAssets           *CloudAssetStatus     `json:"cloudAssets,omitempty`
+	Reconciliation        *ReconciliationStatus `json:"reconciliation,omitempty"`
 }
 
 // CloudAssetStatus describes CloudAsset metadata of a CloudStore
 type CloudAssetStatus struct {
-	Coverage    Window            `json:"coverage"`
-	LastRun     time.Time         `json:"lastRun"`
-	NextRun     time.Time         `json:"nextRun"`
-	Progress    float64           `json:"progress"`
-	RefreshRate string            `json:"refreshRate"`
-	Resolution  string            `json:"resolution"`
-	StartTime   time.Time         `json:"startTime"`
+	Coverage    Window    `json:"coverage"`
+	LastRun     time.Time `json:"lastRun"`
+	NextRun     time.Time `json:"nextRun"`
+	Progress    float64   `json:"progress"`
+	RefreshRate string    `json:"refreshRate"`
+	Resolution  string    `json:"resolution"`
+	StartTime   time.Time `json:"startTime"`
 }
 
 // ReconciliationStatus describes Reconcilation metadata of a CloudStore
 type ReconciliationStatus struct {
-	Coverage    Window            `json:"coverage"`
-	LastRun     time.Time         `json:"lastRun"`
-	NextRun     time.Time         `json:"nextRun"`
-	Progress    float64           `json:"progress"`
-	RefreshRate string            `json:"refreshRate"`
-	Resolution  string            `json:"resolution"`
-	StartTime   time.Time         `json:"startTime"`
+	Coverage    Window    `json:"coverage"`
+	LastRun     time.Time `json:"lastRun"`
+	NextRun     time.Time `json:"nextRun"`
+	Progress    float64   `json:"progress"`
+	RefreshRate string    `json:"refreshRate"`
+	Resolution  string    `json:"resolution"`
+	StartTime   time.Time `json:"startTime"`
 }


### PR DESCRIPTION
Small updates to support: https://github.com/kubecost/kubecost-cost-model/pull/504
- Add CloudConnectionStatus field to CloudStatus struct
- Export key status variable from GCP cloud provider