### PR TITLE
Allow ComputeAllocation to set an uncontrolled ReplicaSet as a Pod owner

### DIFF
--- a/pkg/costmodel/key.go
+++ b/pkg/costmodel/key.go
@@ -213,22 +213,28 @@ func resultDeploymentKey(res *prom.QueryResult, clusterLabel, namespaceLabel, co
 	return resultControllerKey("deployment", res, clusterLabel, namespaceLabel, controllerLabel)
 }
 
-// resultDeploymentKey creates a controllerKey for a StatefulSet.
+// resultStatefulSetKey creates a controllerKey for a StatefulSet.
 // (See resultControllerKey for more.)
 func resultStatefulSetKey(res *prom.QueryResult, clusterLabel, namespaceLabel, controllerLabel string) (controllerKey, error) {
 	return resultControllerKey("statefulset", res, clusterLabel, namespaceLabel, controllerLabel)
 }
 
-// resultDeploymentKey creates a controllerKey for a DaemonSet.
+// resultDaemonSetKey creates a controllerKey for a DaemonSet.
 // (See resultControllerKey for more.)
 func resultDaemonSetKey(res *prom.QueryResult, clusterLabel, namespaceLabel, controllerLabel string) (controllerKey, error) {
 	return resultControllerKey("daemonset", res, clusterLabel, namespaceLabel, controllerLabel)
 }
 
-// resultDeploymentKey creates a controllerKey for a Job.
+// resultJobKey creates a controllerKey for a Job.
 // (See resultControllerKey for more.)
 func resultJobKey(res *prom.QueryResult, clusterLabel, namespaceLabel, controllerLabel string) (controllerKey, error) {
 	return resultControllerKey("job", res, clusterLabel, namespaceLabel, controllerLabel)
+}
+
+// resultReplicaSetKey creates a controllerKey for a Job.
+// (See resultControllerKey for more.)
+func resultReplicaSetKey(res *prom.QueryResult, clusterLabel, namespaceLabel, controllerLabel string) (controllerKey, error) {
+	return resultControllerKey("replicaset", res, clusterLabel, namespaceLabel, controllerLabel)
 }
 
 type serviceKey struct {


### PR DESCRIPTION
## What does this PR change?
- ComputeAllocation used to not consider ReplicaSets for Pod ownership, assuming that they would be controlled by Deployments. This adds two queries: one to identify ReplicaSets that are not controlled, and another to detect the Pods that are controlled by those uncontrolled ReplicaSets.

## How does this PR impact users?
- Users with Pods controlled by uncontrolled ReplicaSets will see those ReplicaSets as the controllers of those Pods.

## Links to Issues or ZD tickets this PR addresses or fixes
- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1048

## How was this PR tested?
- Manually with logs and UI validation

![Screenshot from 2021-09-03 17-18-09](https://user-images.githubusercontent.com/8070055/132074140-2ef35361-37cd-4210-bbfa-ea658b17ccfb.png)

```
[Info] ReplicaSets: skipping gcp-niko-1/integration/replicaset/deployment-1-79565b94b8 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kube-system/replicaset/kube-dns-c598bd956 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kubecost/replicaset/kubecost-cost-analyzer-5d5758795c (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kubecost/replicaset/kubecost-kube-state-metrics-56766ff87c (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kubecost-staging/replicaset/kubecost-staging-grafana-6766db9b9 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/integration/replicaset/deployment-1-79565b94b8 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/integration/replicaset/deployment-1-79565b94b8 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kube-system/replicaset/kube-dns-autoscaler-7f89fb6b79 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kubecost/replicaset/kubecost-grafana-67748c7b6f (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/default/replicaset/redis-master-67b75d6994 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/default/replicaset/redis-slave-5bbcd8bb7b (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kube-system/replicaset/stackdriver-metadata-agent-cluster-level-5569556685 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kubecost/replicaset/kubecost-prometheus-server-c58bb6f5b (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/turndown/replicaset/cluster-turndown-6474d8fb74 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/default/replicaset/frontend-78cb7dc64b (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kubecost/replicaset/kubecost-cost-analyzer-fdd997d (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/ingress-nginx/replicaset/nginx-ingress-controller-7fcf8df75d (not uncontrolled)
[Info] ReplicaSets: found gcp-niko-1/integration/replicaset/replicaset-1 (uncontrolled)
[Info] ReplicaSets: found gcp-niko-1/integration/replicaset/replicaset-1 (uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kube-system/replicaset/l7-default-backend-5d7d4cfccb (not uncontrolled)
[Info] ReplicaSets: found gcp-niko-1/integration/replicaset/replicaset-1 (uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kubecost-staging/replicaset/kubecost-staging-cost-analyzer-7557948dd8 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/default/replicaset/frontend-78cb7dc64b (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/default/replicaset/redis-slave-5bbcd8bb7b (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kube-system/replicaset/tiller-deploy-6b84bcdb5f (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kubecost-staging/replicaset/kubecost-staging-prometheus-server-59467fcc48 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kube-system/replicaset/event-exporter-gke-666b7ffbf7 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kube-system/replicaset/kube-dns-c598bd956 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kube-system/replicaset/metrics-server-v0.3.6-7b5cdbcbb8 (not uncontrolled)
[Info] ReplicaSets: skipping gcp-niko-1/kubecost-staging/replicaset/kubecost-staging-kube-state-metrics-7c7cdcdbd5 (not uncontrolled)
[Info] ReplicaSets: map map[gcp-niko-1/integration/replicaset-1-cw95d:gcp-niko-1/integration/replicaset/replicaset-1 gcp-niko-1/integration/replicaset-1-kdvbl:gcp-niko-1/integration/replicaset/replicaset-1 gcp-niko-1/integration/replicaset-1-sbzx4:gcp-niko-1/integration/replicaset/replicaset-1]
```