### PR TITLE
fix: kube_persistentvolumeclaim_info order

### DIFF
--- a/pkg/metrics/pvcmetrics.go
+++ b/pkg/metrics/pvcmetrics.go
@@ -29,7 +29,7 @@ func (kpvc KubePVCCollector) Collect(ch chan<- prometheus.Metric) {
 		storageClass := getPersistentVolumeClaimClass(pvc)
 		volume := pvc.Spec.VolumeName
 
-		ch <- newKubePVCInfoMetric("kube_persistentvolumeclaim_info", pvc.Name, pvc.Namespace, volume, storageClass)
+		ch <- newKubePVCInfoMetric("kube_persistentvolumeclaim_info", pvc.Name, pvc.Namespace, storageClass, volume)
 
 		if storage, ok := pvc.Spec.Resources.Requests[v1.ResourceStorage]; ok {
 			ch <- newKubePVCResourceRequestsStorageBytesMetric("kube_persistentvolumeclaim_resource_requests_storage_bytes", pvc.Name, pvc.Namespace, float64(storage.Value()))


### PR DESCRIPTION
## What does this PR change?

Fixes #939 messed up metric kube_persistentvolumeclaim_info labels order. 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
It won't affect any users. It only fixes the [labeling issue](https://github.com/kubecost/cost-model/issues/939). 


## How was this PR tested?
Locally. 
