### PR TITLE
Avoid nil panic on non-GKE GCP clusters (K3s)

### DIFF
--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -1403,15 +1403,25 @@ func (gcp *gcpKey) Features() string {
 		log.DedupedErrorf(1, "Missing or Unknown 'node.kubernetes.io/instance-type' node label")
 		instanceType = "unknown"
 	} else {
-		instanceType = strings.ToLower(strings.Join(strings.Split(it, "-")[:2], ""))
-		if instanceType == "n1highmem" || instanceType == "n1highcpu" {
-			instanceType = "n1standard" // These are priced the same. TODO: support n1ultrahighmem
-		} else if instanceType == "n2highmem" || instanceType == "n2highcpu" {
-			instanceType = "n2standard"
-		} else if instanceType == "e2highmem" || instanceType == "e2highcpu" {
-			instanceType = "e2standard"
-		} else if strings.HasPrefix(instanceType, "custom") {
-			instanceType = "custom" // The suffix of custom does not matter
+		splitByDash := strings.Split(it, "-")
+
+		// GKE nodes are labeled with the GCP instance type, but users can deploy on GCP
+		// with tools like K3s, whose instance type labels will be "k3s". This logic
+		// avoids a panic in the slice operation then there are no dashes (-) in the
+		// instance type label value.
+		if len(splitByDash) < 3 {
+			instanceType = "unknown"
+		} else {
+			instanceType = strings.ToLower(strings.Join(splitByDash[:2], ""))
+			if instanceType == "n1highmem" || instanceType == "n1highcpu" {
+				instanceType = "n1standard" // These are priced the same. TODO: support n1ultrahighmem
+			} else if instanceType == "n2highmem" || instanceType == "n2highcpu" {
+				instanceType = "n2standard"
+			} else if instanceType == "e2highmem" || instanceType == "e2highcpu" {
+				instanceType = "e2standard"
+			} else if strings.HasPrefix(instanceType, "custom") {
+				instanceType = "custom" // The suffix of custom does not matter
+			}
 		}
 	}
 

--- a/pkg/cloud/gcpprovider.go
+++ b/pkg/cloud/gcpprovider.go
@@ -1395,6 +1395,33 @@ func (gcp *gcpKey) GPUType() string {
 	return ""
 }
 
+func parseGCPInstanceTypeLabel(it string) string {
+	var instanceType string
+
+	splitByDash := strings.Split(it, "-")
+
+	// GKE nodes are labeled with the GCP instance type, but users can deploy on GCP
+	// with tools like K3s, whose instance type labels will be "k3s". This logic
+	// avoids a panic in the slice operation then there are no dashes (-) in the
+	// instance type label value.
+	if len(splitByDash) < 2 {
+		instanceType = "unknown"
+	} else {
+		instanceType = strings.ToLower(strings.Join(splitByDash[:2], ""))
+		if instanceType == "n1highmem" || instanceType == "n1highcpu" {
+			instanceType = "n1standard" // These are priced the same. TODO: support n1ultrahighmem
+		} else if instanceType == "n2highmem" || instanceType == "n2highcpu" {
+			instanceType = "n2standard"
+		} else if instanceType == "e2highmem" || instanceType == "e2highcpu" {
+			instanceType = "e2standard"
+		} else if strings.HasPrefix(instanceType, "custom") {
+			instanceType = "custom" // The suffix of custom does not matter
+		}
+	}
+
+	return instanceType
+}
+
 // GetKey maps node labels to information needed to retrieve pricing data
 func (gcp *gcpKey) Features() string {
 	var instanceType string
@@ -1403,26 +1430,7 @@ func (gcp *gcpKey) Features() string {
 		log.DedupedErrorf(1, "Missing or Unknown 'node.kubernetes.io/instance-type' node label")
 		instanceType = "unknown"
 	} else {
-		splitByDash := strings.Split(it, "-")
-
-		// GKE nodes are labeled with the GCP instance type, but users can deploy on GCP
-		// with tools like K3s, whose instance type labels will be "k3s". This logic
-		// avoids a panic in the slice operation then there are no dashes (-) in the
-		// instance type label value.
-		if len(splitByDash) < 3 {
-			instanceType = "unknown"
-		} else {
-			instanceType = strings.ToLower(strings.Join(splitByDash[:2], ""))
-			if instanceType == "n1highmem" || instanceType == "n1highcpu" {
-				instanceType = "n1standard" // These are priced the same. TODO: support n1ultrahighmem
-			} else if instanceType == "n2highmem" || instanceType == "n2highcpu" {
-				instanceType = "n2standard"
-			} else if instanceType == "e2highmem" || instanceType == "e2highcpu" {
-				instanceType = "e2standard"
-			} else if strings.HasPrefix(instanceType, "custom") {
-				instanceType = "custom" // The suffix of custom does not matter
-			}
-		}
+		instanceType = parseGCPInstanceTypeLabel(it)
 	}
 
 	r, _ := util.GetRegion(gcp.Labels)

--- a/pkg/cloud/gcpprovider_test.go
+++ b/pkg/cloud/gcpprovider_test.go
@@ -1,0 +1,36 @@
+package cloud
+
+import (
+	"testing"
+)
+
+func TestParseGCPInstanceTypeLabel(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "n1-standard-2",
+			expected: "n1standard",
+		},
+		{
+			input:    "e2-medium",
+			expected: "e2medium",
+		},
+		{
+			input:    "k3s",
+			expected: "unknown",
+		},
+		{
+			input:    "custom-n1-standard-2",
+			expected: "custom",
+		},
+	}
+
+	for _, test := range cases {
+		result := parseGCPInstanceTypeLabel(test.input)
+		if result != test.expected {
+			t.Errorf("Input: %s, Expected: %s, Actual: %s", test.input, test.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR change?

A user running K3s on GCP is encountering a nil panic
caused by our parsing logic for the node.kubernetes.io/instance-type
label. On GCP, we expect GCP node type formats (xx-xx-xx) with
one or two dashes. The K3s cluster sets this value as just "k3s" in the
user's cluster.

By adding a guard on the length of the parsed result we avoid the panic.

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Fix a bug where a nil panic would occur when running on K3s clusters on GCP.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://kubecost.zendesk.com/agent/tickets/864

## How was this PR tested?

Deployed to a GKE cluster to confirm nothing broke (no errors observed) and added unit test for the user's specific case.

## Have you made an update to documentation?

N/A