### PR TITLE
prevent cloud assets from being considered for reconciliation

### DIFF
--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2727,7 +2727,7 @@ func (as *AssetSet) ReconciliationMatch(query Asset) (Asset, bool, error) {
 	for _, asset := range as.assets {
 		// Ignore cloud assets when looking for reconciliation matches
 		if asset.Type() == CloudAssetType {
-			continue;
+			continue
 		}
 		if k, err := key(asset, fullMatchProps); err != nil {
 			return nil, false, err

--- a/pkg/kubecost/asset.go
+++ b/pkg/kubecost/asset.go
@@ -2725,6 +2725,10 @@ func (as *AssetSet) ReconciliationMatch(query Asset) (Asset, bool, error) {
 
 	var providerIDMatch Asset
 	for _, asset := range as.assets {
+		// Ignore cloud assets when looking for reconciliation matches
+		if asset.Type() == CloudAssetType {
+			continue;
+		}
 		if k, err := key(asset, fullMatchProps); err != nil {
 			return nil, false, err
 		} else if k == fullMatchKey {


### PR DESCRIPTION
## What does this PR change
Update reconciliation match check to ignore cloud assets. Cloud Assets do not need to be reconciled with the CUR because that is their source, additionally this lack of filtering appears to be having a negative interaction with the reserved instances in the AWS provider. The enforced compute category of this query is causing partial matches to happen where full matches should be taking place, and inserting duplicate cloud assets into the Asset ETL 
![Screen Shot 2021-09-16 at 5 47 38 PM](https://user-images.githubusercontent.com/12225425/133706554-55e1e536-c5ce-46e9-b826-5eac5ad43e12.png)

## Does this PR rely on any other PRs?

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Faster Reconciliation, remove duplication


## Links to Issues or ZD tickets this PR addresses or fixes

## How was this PR tested?
Tested on federated cluster 
