### PR TITLE
load SubscriptionID from secret if available and load into env variable

### DIFF
--- a/pkg/cloud/csvretriever.go
+++ b/pkg/cloud/csvretriever.go
@@ -58,9 +58,9 @@ func (acr AzureCSVRetriever) getMostRecentFiles(start, end time.Time, containerU
 }
 
 func (acr AzureCSVRetriever) getContainer() (*azblob.ContainerURL, error) {
-	accountKey := env.GetAzureStorageAccessKey()
-	accountName := env.GetAzureStorageAccountName()
-	containerName := env.GetAzureStorageContainerName()
+	accountName := env.Get(env.AzureStorageAccountNameEnvVar, "")
+	accountKey := env.Get(env.AzureStorageAccessKeyEnvVar, "")
+	containerName := env.Get(env.AzureStorageContainerNameEnvVar, "")
 	if accountName == "" || accountKey == "" || containerName == "" {
 		return nil, fmt.Errorf("set up Azure storage config to access out of cluster costs")
 	}

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -16,6 +16,7 @@ const (
 	AWSAccessKeySecretEnvVar = "AWS_SECRET_ACCESS_KEY"
 	AWSClusterIDEnvVar       = "AWS_CLUSTER_ID"
 
+	AzureStorageSubscriptionIDEnvVar       = "AZURE_SUBSCRIPTION_ID"
 	AzureStorageAccessKeyEnvVar     = "AZURE_STORAGE_ACCESS_KEY"
 	AzureStorageAccountNameEnvVar   = "AZURE_STORAGE_ACCOUNT"
 	AzureStorageContainerNameEnvVar = "AZURE_STORAGE_CONTAINER"
@@ -169,18 +170,6 @@ func GetAWSAccessKeySecret() string {
 // an AWS specific cluster identifier.
 func GetAWSClusterID() string {
 	return Get(AWSClusterIDEnvVar, "")
-}
-
-func GetAzureStorageAccessKey() string {
-	return Get(AzureStorageAccessKeyEnvVar, "")
-}
-
-func GetAzureStorageAccountName() string {
-	return Get(AzureStorageAccountNameEnvVar, "")
-}
-
-func GetAzureStorageContainerName() string {
-	return Get(AzureStorageContainerNameEnvVar, "")
 }
 
 // GetKubecostNamespace returns the environment variable value for KubecostNamespaceEnvVar which


### PR DESCRIPTION
## What does this PR change?
This PR fixes a bug introduced with the Multi-Cloud integration feature where Azure users with a single cloud integration need to have set the rate card api configuration (particularly subscriptionID) for the Azure storage cloud integration to function. The reason for this is that Multi-Cloud introduced the idea of ProviderID for each cloud provider to prevent duplicate providers. In the case of Azure, the unique providerID is the Subscription ID. Since subscriptionID is not necessary to query the Azure Storage api it was not included in the original configuration, but it is the best unique identifier for the data contained in Storage per integration.


## Does this PR rely on any other PRs?

- https://github.com/kubecost/kubecost-cost-model/pull/593
- https://github.com/kubecost/cost-analyzer-helm-chart/pull/1161


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
New users setting up Kubecost for Azure will not have to set up the rate card api to have Cloud Integration using Azure Storage work.


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
This PR was tested on an Azure cluster to ensure that users with previous configuration would not be affected by these changes and to show that the Cloud Processes could run without the rate card api being configured.

## Have you made an update to documentation?
https://github.com/kubecost/docs/pull/153
