### PR TITLE
Emit the node_gpu_hourly_cost metric

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -472,6 +472,7 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 				}
 
 				cmme.GPUCountRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion, node.ProviderID).Set(gpu)
+				cmme.GPUPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion, node.ProviderID).Set(gpuCost)
 
 				const outlierFactor float64 = 30
 				// don't record cpuCost, ramCost, or gpuCost in the case of wild outliers


### PR DESCRIPTION
## What does this PR change?

The GaugeVec for recording `node_gpu_hourly_cost` is correctly initialized
but is never written to. This behavior can be observed by deploying
Kubecost and visiting /model/metrics. You will note that the
`node_gpu_count` metric exists but the `node_gpu_hourly_cost` metric does not.

This is causing GPU cost to be 0 throughout the Kubecost application,
even if GPUs are present on a Node and their count is correctly
recorded (see the Assets API).

Fixed by emitting GPU cost!

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

Fixes GPU cost for nodes being incorrectly reported as 0, even when GPUs are present on the node.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://kubecost.zendesk.com/tickets/1041

## How was this PR tested?

Deployed the updated code, observed the `node_gpu_hourly_cost` metric appearing on the `/model/metrics` page.

## Have you made an update to documentation?

N/A