### PR TITLE
Add .gitignore for large AWS reserved instance offering file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ui/.cache
 ui/dist
 ui/node_modules/
+configs/awsreservationofferings.json


### PR DESCRIPTION
This keeps the file `awsreservationofferings.json` out of git, but you still need to add it yourself to the `./configs` directory.

Required for https://github.com/kubecost/kubecost-cost-model/pull/539