### PR TITLE
ClusterMapInfo Injects Local Cluster Info on Empty

### DIFF
--- a/pkg/costmodel/clusterinfo.go
+++ b/pkg/costmodel/clusterinfo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	cloudProvider "github.com/kubecost/cost-model/pkg/cloud"
+	"github.com/kubecost/cost-model/pkg/costmodel/clusters"
 	"github.com/kubecost/cost-model/pkg/env"
 	"github.com/kubecost/cost-model/pkg/thanos"
 
@@ -37,6 +38,27 @@ func writeThanosFlags(clusterInfo map[string]string) {
 	clusterInfo["thanosEnabled"] = fmt.Sprintf("%t", thanos.IsEnabled())
 	if thanos.IsEnabled() {
 		clusterInfo["thanosOffset"] = thanos.Offset()
+	}
+}
+
+// default local cluster info provider implementation which provides an instanced object for
+// getting the local cluster info
+type defaultLocalClusterInfoProvider struct {
+	k8s      kubernetes.Interface
+	provider cloudProvider.Provider
+}
+
+// GetClusterInfo returns a string map containing the local cluster info
+func (dlcip *defaultLocalClusterInfoProvider) GetClusterInfo() map[string]string {
+	return GetClusterInfo(dlcip.k8s, dlcip.provider)
+}
+
+// NewLocalClusterInfoProvider creates a new clusters.LocalClusterInfoProvider implementation for providing local
+// cluster information
+func NewLocalClusterInfoProvider(k8s kubernetes.Interface, cloud cloudProvider.Provider) clusters.LocalClusterInfoProvider {
+	return &defaultLocalClusterInfoProvider{
+		k8s:      k8s,
+		provider: cloud,
 	}
 }
 

--- a/pkg/costmodel/clusters/clustermap.go
+++ b/pkg/costmodel/clusters/clustermap.go
@@ -68,23 +68,31 @@ type ClusterMap interface {
 	StopRefresh()
 }
 
+// LocalClusterInfoProvider is a contract which is capable of performing local cluster info lookups.
+type LocalClusterInfoProvider interface {
+	// GetClusterInfo returns a string map containing the local cluster info
+	GetClusterInfo() map[string]string
+}
+
 // ClusterMap keeps records of all known cost-model clusters.
 type PrometheusClusterMap struct {
-	lock     *sync.RWMutex
-	client   prometheus.Client
-	clusters map[string]*ClusterInfo
-	stop     chan struct{}
+	lock         *sync.RWMutex
+	client       prometheus.Client
+	clusters     map[string]*ClusterInfo
+	localCluster LocalClusterInfoProvider
+	stop         chan struct{}
 }
 
 // NewClusterMap creates a new ClusterMap implementation using a prometheus or thanos client
-func NewClusterMap(client prometheus.Client, refresh time.Duration) ClusterMap {
+func NewClusterMap(client prometheus.Client, lcip LocalClusterInfoProvider, refresh time.Duration) ClusterMap {
 	stop := make(chan struct{})
 
 	cm := &PrometheusClusterMap{
-		lock:     new(sync.RWMutex),
-		client:   client,
-		clusters: make(map[string]*ClusterInfo),
-		stop:     stop,
+		lock:         new(sync.RWMutex),
+		client:       client,
+		clusters:     make(map[string]*ClusterInfo),
+		localCluster: lcip,
+		stop:         stop,
 	}
 
 	// Run an updater to ensure cluster data stays relevant over time
@@ -175,7 +183,57 @@ func (pcm *PrometheusClusterMap) loadClusters() (map[string]*ClusterInfo, error)
 		}
 	}
 
+	if len(clusters) == 0 {
+		localInfo, err := pcm.getLocalClusterInfo()
+		if err != nil {
+			log.Warningf("Failed to load local cluster info: %s", err)
+		} else {
+			clusters[localInfo.ID] = localInfo
+		}
+	}
+
 	return clusters, nil
+}
+
+// getLocalClusterInfo returns the local cluster info in the event there does not exist a metric available.
+func (pcm *PrometheusClusterMap) getLocalClusterInfo() (*ClusterInfo, error) {
+	info := pcm.localCluster.GetClusterInfo()
+
+	var id string
+	var name string
+
+	if i, ok := info["id"]; ok {
+		id = i
+	} else {
+		return nil, fmt.Errorf("Local Cluster Info Missing ID")
+	}
+	if n, ok := info["name"]; ok {
+		name = n
+	} else {
+		return nil, fmt.Errorf("Local Cluster Info Missing Name")
+	}
+
+	var clusterProfile string
+	var provider string
+	var provisioner string
+
+	if cp, ok := info["clusterProfile"]; ok {
+		clusterProfile = cp
+	}
+	if pvdr, ok := info["provider"]; ok {
+		provider = pvdr
+	}
+	if pvsr, ok := info["provisioner"]; ok {
+		provisioner = pvsr
+	}
+
+	return &ClusterInfo{
+		ID:          id,
+		Name:        name,
+		Profile:     clusterProfile,
+		Provider:    provider,
+		Provisioner: provisioner,
+	}, nil
 }
 
 // refreshClusters loads the clusters and updates the internal map

--- a/pkg/costmodel/clusters/clustermap.go
+++ b/pkg/costmodel/clusters/clustermap.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubecost/cost-model/pkg/env"
 	"github.com/kubecost/cost-model/pkg/log"
 	"github.com/kubecost/cost-model/pkg/prom"
 	"github.com/kubecost/cost-model/pkg/thanos"
@@ -183,7 +184,9 @@ func (pcm *PrometheusClusterMap) loadClusters() (map[string]*ClusterInfo, error)
 		}
 	}
 
-	if len(clusters) == 0 {
+	// populate the local cluster if it doesn't exist
+	localID := env.GetClusterID()
+	if _, ok := clusters[localID]; !ok {
 		localInfo, err := pcm.getLocalClusterInfo()
 		if err != nil {
 			log.Warningf("Failed to load local cluster info: %s", err)

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1167,10 +1167,11 @@ func Initialize(additionalConfigWatchers ...ConfigWatchers) *Accesses {
 
 	// Initialize ClusterMap for maintaining ClusterInfo by ClusterID
 	var clusterMap clusters.ClusterMap
+	localCIProvider := NewLocalClusterInfoProvider(kubeClientset, cloudProvider)
 	if thanosClient != nil {
-		clusterMap = clusters.NewClusterMap(thanosClient, 10*time.Minute)
+		clusterMap = clusters.NewClusterMap(thanosClient, localCIProvider, 10*time.Minute)
 	} else {
-		clusterMap = clusters.NewClusterMap(promCli, 5*time.Minute)
+		clusterMap = clusters.NewClusterMap(promCli, localCIProvider, 5*time.Minute)
 	}
 
 	// cache responses from model and aggregation for a default of 10 minutes;


### PR DESCRIPTION
## What does this PR change?
On initial startup, or if cost-model had not been running for the last 5 minutes, the initial prometheus query to get cluster info would always return 0 data (since the cost-model emits this metric). To account for variance here, we always include the local cluster info in the event that the map is empty. 

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* Bug Fix for improperly displaying cluster id/name labels

## How was this PR tested?
Turning off cost-model deployment for 10 minutes, starting up. Observing the bug no longer occurs. 
