### PR TITLE
Fix Azure norwayeast instance pricing not being parsed correctly

### DIFF
--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -789,13 +789,16 @@ func (az *Azure) DownloadPricingData() error {
 
 	klog.Infof("Using ratecard query %s", rateCardFilter)
 	result, err := rcClient.Get(context.TODO(), rateCardFilter)
+	//klog.Infof("result meters valid %t", result.Meters != nil)
 	if err != nil {
+		klog.Infof("Error in pricing download query")
 		az.RateCardPricingError = err
 		return err
 	}
 	allPrices := make(map[string]*AzurePricing)
 	regions, err := getRegions("compute", sClient, providersClient, config.AzureSubscriptionID)
 	if err != nil {
+		klog.Infof("Error in pricing download regions")
 		az.RateCardPricingError = err
 		return err
 	}
@@ -807,6 +810,8 @@ func (az *Azure) DownloadPricingData() error {
 		meterRegion := *v.MeterRegion
 		meterCategory := *v.MeterCategory
 		meterSubCategory := *v.MeterSubCategory
+
+		//klog.Infof("MeterName: %s", meterName)
 
 		region, err := toRegionID(meterRegion, regions)
 		if err != nil {
@@ -919,6 +924,14 @@ func (az *Azure) DownloadPricingData() error {
 	}
 
 	az.Pricing = allPrices
+
+	klog.Infof("--AZURE PRICING RESULTS IN DOWNLOAD--")
+
+	for key, _ := range az.Pricing {
+		//klog.Infof("KEY: %s has Node pricing of %s: %s and PV pricing of %s.", key, azp.Node.Region, azp.Node.InstanceType, azp.PV.Class)
+		klog.Infof("THIS: %s", key)
+	}
+
 	az.RateCardPricingError = nil
 	return nil
 }
@@ -991,6 +1004,14 @@ func (az *Azure) NodePricing(key Key) (*Node, error) {
 		return n.Node, nil
 	}
 	klog.V(1).Infof("[Warning] no pricing data found for %s: %s", azKey.Features(), azKey)
+
+	klog.Infof("--AZURE PRICING RESULTS IN NODE PRICING--")
+
+	for key, _ := range az.Pricing {
+		//klog.Infof("KEY: %s has Node pricing of %s: %s and PV pricing of %s.", key, azp.Node.Region, azp.Node.InstanceType, azp.PV.Class)
+		klog.Infof("THIS: %s", key)
+	}
+
 	c, err := az.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("No default pricing data available")

--- a/pkg/cloud/azureprovider.go
+++ b/pkg/cloud/azureprovider.go
@@ -790,7 +790,6 @@ func (az *Azure) DownloadPricingData() error {
 
 	klog.Infof("Using ratecard query %s", rateCardFilter)
 	result, err := rcClient.Get(context.TODO(), rateCardFilter)
-	//klog.Infof("result meters valid %t", result.Meters != nil)
 	if err != nil {
 		klog.Warningf("Error in pricing download query from API")
 		az.RateCardPricingError = err
@@ -805,7 +804,6 @@ func (az *Azure) DownloadPricingData() error {
 	}
 
 	baseCPUPrice := config.CPU
-	regionError := false
 
 	for _, v := range *result.Meters {
 		meterName := *v.MeterName
@@ -815,7 +813,6 @@ func (az *Azure) DownloadPricingData() error {
 
 		region, err := toRegionID(meterRegion, regions)
 		if err != nil {
-			regionError = true
 			continue
 		}
 
@@ -908,10 +905,6 @@ func (az *Azure) DownloadPricingData() error {
 				}
 			}
 		}
-	}
-
-	if regionError {
-		klog.V(1).Infof("Some pricing regions failed to parse. This is not an error, but could lead to errors in NodePricing.")
 	}
 
 	// There is no easy way of supporting Standard Azure-File, because it's billed per used GB

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -358,6 +358,9 @@ func (a *Accesses) RefreshPricingData(w http.ResponseWriter, r *http.Request, ps
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	err := a.CloudProvider.DownloadPricingData()
+	if err != nil {
+		klog.V(1).Infof("Error refreshing pricing data: %s", err.Error())
+	}
 
 	w.Write(WrapData(nil, err))
 }


### PR DESCRIPTION
## What does this PR change?
Support norwayeast node pricing. Technically a fix as data already exists in API response + pricing logic, it was just being filtered out incorrectly. 

Also, added logs for when long-running pricing API requests fail, which can be missed when only returned e.g. when navigating away from settings.html before change to settings actually happens, page will report success but query to pricing can still fail silently.

## Does this PR rely on any other PRs?
No.

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Support node pricing in Azure norwayeast region.

## Links to Issues or ZD tickets this PR addresses or fixes

- https://kubecost.zendesk.com/agent/tickets/995
- https://github.com/kubecost/cost-model/issues/984


## How was this PR tested?
Tested on kubecost running on fresh Azure norwayeast Standard_DS2_v2 on-demand node and observing pricing configurations.

## Have you made an update to documentation?
No.
