### PR TITLE
Add provider regions

### DIFF
--- a/pkg/cloud/awsprovider.go
+++ b/pkg/cloud/awsprovider.go
@@ -91,7 +91,7 @@ const SpotRefreshDuration = 15 * time.Minute
 
 const defaultConfigPath = "/var/configs/"
 
-var AWSRegions = []string{
+var awsRegions = []string{
 	"us-east-2",
 	"us-east-1",
 	"us-west-1",
@@ -1381,14 +1381,14 @@ func (a *AWS) getAddressesForRegion(region string) (*ec2.DescribeAddressesOutput
 func (a *AWS) GetAddresses() ([]byte, error) {
 	a.ConfigureAuth() // load authentication data into env vars
 
-	addressCh := make(chan *ec2.DescribeAddressesOutput, len(AWSRegions))
-	errorCh := make(chan error, len(AWSRegions))
+	addressCh := make(chan *ec2.DescribeAddressesOutput, len(awsRegions))
+	errorCh := make(chan error, len(awsRegions))
 
 	var wg sync.WaitGroup
-	wg.Add(len(AWSRegions))
+	wg.Add(len(awsRegions))
 
 	// Get volumes from each AWS region
-	for _, r := range AWSRegions {
+	for _, r := range awsRegions {
 		// Fetch IP address response and send results and errors to their
 		// respective channels
 		go func(region string) {
@@ -1466,14 +1466,14 @@ func (a *AWS) getDisksForRegion(region string, maxResults int64, nextToken *stri
 func (a *AWS) GetDisks() ([]byte, error) {
 	a.ConfigureAuth() // load authentication data into env vars
 
-	volumeCh := make(chan *ec2.DescribeVolumesOutput, len(AWSRegions))
-	errorCh := make(chan error, len(AWSRegions))
+	volumeCh := make(chan *ec2.DescribeVolumesOutput, len(awsRegions))
+	errorCh := make(chan error, len(awsRegions))
 
 	var wg sync.WaitGroup
-	wg.Add(len(AWSRegions))
+	wg.Add(len(awsRegions))
 
 	// Get volumes from each AWS region
-	for _, r := range AWSRegions {
+	for _, r := range awsRegions {
 		// Fetch volume response and send results and errors to their
 		// respective channels
 		go func(region string) {
@@ -2325,4 +2325,8 @@ func (a *AWS) ServiceAccountStatus() *ServiceAccountStatus {
 
 func (aws *AWS) CombinedDiscountForNode(instanceType string, isPreemptible bool, defaultDiscount, negotiatedDiscount float64) float64 {
 	return 1.0 - ((1.0 - defaultDiscount) * (1.0 - negotiatedDiscount))
+}
+
+func (aws *AWS) Regions() []string {
+	return awsRegions
 }

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -73,6 +73,77 @@ var (
 	mtStandardN, _ = regexp.Compile(`^Standard_N[C|D|V]\d+r?[_v\d]*[_Promo]*$`)
 )
 
+var azureRegions = []string{
+	"eastus",
+	"eastus2",
+	"southcentralus",
+	"westus2",
+	"westus3",
+	"australiaeast",
+	"southeastasia",
+	"northeurope",
+	"swedencentral",
+	"uksouth",
+	"westeurope",
+	"centralus",
+	"northcentralus",
+	"westus",
+	"southafricanorth",
+	"centralindia",
+	"eastasia",
+	"japaneast",
+	"jioindiawest",
+	"koreacentral",
+	"canadacentral",
+	"francecentral",
+	"germanywestcentral",
+	"norwayeast",
+	"switzerlandnorth",
+	"uaenorth",
+	"brazilsouth",
+	"centralusstage",
+	"eastusstage",
+	"eastus2stage",
+	"northcentralusstage",
+	"southcentralusstage",
+	"westusstage",
+	"westus2stage",
+	"asia",
+	"asiapacific",
+	"australia",
+	"brazil",
+	"canada",
+	"europe",
+	"global",
+	"india",
+	"japan",
+	"uk",
+	"unitedstates",
+	"eastasiastage",
+	"southeastasiastage",
+	"centraluseuap",
+	"eastus2euap",
+	"westcentralus",
+	"southafricawest",
+	"australiacentral",
+	"australiacentral2",
+	"australiasoutheast",
+	"japanwest",
+	"jioindiacentral",
+	"koreasouth",
+	"southindia",
+	"westindia",
+	"canadaeast",
+	"francesouth",
+	"germanynorth",
+	"norwaywest",
+	"swedensouth",
+	"switzerlandwest",
+	"ukwest",
+	"uaecentral",
+	"brazilsoutheast",
+}
+
 const AzureLayout = "2006-01-02"
 
 var HeaderStrings = []string{"MeterCategory", "UsageDateTime", "InstanceId", "AdditionalInfo", "Tags", "PreTaxCost", "SubscriptionGuid", "ConsumedService", "ResourceGroup", "ResourceType"}
@@ -1309,4 +1380,8 @@ func (*Azure) ClusterManagementPricing() (string, float64, error) {
 
 func (az *Azure) CombinedDiscountForNode(instanceType string, isPreemptible bool, defaultDiscount, negotiatedDiscount float64) float64 {
 	return 1.0 - ((1.0 - defaultDiscount) * (1.0 - negotiatedDiscount))
+}
+
+func (az *Azure) Regions() []string {
+	return azureRegions
 }

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -73,6 +73,9 @@ var (
 	mtStandardN, _ = regexp.Compile(`^Standard_N[C|D|V]\d+r?[_v\d]*[_Promo]*$`)
 )
 
+// List obtained by installing the Azure CLI tool "az", described here:
+// https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
+// logging into an Azure account, and running command `az account list-locations`
 var azureRegions = []string{
 	"eastus",
 	"eastus2",
@@ -114,9 +117,16 @@ var azureRegions = []string{
 	"brazil",
 	"canada",
 	"europe",
+	"france",
+	"germany",
 	"global",
 	"india",
 	"japan",
+	"korea",
+	"norway",
+	"southafrica",
+	"switzerland",
+	"uae",
 	"uk",
 	"unitedstates",
 	"eastasiastage",
@@ -137,7 +147,6 @@ var azureRegions = []string{
 	"francesouth",
 	"germanynorth",
 	"norwaywest",
-	"swedensouth",
 	"switzerlandwest",
 	"ukwest",
 	"uaecentral",

--- a/pkg/cloud/csvprovider.go
+++ b/pkg/cloud/csvprovider.go
@@ -366,3 +366,7 @@ func (*CSVProvider) ClusterManagementPricing() (string, float64, error) {
 func (c *CSVProvider) CombinedDiscountForNode(instanceType string, isPreemptible bool, defaultDiscount, negotiatedDiscount float64) float64 {
 	return 1.0 - ((1.0 - defaultDiscount) * (1.0 - negotiatedDiscount))
 }
+
+func (c *CSVProvider) Regions() []string {
+	return []string{}
+}

--- a/pkg/cloud/customprovider.go
+++ b/pkg/cloud/customprovider.go
@@ -308,3 +308,7 @@ func (cp *CustomProvider) PricingSourceStatus() map[string]*PricingSource {
 func (cp *CustomProvider) CombinedDiscountForNode(instanceType string, isPreemptible bool, defaultDiscount, negotiatedDiscount float64) float64 {
 	return 1.0 - ((1.0 - defaultDiscount) * (1.0 - negotiatedDiscount))
 }
+
+func (cp *CustomProvider) Regions() []string {
+	return []string{}
+}

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -34,6 +34,37 @@ import (
 const GKE_GPU_TAG = "cloud.google.com/gke-accelerator"
 const BigqueryUpdateType = "bigqueryupdate"
 
+var gcpRegions = []string{
+	"asia-east1",
+	"asia-east2",
+	"asia-northeast1",
+	"asia-northeast2",
+	"asia-northeast3",
+	"asia-south1",
+	"asia-south2",
+	"asia-southeast1",
+	"asia-southeast2",
+	"australia-southeast1",
+	"australia-southeast2",
+	"europe-central2",
+	"europe-north1",
+	"europe-west1",
+	"europe-west2",
+	"europe-west3",
+	"europe-west4",
+	"europe-west6",
+	"northamerica-northeast1",
+	"northamerica-northeast2",
+	"southamerica-east1",
+	"us-central1",
+	"us-east1",
+	"us-east4",
+	"us-west1",
+	"us-west2",
+	"us-west3",
+	"us-west4",
+}
+
 type userAgentTransport struct {
 	userAgent string
 	base      http.RoundTripper
@@ -1453,6 +1484,10 @@ func (gcp *GCP) PricingSourceStatus() map[string]*PricingSource {
 func (gcp *GCP) CombinedDiscountForNode(instanceType string, isPreemptible bool, defaultDiscount, negotiatedDiscount float64) float64 {
 	class := strings.Split(instanceType, "-")[0]
 	return 1.0 - ((1.0 - sustainedUseDiscount(class, defaultDiscount, isPreemptible)) * (1.0 - negotiatedDiscount))
+}
+
+func (gcp *GCP) Regions() []string {
+	return gcpRegions
 }
 
 func sustainedUseDiscount(class string, defaultDiscount float64, isPreemptible bool) float64 {

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -34,6 +34,9 @@ import (
 const GKE_GPU_TAG = "cloud.google.com/gke-accelerator"
 const BigqueryUpdateType = "bigqueryupdate"
 
+// List obtained by installing the `gcloud` CLI tool,
+// logging into gcp account, and running command
+// `gcloud compute regions list`
 var gcpRegions = []string{
 	"asia-east1",
 	"asia-east2",

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -264,6 +264,7 @@ type Provider interface {
 	PricingSourceStatus() map[string]*PricingSource
 	ClusterManagementPricing() (string, float64, error)
 	CombinedDiscountForNode(string, bool, float64, float64) float64
+	Regions() []string
 }
 
 // ClusterName returns the name defined in cluster info, defaulting to the


### PR DESCRIPTION
Adds a list of supported regions to each provider, and adds a `Regions()` getter to the provider interface. Makes awsRegions var private again.

## What does this PR change?
Providers now implement a `Regions()` method, which returns a list of valid regions.


## Does this PR rely on any other PRs?
No

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
N/A


## Links to Issues or ZD tickets this PR addresses or fixes
N/A


## How was this PR tested?
Manually
