### PR TITLE
Support for fractional GPUs

### DIFF
--- a/pkg/costmodel/costmodel.go
+++ b/pkg/costmodel/costmodel.go
@@ -501,14 +501,14 @@ func (cm *CostModel) ComputeCostData(cli prometheusClient.Client, cp costAnalyze
 
 				gpuReqCount := 0.0
 				if g, ok := container.Resources.Requests["nvidia.com/gpu"]; ok {
-					gpuReqCount = float64(g.Value())
+					gpuReqCount = g.AsApproximateFloat64()
 				} else if g, ok := container.Resources.Limits["nvidia.com/gpu"]; ok {
-					gpuReqCount = float64(g.Value())
+					gpuReqCount = g.AsApproximateFloat64()
 				} else if g, ok := container.Resources.Requests["k8s.amazonaws.com/vgpu"]; ok {
 					// divide vgpu request/limits by total vgpus to get the portion of physical gpus requested
-					gpuReqCount = float64(g.Value()) / vgpuCoeff
+					gpuReqCount = g.AsApproximateFloat64() / vgpuCoeff
 				} else if g, ok := container.Resources.Limits["k8s.amazonaws.com/vgpu"]; ok {
-					gpuReqCount = float64(g.Value()) / vgpuCoeff
+					gpuReqCount = g.AsApproximateFloat64() / vgpuCoeff
 				}
 				GPUReqV := []*util.Vector{
 					{


### PR DESCRIPTION
## What does this PR change?
Changes the function(s) used in parsing container GPU limits, which _should_ allow for fractional GPU percentages (as defined [here](https://docs.run.ai/developer/inference/submit-via-yaml/#submit-inference-workloads-allocating-fractions-of-a-gpu)) to be supported.


## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds support for Run:AI fractional GPUs.


## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-analyzer-helm-chart/issues/1023


## How was this PR tested?
This was difficult to test as, AFAIK, you need Run:AI to actually create pods which use fractional amounts of GPUs. The logic is thus:
- Kubecost gets container GPU allocation through looking at pod `container.Resources.Requests/Limits["nvidia.com/gpu"]`, which is a value of type `resource.Quantity`.
- As per the [docs](https://docs.run.ai/developer/inference/submit-via-yaml/#submit-inference-workloads-allocating-fractions-of-a-gpu), fractional GPUs are specified as under `spec.resources.limits` in the format:
    ```
    limits:
      nvidia.com/gpu: "0.5"
    ```
- Previously, we were doing ` float64(g.Value())` to get these resource limits, which can only get the nearest nonzero int value converted to a float. This PR changes that to `g.AsApproximateFloat64()`, which should allow for a field defined as `resources.limits: nvidia.com/gpu: <SOME-FRACTION>` to be parsed directly as a float. Support for fractional numbers in this field is already confirmed as we support vGPUs in the same way. Separately, I've tested the differences between the new and old ways of getting the value of `g` and they are essentially identical. Additionally, I have tested this on a GPU cluster with pods requesting full GPUs and can see no difference in the numbers resulting from this change.
- Ergo, I believe the changes made should allow for a fractional number to be passed in as a GPU allocation, if a pod with a fractional GPU limit does indeed exist.