### PR TITLE
Add missing quote to CloudStatus object json rule

### DIFF
--- a/pkg/kubecost/status.go
+++ b/pkg/kubecost/status.go
@@ -37,7 +37,7 @@ type FileStatus struct {
 // CloudStatus describes CloudStore metadata
 type CloudStatus struct {
 	CloudConnectionStatus string                `json:"cloudConnectionStatus"`
-	CloudAssets           *CloudAssetStatus     `json:"cloudAssets,omitempty`
+	CloudAssets           *CloudAssetStatus     `json:"cloudAssets,omitempty"`
 	Reconciliation        *ReconciliationStatus `json:"reconciliation,omitempty"`
 }
 
@@ -52,7 +52,7 @@ type CloudAssetStatus struct {
 	StartTime   time.Time `json:"startTime"`
 }
 
-// ReconciliationStatus describes Reconcilation metadata of a CloudStore
+// ReconciliationStatus describes Reconciliation metadata of a CloudStore
 type ReconciliationStatus struct {
 	Coverage    Window    `json:"coverage"`
 	LastRun     time.Time `json:"lastRun"`


### PR DESCRIPTION
## What does this PR change?
This PR fixes a typo which caused the cloud status object to return with a property `CloudAssets` rather than `cloudAssets`


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)



## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?

