### PR TITLE
Config Path Overlap Fixes

### DIFF
--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -914,7 +915,7 @@ func (a *Accesses) GetPrometheusMetrics(w http.ResponseWriter, _ *http.Request, 
 // Creates a new ClusterManager instance using a boltdb storage. If that fails,
 // then we fall back to a memory-only storage.
 func newClusterManager() *cm.ClusterManager {
-	clustersConfigFile := "/var/configs/clusters/default-clusters.yaml"
+	clustersConfigFile := path.Join(env.GetConfigPathWithDefault("/var/configs/"), "clusters/default-clusters.yaml")
 
 	// Return a memory-backed cluster manager populated by configmap
 	return cm.NewConfiguredClusterManager(cm.NewMapDBClusterStorage(), clustersConfigFile)


### PR DESCRIPTION
## What does this PR change?
Removes all hard-coded paths which involve the default CONFIG_PATH environment variable, and replaces with the value from the env package. Since we do not allow the config path to be changed currently from the helm chart, there is currently no effect on the dependent code. However, as we push to build a more reliable configuration, these smaller fixes will become more valuable.

## How was this PR tested?
Helm deployment on AWS and observation. 
