### PR TITLE
deprecate recording rule metric

### DIFF
--- a/pkg/prom/diagnostics.go
+++ b/pkg/prom/diagnostics.go
@@ -101,13 +101,6 @@ func GetPrometheusMetrics(client prometheus.Client, offset string) ([]*Prometheu
 			DocLink:     fmt.Sprintf("%s#node-exporter-metrics-available", docs),
 		},
 		{
-			ID:          "recordingMetric",
-			Query:       fmt.Sprintf(`absent_over_time(node_cpu_seconds_total[5m]  %s)`, offset),
-			Label:       "Recording rules are available",
-			Description: "Determine if metrics defined by kubecost recording rules are available during last 5 minutes.",
-			DocLink:     fmt.Sprintf("%s#recording-rules-are-available", docs),
-		},
-		{
 			ID:          "cadvisorLabel",
 			Query:       fmt.Sprintf(`absent_over_time(container_cpu_usage_seconds_total{container!="",pod!=""}[5m]  %s)`, offset),
 			Label:       "Expected cAdvsior labels available",


### PR DESCRIPTION
## What does this PR change?
Remove deprecated diagnostic for recording rules


## Does this PR rely on any other PRs?
Related to https://github.com/kubecost/cost-analyzer-helm-chart/pull/1185 . See more ticket details there.