### PR TITLE
Fix refresh of DownloadPricingData

### DIFF
--- a/pkg/cloud/csvprovider.go
+++ b/pkg/cloud/csvprovider.go
@@ -54,6 +54,7 @@ func GetCsv(location string) (io.Reader, error) {
 
 func (c *CSVProvider) DownloadPricingData() error {
 	c.DownloadPricingDataLock.Lock()
+	defer time.AfterFunc(refreshMinutes*time.Minute, func() { c.DownloadPricingData() })
 	defer c.DownloadPricingDataLock.Unlock()
 	pricing := make(map[string]*price)
 	nodeclasspricing := make(map[string]float64)
@@ -177,7 +178,6 @@ func (c *CSVProvider) DownloadPricingData() error {
 	} else {
 		log.DedupedWarningf(5, "No data received from csv at %s", c.CSVLocation)
 	}
-	time.AfterFunc(refreshMinutes*time.Minute, func() { c.DownloadPricingData() })
 	return nil
 }
 


### PR DESCRIPTION
## What does this PR change?
DownloadPricingData() is supposed to be called in a loop, but here on error it will not.


## Does this PR rely on any other PRs?
No


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Fix CSV pricing refresh on errors.

## Links to Issues or ZD tickets this PR addresses or fixes
Closes https://github.com/kubecost/cost-model/issues/1048


## How was this PR tested?
Forced an error with no CSV, noted that DownloadPricingData() was re-run

## Have you made an update to documentation?
Not necessary
