### PR TITLE
Implement AllocationSetRange.AccumulateBy

### DIFF
--- a/pkg/costmodel/aggregation.go
+++ b/pkg/costmodel/aggregation.go
@@ -2160,6 +2160,11 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	// sums each Set in the Range, producing one Set.
 	accumulate := qp.GetBool("accumulate", false)
 
+	// AccumulateBy is an optional parameter that accumulates an AllocationSetRange
+	// by the resolution of the given time duration.
+	// Defaults to 0. If a value is not passed then the parameter is not used.
+	accumulateBy := qp.GetDuration("accumulateBy", 0)
+
 	// Query for AllocationSets in increments of the given step duration,
 	// appending each to the AllocationSetRange.
 	asr := kubecost.NewAllocationSetRange()
@@ -2188,7 +2193,13 @@ func (a *Accesses) ComputeAllocationHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Accumulate, if requested
-	if accumulate {
+	if accumulateBy != 0 {
+		asr, err = asr.AccumulateBy(accumulateBy)
+		if err != nil {
+			WriteError(w, InternalServerError(err.Error()))
+			return
+		}
+	} else if accumulate {
 		as, err := asr.Accumulate()
 		if err != nil {
 			WriteError(w, InternalServerError(err.Error()))

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -2269,9 +2269,6 @@ func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*Allocati
 	asr.Lock()
 	defer asr.Unlock()
 
-	fmt.Printf("asr window duration: %v\n", asr.window().Duration())
-	fmt.Printf("resolution: %v\n", resolution)
-
 	// use window() with no lock
 	if asr.window().IsEmpty() {
 		return asr, nil
@@ -2279,7 +2276,7 @@ func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*Allocati
 
 	// Call total accumulate func if resolution is greater than total window duration
 	if resolution > asr.window().Duration() {
-		// unable to acquire lock here if old accumulate is called
+		// unable to acquire lock here if old asr.accumulate is called
 		for _, as := range asr.allocations {
 			allocSet, err = allocSet.accumulate(as)
 			if err != nil {
@@ -2304,14 +2301,13 @@ func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*Allocati
 	// check as.window and accumulate till windowSum == time.duration wanted -> add accumulated set to allocSetRange
 	var currAccumulatedSum time.Duration
 	for _, as := range asr.allocations {
-		//What time group are we in? Is time group bigger than duration?
 		allocSet, err = allocSet.accumulate(as)
 		if err != nil {
 			return nil, err
 		}
 		currAccumulatedSum += allocSet.Window.Duration()
 
-		fmt.Printf("asr end %v as end %v\n", asrWindow.end, allocSet.Window.end)
+		// fmt.Printf("asr end %v as end %v\n", asrWindow.end, allocSet.Window.end)
 		// two ways to get end of asr window
 		// 1. check if last set of asr
 		// 2. check if set window.end is asr.window.end
@@ -2519,8 +2515,6 @@ func (asr *AllocationSetRange) window() Window {
 	start := asr.allocations[0].Start()
 	end := asr.allocations[length-1].End()
 
-	fmt.Printf("start %v\n", start)
-	fmt.Printf("end %v\n", end)
 	return NewWindow(&start, &end)
 }
 

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -2273,7 +2273,6 @@ func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*Allocati
 
 	asr.Lock()
 	defer asr.Unlock()
-
 	for i, as := range asr.allocations {
 		allocSet, err = allocSet.accumulate(as)
 		if err != nil {
@@ -2281,7 +2280,7 @@ func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*Allocati
 		}
 
 		if allocSet != nil {
-			currAccumulatedSum += allocSet.Window.Duration()
+			currAccumulatedSum = allocSet.Window.Duration()
 
 			// check if end of asr to sum the final set
 			// If total asr accumulated sum <= resolution return 1 accumulated set

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -2272,7 +2272,6 @@ func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*Allocati
 	asr.Lock()
 	defer asr.Unlock()
 
-	// check as.window and accumulate sets until sum of window durations == time.duration wanted -> add accumulated set to allocSetRange
 	for i, as := range asr.allocations {
 		allocSet, err = allocSet.accumulate(as)
 		if err != nil {
@@ -2283,7 +2282,7 @@ func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*Allocati
 			currAccumulatedSum += allocSet.Window.Duration()
 
 			// check if end of asr to sum the final set
-			// If accumulated sum never reaches the desired resolution then all sets are returned as 1 accumulated set
+			// If accumulated sum !>= resolution return 1 accumulated set
 			if currAccumulatedSum >= resolution || i == len(asr.allocations)-1 {
 				allocSetRange.allocations = append(allocSetRange.allocations, allocSet)
 				allocSet = &AllocationSet{allocations: map[string]*Allocation{}}

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -2261,10 +2261,68 @@ func (asr *AllocationSetRange) Accumulate() (*AllocationSet, error) {
 }
 
 // TODO accumulate into lower-resolution chunks of the given resolution
-// func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) *AllocationSetRange
+func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*AllocationSetRange, error) {
+	allocSetRange := &AllocationSetRange{allocations: []*AllocationSet{}}
+	var allocSet *AllocationSet
+	var err error
+
+	asr.Lock()
+	defer asr.Unlock()
+
+	fmt.Printf("asrWindow: %v", asr.Window())
+	// fmt.Println(time.Hour > 61*time.Minute)
+	// if asr.Window().IsEmpty() {
+	// 	return asr, nil
+	// }
+
+	// Call total accumulate func if resolution is greater than total window duration
+	// if resolution > asr.Window().Duration() {
+	// 	as, err := asr.Accumulate()
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	allocSetRange.allocations = append(allocSetRange.allocations, as)
+	// 	return allocSetRange, nil
+	// }
+
+	// if asrResolution < 1 hour then there is not enough data to accumulate
+	// if as.allocations end - start > resolution then no need, it's already accumulated. Requery to make more granular in the future?
+
+	// asrResolution := asr.Window().Duration()
+	// fmt.Printf("asrResolution: %s", asrResolution)
+	// if asrResolution <= time.Hour || asrResolution < resolution {
+	// 	return asr, nil
+	// }
+
+	// if(resolution)
+
+	// do not compound
+	// check as.window and accumulate till windowSum == time.duration wanted -> add accumulated set to allocSetRange
+
+	// var currAccumulatedSum time.Duration
+	for _, as := range asr.allocations {
+		//What time group are we in? Is time group bigger than duration?
+
+		allocSet, err = allocSet.accumulate(as)
+		if err != nil {
+			return nil, err
+		}
+		// currAccumulatedSum += allocSet.Window.Duration()
+
+		// if currAccumulatedSum >= resolution { // || check if end of asr to sum the final as
+		allocSetRange.allocations = append(allocSetRange.allocations, allocSet)
+		// make allocSet empty somehow
+		// allocSet = NewAllocationSet(nil, nil, nil)
+		// currAccumulatedSum = 0
+		// }
+	}
+
+	return allocSetRange, nil
+}
 
 // AggregateBy aggregates each AllocationSet in the range by the given
 // properties and options.
+// func (as *AllocationSet) AggregateBy(aggregateBy []string, options *AllocationAggregationOptions) error {
 func (asr *AllocationSetRange) AggregateBy(aggregateBy []string, options *AllocationAggregationOptions) error {
 	aggRange := &AllocationSetRange{allocations: []*AllocationSet{}}
 

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -2260,6 +2260,9 @@ func (asr *AllocationSetRange) Accumulate() (*AllocationSet, error) {
 	return allocSet, nil
 }
 
+// AccumulateBy sums AllocationSets based on the resolution given. The resolution given is subject to the scale used for the AllocationSets.
+// If the requested resolution is smaller than the window of an AllocationSet then the resolution will default to the duration of a set.
+// Resolutions larger than the duration of the entire AllocationSetRange will default to the duration of the range.
 func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*AllocationSetRange, error) {
 	allocSetRange := &AllocationSetRange{allocations: []*AllocationSet{}}
 	var allocSet *AllocationSet

--- a/pkg/kubecost/allocation.go
+++ b/pkg/kubecost/allocation.go
@@ -2268,7 +2268,6 @@ func (asr *AllocationSetRange) Accumulate() (*AllocationSet, error) {
 func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*AllocationSetRange, error) {
 	allocSetRange := NewAllocationSetRange()
 	var allocSet *AllocationSet
-	var currAccumulatedSum time.Duration
 	var err error
 
 	asr.Lock()
@@ -2280,14 +2279,12 @@ func (asr *AllocationSetRange) AccumulateBy(resolution time.Duration) (*Allocati
 		}
 
 		if allocSet != nil {
-			currAccumulatedSum = allocSet.Window.Duration()
 
 			// check if end of asr to sum the final set
 			// If total asr accumulated sum <= resolution return 1 accumulated set
-			if currAccumulatedSum >= resolution || i == len(asr.allocations)-1 {
+			if allocSet.Window.Duration() >= resolution || i == len(asr.allocations)-1 {
 				allocSetRange.allocations = append(allocSetRange.allocations, allocSet)
 				allocSet = NewAllocationSet(time.Time{}, time.Time{})
-				currAccumulatedSum = 0
 			}
 		}
 	}

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -2069,14 +2069,17 @@ func TestAllocationSetRange_Accumulate(t *testing.T) {
 }
 
 func TestAllocationSetRange_AccumulateBy(t *testing.T) {
+	ago4d := time.Now().UTC().Truncate(day).Add(-4 * day)
+	ago3d := time.Now().UTC().Truncate(day).Add(-3 * day)
 	ago2d := time.Now().UTC().Truncate(day).Add(-2 * day)
 	yesterday := time.Now().UTC().Truncate(day).Add(-day)
 	today := time.Now().UTC().Truncate(day)
 	tomorrow := time.Now().UTC().Truncate(day).Add(day)
-	dur := time.Hour
+	dur := time.Hour * 24 * 2
 
 	// Accumulating any combination of nil and/or empty set should result in empty set
-	fmt.Println("test 1")
+	fmt.Println("======================")
+	fmt.Println("test 1 nil set")
 	result, err := NewAllocationSetRange(nil).AccumulateBy(dur)
 	for _, as := range result.allocations {
 		if err != nil {
@@ -2087,7 +2090,8 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 		}
 	}
 
-	fmt.Println("test 2")
+	fmt.Println("======================")
+	fmt.Println("test 2 nil sets")
 	result, err = NewAllocationSetRange(nil, nil).AccumulateBy(dur)
 	for _, as := range result.allocations {
 		if err != nil {
@@ -2098,6 +2102,8 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 		}
 	}
 
+	fmt.Println("======================")
+	fmt.Println("test 1 set 2d long")
 	result, err = NewAllocationSetRange(NewAllocationSet(yesterday, today)).AccumulateBy(dur)
 	for _, as := range result.allocations {
 		if err != nil {
@@ -2108,6 +2114,8 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 		}
 	}
 
+	fmt.Println("======================")
+	fmt.Println("test 2 nil sets 2 1d sets")
 	result, err = NewAllocationSetRange(nil, NewAllocationSet(ago2d, yesterday), nil, NewAllocationSet(today, tomorrow), nil).AccumulateBy(dur)
 	for _, as := range result.allocations {
 		if err != nil {
@@ -2118,21 +2126,58 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 		}
 	}
 
-	todayAS := NewAllocationSet(today, tomorrow)
-	todayAS.Set(NewMockUnitAllocation("", today, day, nil))
-
-	yesterdayAS := NewAllocationSet(yesterday, today)
-	yesterdayAS.Set(NewMockUnitAllocation("", yesterday, day, nil))
-
-	// Accumulate non-nil with nil should result in copy of non-nil, regardless of order
-	result, err = NewAllocationSetRange(nil, todayAS).AccumulateBy(dur)
-	if err != nil {
-		t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
-	}
-	if result == nil {
-		t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	fmt.Println("======================")
+	fmt.Println("test 2 nil sets 2 1d sets")
+	result, err = NewAllocationSetRange(nil, NewAllocationSet(ago2d, yesterday), nil, NewAllocationSet(today, tomorrow), nil).AccumulateBy(dur)
+	for _, as := range result.allocations {
+		if err != nil {
+			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
+		}
+		if !as.IsEmpty() {
+			t.Fatalf("accumulating nil AllocationSetRange: expected empty; actual %s", result)
+		}
 	}
 
+	fmt.Println("======================")
+	fmt.Println("test 2 1d sets")
+	result, err = NewAllocationSetRange(NewAllocationSet(ago2d, yesterday), NewAllocationSet(today, tomorrow), nil).AccumulateBy(dur)
+	for _, as := range result.allocations {
+		if err != nil {
+			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
+		}
+		if !as.IsEmpty() {
+			t.Fatalf("accumulating nil AllocationSetRange: expected empty; actual %s", result)
+		}
+	}
+
+	fmt.Println("======================")
+	fmt.Println("test 3 1d sets")
+	result, err = NewAllocationSetRange(NewAllocationSet(ago4d, ago3d), NewAllocationSet(ago2d, yesterday), NewAllocationSet(today, tomorrow), nil).AccumulateBy(dur)
+	for _, as := range result.allocations {
+		if err != nil {
+			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
+		}
+		if !as.IsEmpty() {
+			t.Fatalf("accumulating nil AllocationSetRange: expected empty; actual %s", result)
+		}
+	}
+	// todayAS := NewAllocationSet(today, tomorrow)
+	// todayAS.Set(NewMockUnitAllocation("", today, day, nil))
+
+	// yesterdayAS := NewAllocationSet(yesterday, today)
+	// yesterdayAS.Set(NewMockUnitAllocation("", yesterday, day, nil))
+
+	// fmt.Println("test 5")
+	// // Accumulate non-nil with nil should result in copy of non-nil, regardless of order
+	// result, err = NewAllocationSetRange(nil, todayAS).AccumulateBy(dur)
+	// if err != nil {
+	// 	t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
+	// }
+	// if result == nil {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	// }
+
+	// fmt.Println("test 6")
 	// for _, as := range result.allocations {
 	// 	if as.TotalCost() != 6.0 {
 	// 		t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", as.TotalCost())

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -158,7 +158,7 @@ func TestAllocation_Add(t *testing.T) {
 		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.PVByteHours()+a2.PVByteHours(), act.PVByteHours())
 	}
 
-	// Minutes should be the duration between min(starts) and max(ends)
+	// Minutes should be the duration2Daysation between min(starts) and max(ends)
 	if !act.Start.Equal(a1.Start) || !act.End.Equal(a2.End) {
 		t.Fatalf("Allocation.Add: expected %s; actual %s", NewWindow(&a1.Start, &a2.End), NewWindow(&act.Start, &act.End))
 	}
@@ -2074,11 +2074,11 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	yesterday := time.Now().UTC().Truncate(day).Add(-day)
 	today := time.Now().UTC().Truncate(day)
 	tomorrow := time.Now().UTC().Truncate(day).Add(day)
-	dur := time.Hour * 24 * 2
+	duration2Days := time.Hour * 24 * 2
 
 	// Accumulating any combination of nil and/or empty set should result in empty set
 	// test 1 nil set
-	result, err := NewAllocationSetRange(nil).AccumulateBy(dur)
+	result, err := NewAllocationSetRange(nil).AccumulateBy(duration2Days)
 	for _, as := range result.allocations {
 		if err != nil {
 			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
@@ -2089,7 +2089,7 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	}
 
 	// test 2 nil sets
-	result, err = NewAllocationSetRange(nil, nil).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(nil, nil).AccumulateBy(duration2Days)
 	for _, as := range result.allocations {
 		if err != nil {
 			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
@@ -2100,7 +2100,7 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	}
 
 	// test 1 set 2d long
-	result, err = NewAllocationSetRange(NewAllocationSet(yesterday, today)).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(NewAllocationSet(yesterday, today)).AccumulateBy(duration2Days)
 	for _, as := range result.allocations {
 		if err != nil {
 			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
@@ -2111,7 +2111,7 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	}
 
 	// test 2 nil sets 2 1d sets
-	result, err = NewAllocationSetRange(nil, NewAllocationSet(ago2d, yesterday), nil, NewAllocationSet(today, tomorrow), nil).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(nil, NewAllocationSet(ago2d, yesterday), nil, NewAllocationSet(today, tomorrow), nil).AccumulateBy(duration2Days)
 	for _, as := range result.allocations {
 		if err != nil {
 			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
@@ -2122,7 +2122,7 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	}
 
 	// test 2 nil sets 2 1d sets
-	result, err = NewAllocationSetRange(nil, NewAllocationSet(ago2d, yesterday), nil, NewAllocationSet(today, tomorrow), nil).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(nil, NewAllocationSet(ago2d, yesterday), nil, NewAllocationSet(today, tomorrow), nil).AccumulateBy(duration2Days)
 	for _, as := range result.allocations {
 		if err != nil {
 			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
@@ -2132,7 +2132,6 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 		}
 	}
 
-	// test 2 1d sets
 	ago3dAS := NewAllocationSet(ago3d, ago2d)
 	ago3dAS.Set(NewMockUnitAllocation("a", ago3d, day, nil))
 	ago2dAS := NewAllocationSet(ago2d, yesterday)
@@ -2143,7 +2142,8 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	todayAS.Set(NewMockUnitAllocation("", today, day, nil))
 	sumCost := 0.0
 
-	result, err = NewAllocationSetRange(ago2dAS, yesterdayAS).AccumulateBy(dur)
+	// test 2 1d sets
+	result, err = NewAllocationSetRange(ago2dAS, yesterdayAS).AccumulateBy(duration2Days)
 	if err != nil {
 		t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
 	}
@@ -2160,7 +2160,7 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 
 	// test 3 1d sets
 	sumCost = 0.0
-	result, err = NewAllocationSetRange(ago2dAS, yesterdayAS, todayAS).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(ago2dAS, yesterdayAS, todayAS).AccumulateBy(duration2Days)
 	if err != nil {
 		t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
 	}
@@ -2174,16 +2174,33 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	if sumCost != 18.0 {
 		t.Fatalf("accumulating AllocationSetRange: expected total cost 18.0; actual %f", sumCost)
 	}
-	if result.allocations[0].Resolution() != dur {
-		t.Fatalf("accumulating AllocationSetRange: expected first allocationSet window duration to be %v; actual %v", dur, result.allocations[0].Resolution())
+	if result.allocations[0].Resolution() != duration2Days {
+		t.Fatalf("accumulating AllocationSetRange: expected first allocationSet window duration2Days to be %v; actual %v", duration2Days, result.allocations[0].Resolution())
 	}
-	if result.allocations[1].Resolution() != dur/2 {
-		t.Fatalf("accumulating AllocationSetRange: expected second allocationSet window duration to be %v; actual %v", dur, result.allocations[1].Resolution())
+	if result.allocations[1].Resolution() != duration2Days/2 {
+		t.Fatalf("accumulating AllocationSetRange: expected second allocationSet window duration to be %v; actual %v", duration2Days, result.allocations[1].Resolution())
+	}
+
+	// test 3 1d sets - duration is larger than asr.window
+	sumCost = 0.0
+	result, err = NewAllocationSetRange(ago2dAS, yesterdayAS, todayAS).AccumulateBy(duration2Days * 2)
+	if err != nil {
+		t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
+	}
+	if result == nil {
+		t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	}
+
+	for _, as := range result.allocations {
+		sumCost += as.TotalCost()
+	}
+	if sumCost != 18.0 {
+		t.Fatalf("accumulating AllocationSetRange: expected total cost 18.0; actual %f", sumCost)
 	}
 
 	// test 4 1d sets
 	sumCost = 0.0
-	result, err = NewAllocationSetRange(ago3dAS, ago2dAS, yesterdayAS, todayAS).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(ago3dAS, ago2dAS, yesterdayAS, todayAS).AccumulateBy(duration2Days)
 	if err != nil {
 		t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
 	}
@@ -2197,15 +2214,16 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	if sumCost != 24.0 {
 		t.Fatalf("accumulating AllocationSetRange: expected total cost 24.0; actual %f", sumCost)
 	}
-	if result.allocations[0].Resolution() != dur {
-		t.Fatalf("accumulating AllocationSetRange: expected first allocationSet window duration to be %v; actual %v", dur, result.allocations[0].Resolution())
+	if result.allocations[0].Resolution() != duration2Days {
+		t.Fatalf("accumulating AllocationSetRange: expected first allocationSet window duration2Days to be %v; actual %v", duration2Days, result.allocations[0].Resolution())
+
 	}
-	if result.allocations[1].Resolution() != dur {
-		t.Fatalf("accumulating AllocationSetRange: expected first allocationSet window duration to be %v; actual %v", dur, result.allocations[1].Resolution())
+	if result.allocations[1].Resolution() != duration2Days {
+		t.Fatalf("accumulating AllocationSetRange: expected first allocationSet window duration2Days to be %v; actual %v", duration2Days, result.allocations[1].Resolution())
 	}
 
 	// Accumulate non-nil with nil should result in copy of non-nil, regardless of order
-	result, err = NewAllocationSetRange(nil, todayAS).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(nil, todayAS).AccumulateBy(duration2Days)
 	if err != nil {
 		t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
 	}
@@ -2219,7 +2237,7 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 		}
 	}
 
-	result, err = NewAllocationSetRange(todayAS, nil).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(todayAS, nil).AccumulateBy(duration2Days)
 	if err != nil {
 		t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
 	}
@@ -2234,7 +2252,7 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 		t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", sumCost)
 	}
 
-	result, err = NewAllocationSetRange(nil, todayAS, nil).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(nil, todayAS, nil).AccumulateBy(duration2Days)
 	if err != nil {
 		t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
 	}
@@ -2250,7 +2268,7 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	}
 
 	// // Accumulate three non-nil should result in sum of both with appropriate start, end
-	result, err = NewAllocationSetRange(ago2dAS, yesterdayAS, todayAS).AccumulateBy(dur)
+	result, err = NewAllocationSetRange(ago2dAS, yesterdayAS, todayAS).AccumulateBy(duration2Days)
 	if err != nil {
 		t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
 	}

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -158,7 +158,7 @@ func TestAllocation_Add(t *testing.T) {
 		t.Fatalf("Allocation.Add: expected %f; actual %f", a1.PVByteHours()+a2.PVByteHours(), act.PVByteHours())
 	}
 
-	// Minutes should be the duration2Daysation between min(starts) and max(ends)
+	// Minutes should be the duration between min(starts) and max(ends)
 	if !act.Start.Equal(a1.Start) || !act.End.Equal(a2.End) {
 		t.Fatalf("Allocation.Add: expected %s; actual %s", NewWindow(&a1.Start, &a2.End), NewWindow(&act.Start, &act.End))
 	}

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -2176,12 +2176,15 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	var err error
 	var result *AllocationSetRange
 
+	ago4d := time.Now().UTC().Truncate(day).Add(-4 * day)
 	ago3d := time.Now().UTC().Truncate(day).Add(-3 * day)
 	ago2d := time.Now().UTC().Truncate(day).Add(-2 * day)
 	yesterday := time.Now().UTC().Truncate(day).Add(-day)
 	today := time.Now().UTC().Truncate(day)
 	tomorrow := time.Now().UTC().Truncate(day).Add(day)
 
+	ago4dAS := NewAllocationSet(ago4d, ago3d)
+	ago4dAS.Set(NewMockUnitAllocation("4", ago4d, day, nil))
 	ago3dAS := NewAllocationSet(ago3d, ago2d)
 	ago3dAS.Set(NewMockUnitAllocation("a", ago3d, day, nil))
 	ago2dAS := NewAllocationSet(ago2d, yesterday)
@@ -2303,12 +2306,21 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 
 			testId: "AccumulateBy Test 10",
 		},
+		{
+			asr:        NewAllocationSetRange(ago4dAS, ago3dAS, ago2dAS, yesterdayAS, todayAS),
+			resolution: time.Hour * 72,
+
+			expectedCost: 30.0,
+			expectedSets: 2,
+
+			testId: "AccumulateBy Test 11",
+		},
 	}
 
 	for _, c := range cases {
 		result, err = c.asr.AccumulateBy(c.resolution)
 		sumCost := 0.0
-
+		fmt.Println(c.testId)
 		if result == nil {
 			t.Errorf("accumulating AllocationSetRange: expected AllocationSet; actual %s; TestId: %s", result, c.testId)
 		}

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -2204,43 +2204,50 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 		t.Fatalf("accumulating AllocationSetRange: expected first allocationSet window duration to be %v; actual %v", dur, result.allocations[1].Resolution())
 	}
 
-	// // Accumulate non-nil with nil should result in copy of non-nil, regardless of order
-	// accumulateBy -> accumulate -> returns todayAs to set as result but nil pointer dereference error?
-	// result, err = NewAllocationSetRange(nil, todayAS).AccumulateBy(dur)
-	// if err != nil {
-	// 	t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
-	// }
-	// if result == nil {
-	// 	t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
-	// }
+	// Accumulate non-nil with nil should result in copy of non-nil, regardless of order
+	result, err = NewAllocationSetRange(nil, todayAS).AccumulateBy(dur)
+	if err != nil {
+		t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
+	}
+	if result == nil {
+		t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	}
 
-	// for _, as := range result.allocations {
-	// 	if as.TotalCost() != 6.0 {
-	// 		t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", as.TotalCost())
-	// 	}
-	// }
+	for _, as := range result.allocations {
+		if as.TotalCost() != 6.0 {
+			t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", as.TotalCost())
+		}
+	}
 
-	// result, err = NewAllocationSetRange(todayAS, nil).Accumulate()
-	// if err != nil {
-	// 	t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
-	// }
-	// if result == nil {
-	// 	t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
-	// }
-	// if result.TotalCost() != 6.0 {
-	// 	t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", result.TotalCost())
-	// }
+	result, err = NewAllocationSetRange(todayAS, nil).AccumulateBy(dur)
+	if err != nil {
+		t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
+	}
+	if result == nil {
+		t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	}
+	sumCost = 0.0
+	for _, as := range result.allocations {
+		sumCost += as.TotalCost()
+	}
+	if sumCost != 6.0 {
+		t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", sumCost)
+	}
 
-	// result, err = NewAllocationSetRange(nil, todayAS, nil).Accumulate()
-	// if err != nil {
-	// 	t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
-	// }
-	// if result == nil {
-	// 	t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
-	// }
-	// if result.TotalCost() != 6.0 {
-	// 	t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", result.TotalCost())
-	// }
+	result, err = NewAllocationSetRange(nil, todayAS, nil).AccumulateBy(dur)
+	if err != nil {
+		t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
+	}
+	if result == nil {
+		t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	}
+	sumCost = 0.0
+	for _, as := range result.allocations {
+		sumCost += as.TotalCost()
+	}
+	if sumCost != 6.0 {
+		t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", sumCost)
+	}
 
 	// // Accumulate three non-nil should result in sum of both with appropriate start, end
 	result, err = NewAllocationSetRange(ago2dAS, yesterdayAS, todayAS).AccumulateBy(dur)
@@ -2300,9 +2307,9 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	if alloc.RAMEfficiency() != 1.0 {
 		t.Fatalf("accumulating AllocationSetRange: expected 1.0; actual %f", alloc.RAMEfficiency())
 	}
-	// if alloc.TotalCost() != 12.0 {
-	// 	t.Fatalf("accumulating AllocationSetRange: expected 12.0; actual %f", alloc.TotalCost())
-	// }
+	if alloc.TotalCost() != 12.0 {
+		t.Fatalf("accumulating AllocationSetRange: expected 12.0; actual %f", alloc.TotalCost())
+	}
 	if alloc.TotalEfficiency() != 1.0 {
 		t.Fatalf("accumulating AllocationSetRange: expected 1.0; actual %f", alloc.TotalEfficiency())
 	}

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -2320,7 +2320,6 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 	for _, c := range cases {
 		result, err = c.asr.AccumulateBy(c.resolution)
 		sumCost := 0.0
-		fmt.Println(c.testId)
 		if result == nil {
 			t.Errorf("accumulating AllocationSetRange: expected AllocationSet; actual %s; TestId: %s", result, c.testId)
 		}

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -2068,8 +2068,170 @@ func TestAllocationSetRange_Accumulate(t *testing.T) {
 	}
 }
 
-// TODO niko/etl
-// func TestAllocationSetRange_AccumulateBy(t *testing.T) {}
+func TestAllocationSetRange_AccumulateBy(t *testing.T) {
+	ago2d := time.Now().UTC().Truncate(day).Add(-2 * day)
+	yesterday := time.Now().UTC().Truncate(day).Add(-day)
+	today := time.Now().UTC().Truncate(day)
+	tomorrow := time.Now().UTC().Truncate(day).Add(day)
+	dur := time.Hour
+
+	// Accumulating any combination of nil and/or empty set should result in empty set
+	fmt.Println("test 1")
+	result, err := NewAllocationSetRange(nil).AccumulateBy(dur)
+	for _, as := range result.allocations {
+		if err != nil {
+			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
+		}
+		if !as.IsEmpty() {
+			t.Fatalf("accumulating nil AllocationSetRange: expected empty; actual %s", result)
+		}
+	}
+
+	fmt.Println("test 2")
+	result, err = NewAllocationSetRange(nil, nil).AccumulateBy(dur)
+	for _, as := range result.allocations {
+		if err != nil {
+			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
+		}
+		if !as.IsEmpty() {
+			t.Fatalf("accumulating nil AllocationSetRange: expected empty; actual %s", result)
+		}
+	}
+
+	result, err = NewAllocationSetRange(NewAllocationSet(yesterday, today)).AccumulateBy(dur)
+	for _, as := range result.allocations {
+		if err != nil {
+			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
+		}
+		if !as.IsEmpty() {
+			t.Fatalf("accumulating nil AllocationSetRange: expected empty; actual %s", result)
+		}
+	}
+
+	result, err = NewAllocationSetRange(nil, NewAllocationSet(ago2d, yesterday), nil, NewAllocationSet(today, tomorrow), nil).AccumulateBy(dur)
+	for _, as := range result.allocations {
+		if err != nil {
+			t.Fatalf("unexpected error accumulating nil AllocationSetRange: %s", err)
+		}
+		if !as.IsEmpty() {
+			t.Fatalf("accumulating nil AllocationSetRange: expected empty; actual %s", result)
+		}
+	}
+
+	todayAS := NewAllocationSet(today, tomorrow)
+	todayAS.Set(NewMockUnitAllocation("", today, day, nil))
+
+	yesterdayAS := NewAllocationSet(yesterday, today)
+	yesterdayAS.Set(NewMockUnitAllocation("", yesterday, day, nil))
+
+	// Accumulate non-nil with nil should result in copy of non-nil, regardless of order
+	result, err = NewAllocationSetRange(nil, todayAS).AccumulateBy(dur)
+	if err != nil {
+		t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
+	}
+	if result == nil {
+		t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	}
+
+	// for _, as := range result.allocations {
+	// 	if as.TotalCost() != 6.0 {
+	// 		t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", as.TotalCost())
+	// 	}
+	// }
+
+	// result, err = NewAllocationSetRange(todayAS, nil).Accumulate()
+	// if err != nil {
+	// 	t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
+	// }
+	// if result == nil {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	// }
+	// if result.TotalCost() != 6.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", result.TotalCost())
+	// }
+
+	// result, err = NewAllocationSetRange(nil, todayAS, nil).Accumulate()
+	// if err != nil {
+	// 	t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
+	// }
+	// if result == nil {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	// }
+	// if result.TotalCost() != 6.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected total cost 6.0; actual %f", result.TotalCost())
+	// }
+
+	// // Accumulate two non-nil should result in sum of both with appropriate start, end
+	// result, err = NewAllocationSetRange(yesterdayAS, todayAS).Accumulate()
+	// if err != nil {
+	// 	t.Fatalf("unexpected error accumulating AllocationSetRange of length 1: %s", err)
+	// }
+	// if result == nil {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected AllocationSet; actual %s", result)
+	// }
+	// if result.TotalCost() != 12.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected total cost 12.0; actual %f", result.TotalCost())
+	// }
+	// allocMap := result.Map()
+	// if len(allocMap) != 1 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected length 1; actual length %d", len(allocMap))
+	// }
+	// alloc := allocMap["cluster1/namespace1/pod1/container1"]
+	// if alloc == nil {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected allocation 'cluster1/namespace1/pod1/container1'")
+	// }
+	// if alloc.CPUCoreHours != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", result.TotalCost())
+	// }
+	// if alloc.CPUCost != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", alloc.CPUCost)
+	// }
+	// if alloc.CPUEfficiency() != 1.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 1.0; actual %f", alloc.CPUEfficiency())
+	// }
+	// if alloc.GPUHours != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", alloc.GPUHours)
+	// }
+	// if alloc.GPUCost != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", alloc.GPUCost)
+	// }
+	// if alloc.NetworkCost != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", alloc.NetworkCost)
+	// }
+	// if alloc.LoadBalancerCost != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", alloc.LoadBalancerCost)
+	// }
+	// if alloc.PVByteHours() != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", alloc.PVByteHours())
+	// }
+	// if alloc.PVCost() != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", alloc.PVCost())
+	// }
+	// if alloc.RAMByteHours != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", alloc.RAMByteHours)
+	// }
+	// if alloc.RAMCost != 2.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 2.0; actual %f", alloc.RAMCost)
+	// }
+	// if alloc.RAMEfficiency() != 1.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 1.0; actual %f", alloc.RAMEfficiency())
+	// }
+	// if alloc.TotalCost() != 12.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 12.0; actual %f", alloc.TotalCost())
+	// }
+	// if alloc.TotalEfficiency() != 1.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected 1.0; actual %f", alloc.TotalEfficiency())
+	// }
+	// if !alloc.Start.Equal(yesterday) {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected to start %s; actual %s", yesterday, alloc.Start)
+	// }
+	// if !alloc.End.Equal(tomorrow) {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected to end %s; actual %s", tomorrow, alloc.End)
+	// }
+	// if alloc.Minutes() != 2880.0 {
+	// 	t.Fatalf("accumulating AllocationSetRange: expected %f minutes; actual %f", 2880.0, alloc.Minutes())
+	// }
+}
 
 // TODO niko/etl
 // func TestAllocationSetRange_AggregateBy(t *testing.T) {}

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -2294,6 +2294,15 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 
 			testId: "AccumulateBy Test 9",
 		},
+		{
+			asr:        NewAllocationSetRange(ago3dAS, ago2dAS, yesterdayAS, todayAS),
+			resolution: time.Hour * 25,
+
+			expectedCost: 24.0,
+			expectedSets: 2,
+
+			testId: "AccumulateBy Test 10",
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/kubecost/allocation_test.go
+++ b/pkg/kubecost/allocation_test.go
@@ -2285,6 +2285,15 @@ func TestAllocationSetRange_AccumulateBy(t *testing.T) {
 
 			testId: "AccumulateBy Test 8",
 		},
+		{
+			asr:        NewAllocationSetRange(ago2dAS, yesterdayAS, todayAS),
+			resolution: time.Hour * 24 * 2,
+
+			expectedCost: 18.0,
+			expectedSets: 2,
+
+			testId: "AccumulateBy Test 9",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## What does this PR change?
A  new AccumulateBy function that sums AllocationSets based on the given time duration and it's interoperability with the resolution of the AllocationSets. A lockless window() function was also added in which the original Window() function now calls to offer backwards compatibility. Functionality should be the same

## Does this PR rely on any other PRs?

- This can stand alone but I imagine won't be accessible until exposed https://github.com/kubecost/kubecost-cost-model/pull/630

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
- The write up can be included in the final PR exposing the new function via it's parameter


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
- New tests were written in `allocation_test.go` testing nils, empty sets, happy paths, and combinations of the 3. Further testing can be done if desirable

## Have you made an update to documentation?
- Soon to follow the PR merges
