### PR TITLE
Detect, prevent, and log warning if precomputed sharing coefficients generate a NaN

### DIFF
--- a/pkg/kubecost/summaryallocation.go
+++ b/pkg/kubecost/summaryallocation.go
@@ -875,7 +875,12 @@ func (sas *SummaryAllocationSet) AggregateBy(aggregateBy []string, options *Allo
 			// Compute sharing coeffs by dividing the thus-far accumulated
 			// numerators by the now-finalized denominator.
 			for key := range sharingCoeffs {
-				sharingCoeffs[key] /= sharingCoeffDenominator
+				if sharingCoeffs[key] > 0.0 {
+					sharingCoeffs[key] /= sharingCoeffDenominator
+				} else {
+					log.Warningf("SummaryAllocation: detected illegal sharing coefficient for %s: %v (setting to zero)", key, sharingCoeffs[key])
+					sharingCoeffs[key] = 0.0
+				}
 			}
 
 			for key, sa := range resultSet.SummaryAllocations {


### PR DESCRIPTION
Note: this is a straight-to-master version of https://github.com/kubecost/cost-model/pull/1037

## What does this PR change?
* Attempts to fix https://github.com/kubecost/kubecost-cost-model/issues/613. Pure repro was not achieved, so worked off of the two best hypotheses for where a NaN could sneak in and addressed those with warnings and prevention tactics.

## Does this PR rely on any other PRs?
- https://github.com/kubecost/kubecost-cost-model/pull/625

## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fixes https://github.com/kubecost/kubecost-cost-model/issues/613

## Links to Issues or ZD tickets this PR addresses or fixes
- https://github.com/kubecost/kubecost-cost-model/issues/613

## How was this PR tested?
Manually, by injecting NaN into suspicious places, noting the described issue, then noting that the injected issue was resolved after the code changes. As mentioned above, this was partially contrived because we were unable to achieve a _pure_, as reported in the wild.

### Semi-repro steps
Producing the error:
![Screenshot from 2022-01-21 18-00-13](https://user-images.githubusercontent.com/8070055/150618600-cba1025c-78f0-4784-85f6-100228997031.png)
Turning sharing off fixes the error:
![Screenshot from 2022-01-21 18-00-39](https://user-images.githubusercontent.com/8070055/150618606-921125b0-b608-48f7-b012-009610c81c18.png)
![Screenshot from 2022-01-21 18-00-59](https://user-images.githubusercontent.com/8070055/150618608-04fc6a0b-ba86-4394-86ec-59006cc43593.png)

### After fix
Everything WAI