### PR TITLE
Regenerate codecs with backwards-compat support

### DIFF
--- a/pkg/kubecost/bingen.go
+++ b/pkg/kubecost/bingen.go
@@ -1,5 +1,25 @@
 package kubecost
 
+////////////////////////////////////////////////////////////////////////////////
+// NOTE: If you add fields to _any_ struct that is serialized by bingen, please
+// make sure to add those fields to the END of the struct definition. This is
+// required for backwards-compatibility. So:
+//
+// type Foo struct {
+//     ExistingField1 string
+//     ExistingField2 int
+// }
+//
+// becomes:
+//
+// type Foo struct {
+//     ExistingField1 string
+//     ExistingField2 int
+//     NewField       float64 // @bingen: <- annotation ref: bingen README
+// }
+//
+////////////////////////////////////////////////////////////////////////////////
+
 // Default Version Set (uses -version flag passed) includes shared resources
 // @bingen:generate:Window
 


### PR DESCRIPTION
## What does this PR change?

Updates codecs with bingen v0.0.7 by rerunning `go generate ./...`.

Bingen supports backwards compatibility (1). This commit doesn't add
any fields, so it should be safe to keep the schema version as v15.
All data should effectively read and write the same, just with support
for reading v<=15 schemas. Migration of old schema files to the new
file location will be part of a different PR.

1. https://github.com/kubecost/bingen/pull/7

## Does this PR rely on any other PRs?

N/A

## How does this PR impact users? (This is the kind of thing that goes in release notes!)

N/A. Future PRs that rely on this will, though!

## Links to Issues or ZD tickets this PR addresses or fixes

N/A

## How was this PR tested?

Deployed to an existing cluster. Noted that the UI loads as expected and the ETL logging that it was loading from backup files:
```
I0124 20:01:05.605572       1 log.go:62] [Profiler] 728.543µs: ETL: Allocation[1h]: build[ftifr]: from backup: coverage [2022-01-24T15:00:00+0000, 2022-01-24T20:01:05+0000) (10.2% complete)
```

## Have you made an update to documentation?

Yes, see the new comment in bingen.go.