### PR TITLE
Fix AggregateCostModel's parsing of configured SharedOverhead

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -1453,19 +1453,12 @@ func (a *Accesses) ComputeAggregateCostModel(promClient prometheusClient.Client,
 
 	sc := make(map[string]*SharedCostInfo)
 	if !disableSharedOverhead {
-
-		overheadVal := c.SharedOverhead
-
-		cost, err := strconv.ParseFloat(overheadVal, 64)
+		costPerMonth := c.GetSharedOverheadCostPerMonth()
 		durationCoefficient := window.Hours() / timeutil.HoursPerMonth
-		if err != nil {
-			return nil, "", fmt.Errorf("unable to parse shared cost %s: %s", overheadVal, err)
-		}
 		sc["total"] = &SharedCostInfo{
 			Name: "total",
-			Cost: cost * durationCoefficient,
+			Cost: costPerMonth * durationCoefficient,
 		}
-
 	}
 
 	idleCoefficients := make(map[string]float64)


### PR DESCRIPTION
## What does this PR change?
- Implement `GetSharedOverheadCostPerMonth` as a clear and safe way to access the configured shared overhead field.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- When shared overhead is an empty string, the value will default to `0.0` instead of creating errors.

## How was this PR tested?
- Manually on gcp-niko

### Before
![Screenshot from 2021-09-07 13-52-17](https://user-images.githubusercontent.com/8070055/132407466-ae37aa92-f75c-4766-b290-9c96b5ccf568.png)

### After
![Screenshot from 2021-09-07 13-48-37](https://user-images.githubusercontent.com/8070055/132407490-08cf6e5e-b64d-4854-8424-7433c8fd291c.png)

Also confirmed that setting non-zero shared costs still works, then reset to $0.00 and confirmed that that still worked, too.
![Screenshot from 2021-09-07 14-33-02](https://user-images.githubusercontent.com/8070055/132407557-c6748041-92c4-4b6b-8b17-d9387bb21aaf.png)
