### PR TITLE
Detect the correct azure cloud api object to use by billing region

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -929,9 +929,6 @@ func determineCloudByRegion(region string) azure.Environment{
 	if strings.Contains(lcRegion, "china") {
 		return azure.ChinaCloud
 	}
-	if strings.Contains(lcRegion, "germany") {
-		return azure.GermanCloud
-	}
 	if strings.Contains(lcRegion, "gov") || strings.Contains(lcRegion, "dod") {
 		return azure.USGovernmentCloud
 	}

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -761,7 +761,7 @@ func (az *Azure) DownloadPricingData() error {
 		a, err := auth.NewAuthorizerFromEnvironment()
 		authorizer = a
 		if err != nil { // Failed to create authorizer from environment, try from file
-			a, err := auth.NewAuthorizerFromFile(azure.PublicCloud.ResourceManagerEndpoint)
+			a, err := auth.NewAuthorizerFromFile(determineCloudByRegion(config.AzureBillingRegion).ResourceManagerEndpoint)
 			if err != nil {
 				az.RateCardPricingError = err
 				return err
@@ -921,6 +921,22 @@ func (az *Azure) DownloadPricingData() error {
 	az.Pricing = allPrices
 	az.RateCardPricingError = nil
 	return nil
+}
+
+// determineCloudByRegion uses region name to pick the correct Cloud Environment for the azure provider to use
+func determineCloudByRegion(region string) azure.Environment{
+	lcRegion := strings.ToLower(region)
+	if strings.Contains(lcRegion, "china") {
+		return azure.ChinaCloud
+	}
+	if strings.Contains(lcRegion, "germany") {
+		return azure.GermanCloud
+	}
+	if strings.Contains(lcRegion, "gov") || strings.Contains(lcRegion, "dod") {
+		return azure.USGovernmentCloud
+	}
+	// Default to public cloud
+	return azure.PublicCloud
 }
 
 func (az *Azure) addPricing(features string, azurePricing *AzurePricing) {


### PR DESCRIPTION
## What does this PR change?
This PR adds a method that switches out the azure SDK environment object that is used based on the configured billing region. The environment object contains the correct endpoints for that particular cloud.


## Does this PR rely on any other PRs?

- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Users on US gov cloud and China cloud should be able to use the rate card api


## Links to Issues or ZD tickets this PR addresses or fixes

- https://github.com/kubecost/cost-model/issues/990
- https://kubecost.zendesk.com/agent/tickets/995


## How was this PR tested?
This PR defaults to the original functionality, and continues to work on my clusters, but I will have to rely on user feedback to ensure that the gov cloud option is working. 


## Have you made an update to documentation?

