### PR TITLE
Fix shared overhead on Summary Allocation API

### DIFF
--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -671,6 +671,7 @@ func (sas *SummaryAllocationSet) AggregateBy(aggregateBy []string, options *Allo
 
 			shareSet.Insert(&SummaryAllocation{
 				Name:       fmt.Sprintf("%s/%s", name, SharedSuffix),
+				Properties: &AllocationProperties{},
 				Start:      *sas.Window.Start(),
 				End:        *sas.Window.End(),
 				SharedCost: totalSharedCost,


### PR DESCRIPTION
## What does this PR change?
* Fixes a bug where, due to order of operations, shared overhead would not be shared unless other resources were shared.

## How was this PR tested?
* Integration tests: https://github.com/kubecost/kubecost-integration-tests/pull/28
* Manual testing on `gcp-niko`
