### PR TITLE
Emit the node_gpu_hourly_cost metric

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -472,6 +472,7 @@ func (cmme *CostModelMetricsEmitter) Start() bool {
 				}
 
 				cmme.GPUCountRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion, node.ProviderID).Set(gpu)
+				cmme.GPUPriceRecorder.WithLabelValues(nodeName, nodeName, nodeType, nodeRegion, node.ProviderID).Set(gpuCost)
 
 				const outlierFactor float64 = 30
 				// don't record cpuCost, ramCost, or gpuCost in the case of wild outliers


### PR DESCRIPTION
Cherry pick of https://github.com/kubecost/cost-model/pull/992 for hotfix. See that PR for notes and commentary.