### PR TITLE
optimize query, fix for no cadvisor relabels [DRAFT]

### DIFF
--- a/pkg/costmodel/allocation.go
+++ b/pkg/costmodel/allocation.go
@@ -45,8 +45,8 @@ const (
 	queryFmtNetRegionCostPerGiB   = `avg(avg_over_time(kubecost_network_region_egress_cost{}[%s]%s)) by (%s)`
 	queryFmtNetInternetGiB        = `sum(increase(kubecost_pod_network_egress_bytes_total{internet="true"}[%s]%s)) by (pod_name, namespace, %s) / 1024 / 1024 / 1024`
 	queryFmtNetInternetCostPerGiB = `avg(avg_over_time(kubecost_network_internet_egress_cost{}[%s]%s)) by (%s)`
-	queryFmtNetReceiveBytes       = `sum(increase(container_network_receive_bytes_total{pod_name!=""}[%s]%s)) by (pod_name, namespace, %s)`
-	queryFmtNetTransferBytes      = `sum(increase(container_network_transmit_bytes_total{pod_name!=""}[%s]%s)) by (pod_name, namespace, %s)`
+	queryFmtNetReceiveBytes       = `sum(increase(container_network_receive_bytes_total{pod!="", container_name!="POD", container!="POD"}[%s]%s)) by (pod_name, pod, namespace, %s)`
+	queryFmtNetTransferBytes      = `sum(increase(container_network_transmit_bytes_total{pod!="", container_name!="POD", container!="POD"}[%s]%s)) by (pod_name, pod, namespace, %s)`
 	queryFmtNamespaceLabels       = `avg_over_time(kube_namespace_labels[%s]%s)`
 	queryFmtNamespaceAnnotations  = `avg_over_time(kube_namespace_annotations[%s]%s)`
 	queryFmtPodLabels             = `avg_over_time(kube_pod_labels[%s]%s)`


### PR DESCRIPTION
## What does this PR change?
Neglected to migrate the container_network* queries to new cadvisor data. Also, filtering !="POD" clears a significant amount of data


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Minor query optimization, supports users not using the default cadvisor relabel rules better.


## Links to Issues or ZD tickets this PR addresses or fixes
Perhaps ZD #608? Unclear. 

## How was this PR tested?
Testing now...it is a draft
