### PR TITLE
Ajay tripathy env cleanup

### DIFF
--- a/configs/pricing_schema_pv.csv
+++ b/configs/pricing_schema_pv.csv
@@ -1,0 +1,2 @@
+EndTimestamp,InstanceID,Region,AssetClass,InstanceIDField,InstanceType,MarketPriceHourly,Version
+2019-04-17 23:34:22 UTC,pvc-08e1f205-d7a9-4430-90fc-7b3965a18c4d,,pv,metadata.name,,0.1337,

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1093,6 +1093,9 @@ func (a *Accesses) GetPod(w http.ResponseWriter, r *http.Request, ps httprouter.
 	// TODO: ClusterCache API could probably afford to have some better filtering
 	allPods := a.ClusterCache.GetAllPods()
 	for _, pod := range allPods {
+		for _, container := range pod.Spec.Containers {
+			container.Env = make([]v1.EnvVar, 0)
+		}
 		if pod.Namespace == podNamespace && pod.Name == podName {
 			body, err := json.Marshal(pod)
 			if err != nil {

--- a/test/cloud_test.go
+++ b/test/cloud_test.go
@@ -92,6 +92,32 @@ func TestNodeValueFromMapField(t *testing.T) {
 
 }
 
+func TestPVPriceFromCSV(t *testing.T) {
+	nameWant := "pvc-08e1f205-d7a9-4430-90fc-7b3965a18c4d"
+	pv := &v1.PersistentVolume{}
+	pv.Name = nameWant
+
+	wantPrice := "0.1337"
+	c := &cloud.CSVProvider{
+		CSVLocation: "../configs/pricing_schema_pv.csv",
+		CustomProvider: &cloud.CustomProvider{
+			Config: cloud.NewProviderConfig("../configs/default.json"),
+		},
+	}
+	c.DownloadPricingData()
+	k := c.GetPVKey(pv, make(map[string]string), "")
+	resPV, err := c.PVPricing(k)
+	if err != nil {
+		t.Errorf("Error in NodePricing: %s", err.Error())
+	} else {
+		gotPrice := resPV.Cost
+		if gotPrice != wantPrice {
+			t.Errorf("Wanted price '%s' got price '%s'", wantPrice, gotPrice)
+		}
+	}
+
+}
+
 func TestNodePriceFromCSV(t *testing.T) {
 	providerIDWant := "providerid"
 	nameWant := "gke-standard-cluster-1-pool-1-91dc432d-cg69"


### PR DESCRIPTION
## What does this PR change?
Remove env variables from being sent by /api/allPods


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
You will no longer be able to see env vars on /api/allPods, which was an internal-only API anyway, so no impact.

## How was this PR tested?
Visit /api/allPods and note env variables are not sent.

## Have you made an update to documentation?
No-- internal api only and subject to change.
