### PR TITLE
Added StringTable Encoding/Decoding to AssetSet and AllocationSet

### DIFF
--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -10,7 +10,7 @@ package kubecost
 // @bingen:generate:AssetLabels
 // @bingen:generate:AssetProperties
 // @bingen:generate:AssetProperty
-// @bingen:generate:AssetSet
+// @bingen:generate[stringtable]:AssetSet
 // @bingen:generate:AssetSetRange
 // @bingen:generate:Breakdown
 // @bingen:generate:Cloud
@@ -25,7 +25,7 @@ package kubecost
 // Allocation Version Set: Includes Allocation pipeline specific resources
 // @bingen:set[name=Allocation,version=15]
 // @bingen:generate:Allocation
-// @bingen:generate:AllocationSet
+// @bingen:generate[stringtable]:AllocationSet
 // @bingen:generate:AllocationSetRange
 // @bingen:generate:AllocationProperties
 // @bingen:generate:AllocationProperty

--- a/pkg/kubecost/kubecost_codecs.go
+++ b/pkg/kubecost/kubecost_codecs.go
@@ -34,14 +34,14 @@ const (
 )
 
 const (
+	// AllocationCodecVersion is used for any resources listed in the Allocation version set
+	AllocationCodecVersion uint8 = 15
+
 	// DefaultCodecVersion is used for any resources listed in the Default version set
 	DefaultCodecVersion uint8 = 15
 
 	// AssetsCodecVersion is used for any resources listed in the Assets version set
 	AssetsCodecVersion uint8 = 15
-
-	// AllocationCodecVersion is used for any resources listed in the Allocation version set
-	AllocationCodecVersion uint8 = 15
 )
 
 //--------------------------------------------------------------------------
@@ -1059,7 +1059,7 @@ func (target *AllocationProperties) UnmarshalBinaryWithContext(ctx *DecodingCont
 func (target *AllocationSet) MarshalBinary() (data []byte, err error) {
 	ctx := &EncodingContext{
 		Buffer: util.NewBuffer(),
-		Table:  nil,
+		Table:  NewStringTable(),
 	}
 
 	e := target.MarshalBinaryWithContext(ctx)
@@ -1068,7 +1068,9 @@ func (target *AllocationSet) MarshalBinary() (data []byte, err error) {
 	}
 
 	encBytes := ctx.Buffer.Bytes()
-	return encBytes, nil
+	sTableBytes := ctx.Table.ToBytes()
+	merged := appendBytes(sTableBytes, encBytes)
+	return merged, nil
 }
 
 // MarshalBinaryWithContext serializes the internal properties of this AllocationSet instance
@@ -2101,7 +2103,7 @@ func (target *AssetProperties) UnmarshalBinaryWithContext(ctx *DecodingContext) 
 func (target *AssetSet) MarshalBinary() (data []byte, err error) {
 	ctx := &EncodingContext{
 		Buffer: util.NewBuffer(),
-		Table:  nil,
+		Table:  NewStringTable(),
 	}
 
 	e := target.MarshalBinaryWithContext(ctx)
@@ -2110,7 +2112,9 @@ func (target *AssetSet) MarshalBinary() (data []byte, err error) {
 	}
 
 	encBytes := ctx.Buffer.Bytes()
-	return encBytes, nil
+	sTableBytes := ctx.Table.ToBytes()
+	merged := appendBytes(sTableBytes, encBytes)
+	return merged, nil
 }
 
 // MarshalBinaryWithContext serializes the internal properties of this AssetSet instance


### PR DESCRIPTION
## What does this PR change?
Enables StringTable encoding/decoding on AssetSet and AllocationSet to reduce file size and speed up IO.


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
* From this point forward, all ETL data will be encoding using a string table format which reduces file size 20-30% and speeds up encoding and decoding 20%


## How was this PR tested?
* Against scale cluster data, and with sandboxed bingen tests
