### PR TITLE
Add fine-grained control for disabling metrics

### DIFF
--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -40,23 +40,27 @@ type ClusterInfoCollector struct {
 // collected by this Collector.
 func (cic ClusterInfoCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := cic.metricsConfig.GetDisabledMetricsMap()
-
-	if _, ok := disabledMetrics["kube_pod_annotations"]; !ok {
-		ch <- prometheus.NewDesc("kubecost_cluster_info", "Kubecost Cluster Info", []string{}, nil)
+	if _, disabled := disabledMetrics["kube_pod_annotations"]; disabled {
+		return
 	}
+
+	ch <- prometheus.NewDesc("kubecost_cluster_info", "Kubecost Cluster Info", []string{}, nil)
+
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (cic ClusterInfoCollector) Collect(ch chan<- prometheus.Metric) {
 	disabledMetrics := cic.metricsConfig.GetDisabledMetricsMap()
-
-	if _, ok := disabledMetrics["kube_pod_annotations"]; !ok {
-		clusterInfo := cic.ClusterInfo.GetClusterInfo()
-		labels := prom.MapToLabels(clusterInfo)
-
-		m := newClusterInfoMetric("kubecost_cluster_info", labels)
-		ch <- m
+	if _, disabled := disabledMetrics["kube_pod_annotations"]; disabled {
+		return
 	}
+
+	clusterInfo := cic.ClusterInfo.GetClusterInfo()
+	labels := prom.MapToLabels(clusterInfo)
+
+	m := newClusterInfoMetric("kubecost_cluster_info", labels)
+	ch <- m
+
 }
 
 //--------------------------------------------------------------------------
@@ -138,11 +142,11 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 
 	disabledMetrics := metricsConfig.GetDisabledMetricsMap()
 	var toRegisterGV []*prometheus.GaugeVec
-	var toRegisterGage []prometheus.Gauge
+	var toRegisterGauge []prometheus.Gauge
 
 	metricsInit.Do(func() {
 
-		if _, ok := disabledMetrics["node_cpu_hourly_cost"]; !ok {
+		if _, disabled := disabledMetrics["node_cpu_hourly_cost"]; !disabled {
 			cpuGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "node_cpu_hourly_cost",
 				Help: "node_cpu_hourly_cost hourly cost for each cpu on this node",
@@ -150,7 +154,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, cpuGv)
 		}
 
-		if _, ok := disabledMetrics["node_ram_hourly_cost"]; !ok {
+		if _, disabled := disabledMetrics["node_ram_hourly_cost"]; !disabled {
 			ramGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "node_ram_hourly_cost",
 				Help: "node_ram_hourly_cost hourly cost for each gb of ram on this node",
@@ -158,7 +162,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, ramGv)
 		}
 
-		if _, ok := disabledMetrics["node_gpu_hourly_cost"]; !ok {
+		if _, disabled := disabledMetrics["node_gpu_hourly_cost"]; !disabled {
 			gpuGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "node_gpu_hourly_cost",
 				Help: "node_gpu_hourly_cost hourly cost for each gpu on this node",
@@ -166,7 +170,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, gpuGv)
 		}
 
-		if _, ok := disabledMetrics["node_gpu_count"]; !ok {
+		if _, disabled := disabledMetrics["node_gpu_count"]; !disabled {
 			gpuCountGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "node_gpu_count",
 				Help: "node_gpu_count count of gpu on this node",
@@ -174,7 +178,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, gpuCountGv)
 		}
 
-		if _, ok := disabledMetrics["pv_hourly_cost"]; !ok {
+		if _, disabled := disabledMetrics["pv_hourly_cost"]; !disabled {
 			pvGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "pv_hourly_cost",
 				Help: "pv_hourly_cost Cost per GB per hour on a persistent disk",
@@ -182,7 +186,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, pvGv)
 		}
 
-		if _, ok := disabledMetrics["kubecost_node_is_spot"]; !ok {
+		if _, disabled := disabledMetrics["kubecost_node_is_spot"]; !disabled {
 			spotGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "kubecost_node_is_spot",
 				Help: "kubecost_node_is_spot Cloud provider info about node preemptibility",
@@ -190,7 +194,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, spotGv)
 		}
 
-		if _, ok := disabledMetrics["node_total_hourly_cost"]; !ok {
+		if _, disabled := disabledMetrics["node_total_hourly_cost"]; !disabled {
 			totalGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "node_total_hourly_cost",
 				Help: "node_total_hourly_cost Total node cost per hour",
@@ -198,7 +202,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, totalGv)
 		}
 
-		if _, ok := disabledMetrics["container_memory_allocation_bytes"]; !ok {
+		if _, disabled := disabledMetrics["container_memory_allocation_bytes"]; !disabled {
 			ramAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "container_memory_allocation_bytes",
 				Help: "container_memory_allocation_bytes Bytes of RAM used",
@@ -206,7 +210,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, ramAllocGv)
 		}
 
-		if _, ok := disabledMetrics["container_cpu_allocation"]; !ok {
+		if _, disabled := disabledMetrics["container_cpu_allocation"]; !disabled {
 			cpuAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "container_cpu_allocation",
 				Help: "container_cpu_allocation Percent of a single CPU used in a minute",
@@ -214,7 +218,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, cpuAllocGv)
 		}
 
-		if _, ok := disabledMetrics["container_gpu_allocation"]; !ok {
+		if _, disabled := disabledMetrics["container_gpu_allocation"]; !disabled {
 			gpuAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "container_gpu_allocation",
 				Help: "container_gpu_allocation GPU used",
@@ -222,7 +226,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, gpuAllocGv)
 		}
 
-		if _, ok := disabledMetrics["pod_pvc_allocation"]; !ok {
+		if _, disabled := disabledMetrics["pod_pvc_allocation"]; !disabled {
 			pvAllocGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "pod_pvc_allocation",
 				Help: "pod_pvc_allocation Bytes used by a PVC attached to a pod",
@@ -230,31 +234,31 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, pvAllocGv)
 		}
 
-		if _, ok := disabledMetrics["kubecost_network_zone_egress_cost"]; !ok {
+		if _, disabled := disabledMetrics["kubecost_network_zone_egress_cost"]; !disabled {
 			networkZoneEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
 				Name: "kubecost_network_zone_egress_cost",
 				Help: "kubecost_network_zone_egress_cost Total cost per GB egress across zones",
 			})
-			toRegisterGage = append(toRegisterGage, networkZoneEgressCostG)
+			toRegisterGauge = append(toRegisterGauge, networkZoneEgressCostG)
 		}
 
-		if _, ok := disabledMetrics["kubecost_network_region_egress_cost"]; !ok {
+		if _, disabled := disabledMetrics["kubecost_network_region_egress_cost"]; !disabled {
 			networkRegionEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
 				Name: "kubecost_network_region_egress_cost",
 				Help: "kubecost_network_region_egress_cost Total cost per GB egress across regions",
 			})
-			toRegisterGage = append(toRegisterGage, networkRegionEgressCostG)
+			toRegisterGauge = append(toRegisterGauge, networkRegionEgressCostG)
 		}
 
-		if _, ok := disabledMetrics["kubecost_network_internet_egress_cost"]; !ok {
+		if _, disabled := disabledMetrics["kubecost_network_internet_egress_cost"]; !disabled {
 			networkInternetEgressCostG = prometheus.NewGauge(prometheus.GaugeOpts{
 				Name: "kubecost_network_internet_egress_cost",
 				Help: "kubecost_network_internet_egress_cost Total cost per GB of internet egress.",
 			})
-			toRegisterGage = append(toRegisterGage, networkInternetEgressCostG)
+			toRegisterGauge = append(toRegisterGauge, networkInternetEgressCostG)
 		}
 
-		if _, ok := disabledMetrics["kubecost_cluster_management_cost"]; !ok {
+		if _, disabled := disabledMetrics["kubecost_cluster_management_cost"]; !disabled {
 			clusterManagementCostGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "kubecost_cluster_management_cost",
 				Help: "kubecost_cluster_management_cost Hourly cost paid as a cluster management fee.",
@@ -262,7 +266,7 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 			toRegisterGV = append(toRegisterGV, clusterManagementCostGv)
 		}
 
-		if _, ok := disabledMetrics["kubecost_load_balancer_cost"]; !ok {
+		if _, disabled := disabledMetrics["kubecost_load_balancer_cost"]; !disabled {
 			lbCostGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{ // no differentiation between ELB and ALB right now
 				Name: "kubecost_load_balancer_cost",
 				Help: "kubecost_load_balancer_cost Hourly cost of load balancer",
@@ -271,11 +275,11 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 		}
 
 		// Register cost-model metrics for emission
-		for i := range toRegisterGV {
-			prometheus.MustRegister(toRegisterGV[i])
+		for _, gv := range toRegisterGV {
+			prometheus.MustRegister(gv)
 		}
-		for i := range toRegisterGage {
-			prometheus.MustRegister(toRegisterGage[i])
+		for _, g := range toRegisterGauge {
+			prometheus.MustRegister(g)
 		}
 
 		// General Metric Collectors
@@ -327,6 +331,10 @@ func NewCostModelMetricsEmitter(promClient promclient.Client, clusterCache clust
 	metricsConfig, err := metrics.GetMetricsConfig()
 	if err != nil {
 		log.Infof("Failed to get metrics config before init: %s", err)
+	}
+
+	if len(metricsConfig.DisabledMetrics) > 0 {
+		log.Infof("Starting metrics init with disabled metrics: %v", metricsConfig.DisabledMetrics)
 	}
 
 	// init will only actually execute once to register the custom gauges

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -1,10 +1,7 @@
 package costmodel
 
 import (
-	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,8 +17,6 @@ import (
 	"github.com/kubecost/cost-model/pkg/prom"
 	"github.com/kubecost/cost-model/pkg/util"
 	"github.com/kubecost/cost-model/pkg/util/atomic"
-	"github.com/kubecost/cost-model/pkg/util/json"
-	"github.com/kubecost/cost-model/pkg/util/watcher"
 
 	promclient "github.com/prometheus/client_golang/api"
 	"github.com/prometheus/client_golang/prometheus"
@@ -130,20 +125,8 @@ var (
 )
 
 // initCostModelMetrics uses a sync.Once to ensure that these metrics are only created once
-func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud.Provider, clusterInfo clusters.ClusterInfoProvider) {
+func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud.Provider, clusterInfo clusters.ClusterInfoProvider, metricsConfig *metrics.MetricsConfig) {
 	metricsInit.Do(func() {
-
-		metricsConfig, err := GetMetricsConfig()
-		if err != nil {
-			log.Infof("Failed to get metrics configuration: %s", err)
-		}
-
-		log.Infof("--DISABLED LABELS--")
-		for i := range metricsConfig.DisabledMetrics {
-			log.Infof("DISABLE LABEL: %s", metricsConfig.DisabledMetrics[i])
-		}
-		log.Infof("-------------------")
-
 		cpuGv = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "node_cpu_hourly_cost",
 			Help: "node_cpu_hourly_cost hourly cost for each cpu on this node",
@@ -237,98 +220,6 @@ func initCostModelMetrics(clusterCache clustercache.ClusterCache, provider cloud
 	})
 }
 
-var metricsConfigLock = new(sync.Mutex)
-
-type MetricsConfig struct {
-	DisabledMetrics []string `json:"disabledMetrics"`
-}
-
-func (mc MetricsConfig) GetDisabledMetricsMap() map[string]struct{} {
-	disabledMetricsMap := make(map[string]struct{})
-
-	for i := range mc.DisabledMetrics {
-		disabledMetricsMap[mc.DisabledMetrics[i]] = struct{}{}
-	}
-
-	return disabledMetricsMap
-}
-
-func GetMetricsConfig() (*MetricsConfig, error) {
-	metricsConfigLock.Lock()
-	defer metricsConfigLock.Unlock()
-	mc := &MetricsConfig{}
-	body, err := ioutil.ReadFile("/var/configs/metrics.json")
-	if os.IsNotExist(err) {
-
-		return mc, nil
-	} else if err != nil {
-		return mc, err
-	}
-
-	err = json.Unmarshal(body, mc)
-	if err != nil {
-		return mc, err
-	}
-
-	return mc, nil
-}
-
-func UpdateMetricsConfig(mc *MetricsConfig) (*MetricsConfig, error) {
-	metricsConfigLock.Lock()
-	defer metricsConfigLock.Unlock()
-
-	mcb, err := json.Marshal(mc)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding metrics config struct: %s", err)
-	}
-
-	err = ioutil.WriteFile("/var/configs/metrics.json", mcb, 0644)
-	if err != nil {
-		return nil, fmt.Errorf("error writing to metrics config file: %s", err)
-	}
-
-	return mc, nil
-}
-
-func UpdateMetricsConfigFromConfigmap(data map[string]string) error {
-
-	mc := &MetricsConfig{}
-	key := "metrics.json"
-
-	cdata, ok := data[key]
-	if !ok {
-		return fmt.Errorf("error finding metrics config data")
-	}
-
-	err := json.Unmarshal([]byte(cdata), &mc)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal metrics configs: %s", err)
-	}
-
-	_, err = UpdateMetricsConfig(mc)
-	if err != nil {
-		return err
-	}
-
-	return nil
-
-}
-
-func GetMetricsConfigWatcher() *watcher.ConfigMapWatcher {
-	return &watcher.ConfigMapWatcher{
-		ConfigMapName: "metrics-config", // temporary, use env
-		WatchFunc: func(name string, data map[string]string) error {
-			klog.Infof("--CONFIGMAP DATA--")
-			for key, val := range data {
-				klog.Infof("%s : %s", key, val)
-			}
-			klog.Infof("------------------")
-			err := UpdateMetricsConfigFromConfigmap(data)
-			return err
-		},
-	}
-}
-
 //--------------------------------------------------------------------------
 //  CostModelMetricsEmitter
 //--------------------------------------------------------------------------
@@ -365,10 +256,22 @@ type CostModelMetricsEmitter struct {
 
 // NewCostModelMetricsEmitter creates a new cost-model metrics emitter. Use Start() to begin metric emission.
 func NewCostModelMetricsEmitter(promClient promclient.Client, clusterCache clustercache.ClusterCache, provider cloud.Provider, clusterInfo clusters.ClusterInfoProvider, model *CostModel) *CostModelMetricsEmitter {
-	// init will only actually execute once to register the custom gauges
-	initCostModelMetrics(clusterCache, provider, clusterInfo)
 
-	metrics.InitKubeMetrics(clusterCache, &metrics.KubeMetricsOpts{
+	metricsConfig, err := metrics.GetMetricsConfig()
+	if err != nil {
+		log.Infof("Failed to get metrics configuration: %s", err)
+	}
+
+	log.Infof("--DISABLED LABELS--")
+	for i := range metricsConfig.DisabledMetrics {
+		log.Infof("DISABLE LABEL: %s", metricsConfig.DisabledMetrics[i])
+	}
+	log.Infof("-------------------")
+
+	// init will only actually execute once to register the custom gauges
+	initCostModelMetrics(clusterCache, provider, clusterInfo, metricsConfig)
+
+	metrics.InitKubeMetrics(clusterCache, metricsConfig, &metrics.KubeMetricsOpts{
 		EmitKubecostControllerMetrics: true,
 		EmitNamespaceAnnotations:      env.IsEmitNamespaceAnnotationsMetric(),
 		EmitPodAnnotations:            env.IsEmitPodAnnotationsMetric(),

--- a/pkg/costmodel/metrics.go
+++ b/pkg/costmodel/metrics.go
@@ -323,16 +323,11 @@ type CostModelMetricsEmitter struct {
 // NewCostModelMetricsEmitter creates a new cost-model metrics emitter. Use Start() to begin metric emission.
 func NewCostModelMetricsEmitter(promClient promclient.Client, clusterCache clustercache.ClusterCache, provider cloud.Provider, clusterInfo clusters.ClusterInfoProvider, model *CostModel) *CostModelMetricsEmitter {
 
+	// Get metric configurations, if any
 	metricsConfig, err := metrics.GetMetricsConfig()
 	if err != nil {
-		log.Infof("Failed to get metrics configuration: %s", err)
+		log.Infof("Failed to get metrics config before init: %s", err)
 	}
-
-	log.Infof("--DISABLED LABELS--")
-	for i := range metricsConfig.DisabledMetrics {
-		log.Infof("DISABLE LABEL: %s", metricsConfig.DisabledMetrics[i])
-	}
-	log.Infof("-------------------")
 
 	// init will only actually execute once to register the custom gauges
 	initCostModelMetrics(clusterCache, provider, clusterInfo, metricsConfig)

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kubecost/cost-model/pkg/config"
+	"github.com/kubecost/cost-model/pkg/metrics"
 	"github.com/kubecost/cost-model/pkg/services"
 	"github.com/kubecost/cost-model/pkg/util/httputil"
 	"github.com/kubecost/cost-model/pkg/util/timeutil"
@@ -1416,8 +1417,7 @@ func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses
 
 	// Append the pricing config watcher
 	configWatchers.AddWatcher(cloud.ConfigWatcherFor(cloudProvider))
-
-	configWatchers.AddWatcher(GetMetricsConfigWatcher())
+	configWatchers.AddWatcher(metrics.GetMetricsConfigWatcher())
 
 	watchConfigFunc := configWatchers.ToWatchFunc()
 	watchedConfigs := configWatchers.GetWatchedConfigs()

--- a/pkg/costmodel/router.go
+++ b/pkg/costmodel/router.go
@@ -1416,6 +1416,9 @@ func Initialize(additionalConfigWatchers ...*watcher.ConfigMapWatcher) *Accesses
 
 	// Append the pricing config watcher
 	configWatchers.AddWatcher(cloud.ConfigWatcherFor(cloudProvider))
+
+	configWatchers.AddWatcher(GetMetricsConfigWatcher())
+
 	watchConfigFunc := configWatchers.ToWatchFunc()
 	watchedConfigs := configWatchers.GetWatchedConfigs()
 

--- a/pkg/env/costmodelenv.go
+++ b/pkg/env/costmodelenv.go
@@ -76,6 +76,7 @@ const (
 	PromClusterIDLabelEnvVar = "PROM_CLUSTER_ID_LABEL"
 
 	PricingConfigmapName  = "PRICING_CONFIGMAP_NAME"
+	MetricsConfigmapName  = "METRICS_CONFIGMAP_NAME"
 	KubecostJobNameEnvVar = "KUBECOST_JOB_NAME"
 
 	KubecostConfigBucketEnvVar    = "KUBECOST_CONFIG_BUCKET"
@@ -124,6 +125,10 @@ func GetPrometheusQueryOffset() time.Duration {
 
 func GetPricingConfigmapName() string {
 	return Get(PricingConfigmapName, "pricing-configs")
+}
+
+func GetMetricsConfigmapName() string {
+	return Get(MetricsConfigmapName, "metrics-config")
 }
 
 // GetAWSAccessKeyID returns the environment variable value for AWSAccessKeyIDEnvVar which represents

--- a/pkg/metrics/jobmetrics.go
+++ b/pkg/metrics/jobmetrics.go
@@ -25,43 +25,46 @@ type KubeJobCollector struct {
 // collected by this Collector.
 func (kjc KubeJobCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := kjc.metricsConfig.GetDisabledMetricsMap()
-
-	if _, ok := disabledMetrics["kube_pod_annotations"]; !ok {
-		ch <- prometheus.NewDesc("kube_job_status_failed", "The number of pods which reached Phase Failed and the reason for failure.", []string{}, nil)
+	if _, disabled := disabledMetrics["kube_pod_annotations"]; disabled {
+		return
 	}
+
+	ch <- prometheus.NewDesc("kube_job_status_failed", "The number of pods which reached Phase Failed and the reason for failure.", []string{}, nil)
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (kjc KubeJobCollector) Collect(ch chan<- prometheus.Metric) {
 	disabledMetrics := kjc.metricsConfig.GetDisabledMetricsMap()
+	if _, disabled := disabledMetrics["kube_pod_annotations"]; disabled {
+		return
+	}
 
-	if _, ok := disabledMetrics["kube_pod_annotations"]; !ok {
-		jobs := kjc.KubeClusterCache.GetAllJobs()
-		for _, job := range jobs {
-			jobName := job.GetName()
-			jobNS := job.GetNamespace()
+	jobs := kjc.KubeClusterCache.GetAllJobs()
+	for _, job := range jobs {
+		jobName := job.GetName()
+		jobNS := job.GetNamespace()
 
-			if job.Status.Failed == 0 {
-				ch <- newKubeJobStatusFailedMetric(jobName, jobNS, "kube_job_status_failed", "", 0)
-			} else {
-				for _, condition := range job.Status.Conditions {
-					if condition.Type == batchv1.JobFailed {
-						reasonKnown := false
-						for _, reason := range jobFailureReasons {
-							reasonKnown = reasonKnown || failureReason(&condition, reason)
+		if job.Status.Failed == 0 {
+			ch <- newKubeJobStatusFailedMetric(jobName, jobNS, "kube_job_status_failed", "", 0)
+		} else {
+			for _, condition := range job.Status.Conditions {
+				if condition.Type == batchv1.JobFailed {
+					reasonKnown := false
+					for _, reason := range jobFailureReasons {
+						reasonKnown = reasonKnown || failureReason(&condition, reason)
 
-							ch <- newKubeJobStatusFailedMetric(jobName, jobNS, "kube_job_status_failed", reason, boolFloat64(failureReason(&condition, reason)))
-						}
+						ch <- newKubeJobStatusFailedMetric(jobName, jobNS, "kube_job_status_failed", reason, boolFloat64(failureReason(&condition, reason)))
+					}
 
-						// for unknown reasons
-						if !reasonKnown {
-							ch <- newKubeJobStatusFailedMetric(jobName, jobNS, "kube_job_status_failed", "", float64(job.Status.Failed))
-						}
+					// for unknown reasons
+					if !reasonKnown {
+						ch <- newKubeJobStatusFailedMetric(jobName, jobNS, "kube_job_status_failed", "", float64(job.Status.Failed))
 					}
 				}
 			}
 		}
 	}
+
 }
 
 //--------------------------------------------------------------------------

--- a/pkg/metrics/kubemetrics.go
+++ b/pkg/metrics/kubemetrics.go
@@ -43,7 +43,7 @@ func DefaultKubeMetricsOpts() *KubeMetricsOpts {
 }
 
 // InitKubeMetrics initializes kubernetes metric emission using the provided options.
-func InitKubeMetrics(clusterCache clustercache.ClusterCache, opts *KubeMetricsOpts) {
+func InitKubeMetrics(clusterCache clustercache.ClusterCache, metricsConfig *MetricsConfig, opts *KubeMetricsOpts) {
 	if opts == nil {
 		opts = DefaultKubeMetricsOpts()
 	}
@@ -52,58 +52,73 @@ func InitKubeMetrics(clusterCache clustercache.ClusterCache, opts *KubeMetricsOp
 		if opts.EmitKubecostControllerMetrics {
 			prometheus.MustRegister(KubecostServiceCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubecostDeploymentCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubecostStatefulsetCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 		}
 
 		if opts.EmitPodAnnotations {
 			prometheus.MustRegister(KubecostPodCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 		}
 
 		if opts.EmitNamespaceAnnotations {
 			prometheus.MustRegister(KubecostNamespaceCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 		}
 
 		if opts.EmitKubeStateMetrics {
 			prometheus.MustRegister(KubeNodeCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubeNamespaceCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubeDeploymentCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubePodCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubePVCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubePVCCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubeJobCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 		} else if opts.EmitKubeStateMetricsV1Only {
 			prometheus.MustRegister(KubeNodeCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubeNamespaceCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 			prometheus.MustRegister(KubePodLabelsCollector{
 				KubeClusterCache: clusterCache,
+				metricsConfig:    *metricsConfig,
 			})
 		}
 	})

--- a/pkg/metrics/metricsconfig.go
+++ b/pkg/metrics/metricsconfig.go
@@ -1,0 +1,106 @@
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+
+	"github.com/kubecost/cost-model/pkg/log"
+	"github.com/kubecost/cost-model/pkg/util/watcher"
+	"k8s.io/klog"
+)
+
+var metricsConfigLock = new(sync.Mutex)
+
+type MetricsConfig struct {
+	DisabledMetrics []string `json:"disabledMetrics"`
+}
+
+func (mc MetricsConfig) GetDisabledMetricsMap() map[string]struct{} {
+	disabledMetricsMap := make(map[string]struct{})
+
+	for i := range mc.DisabledMetrics {
+		disabledMetricsMap[mc.DisabledMetrics[i]] = struct{}{}
+		log.Infof("Adding disabled metric %s", mc.DisabledMetrics[i])
+	}
+
+	return disabledMetricsMap
+}
+
+func GetMetricsConfig() (*MetricsConfig, error) {
+	metricsConfigLock.Lock()
+	defer metricsConfigLock.Unlock()
+	mc := &MetricsConfig{}
+	body, err := ioutil.ReadFile("/var/configs/metrics.json")
+	if os.IsNotExist(err) {
+
+		return mc, nil
+	} else if err != nil {
+		return mc, err
+	}
+
+	err = json.Unmarshal(body, mc)
+	if err != nil {
+		return mc, err
+	}
+
+	return mc, nil
+}
+
+func UpdateMetricsConfig(mc *MetricsConfig) (*MetricsConfig, error) {
+	metricsConfigLock.Lock()
+	defer metricsConfigLock.Unlock()
+
+	mcb, err := json.Marshal(mc)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding metrics config struct: %s", err)
+	}
+
+	err = ioutil.WriteFile("/var/configs/metrics.json", mcb, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("error writing to metrics config file: %s", err)
+	}
+
+	return mc, nil
+}
+
+func UpdateMetricsConfigFromConfigmap(data map[string]string) error {
+
+	mc := &MetricsConfig{}
+	key := "metrics.json"
+
+	cdata, ok := data[key]
+	if !ok {
+		return fmt.Errorf("error finding metrics config data")
+	}
+
+	err := json.Unmarshal([]byte(cdata), &mc)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal metrics configs: %s", err)
+	}
+
+	_, err = UpdateMetricsConfig(mc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func GetMetricsConfigWatcher() *watcher.ConfigMapWatcher {
+	return &watcher.ConfigMapWatcher{
+		ConfigMapName: "metrics-config", // temporary, use env
+		WatchFunc: func(name string, data map[string]string) error {
+			klog.Infof("--CONFIGMAP DATA--")
+			for key, val := range data {
+				klog.Infof("%s : %s", key, val)
+			}
+			klog.Infof("------------------")
+			err := UpdateMetricsConfigFromConfigmap(data)
+			return err
+		},
+	}
+}

--- a/pkg/metrics/metricsconfig.go
+++ b/pkg/metrics/metricsconfig.go
@@ -38,12 +38,12 @@ func GetMetricsConfig() (*MetricsConfig, error) {
 
 		return mc, nil
 	} else if err != nil {
-		return mc, err
+		return mc, fmt.Errorf("error reading metrics config file: %s", err)
 	}
 
 	err = json.Unmarshal(body, mc)
 	if err != nil {
-		return mc, err
+		return mc, fmt.Errorf("error decoding metrics config: %s", err)
 	}
 
 	return mc, nil
@@ -56,7 +56,7 @@ func UpdateMetricsConfig(mc *MetricsConfig) (*MetricsConfig, error) {
 
 	mcb, err := json.Marshal(mc)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding metrics config struct: %s", err)
+		return nil, fmt.Errorf("error encoding metrics config struct: %s", err)
 	}
 
 	err = ioutil.WriteFile("/var/configs/metrics.json", mcb, 0644)

--- a/pkg/metrics/namespacemetrics.go
+++ b/pkg/metrics/namespacemetrics.go
@@ -15,24 +15,33 @@ import (
 // KubecostNamespaceCollector is a prometheus collector that generates namespace sourced metrics
 type KubecostNamespaceCollector struct {
 	KubeClusterCache clustercache.ClusterCache
+	metricsConfig    MetricsConfig
 }
 
 // Describe sends the super-set of all possible descriptors of metrics
 // collected by this Collector.
 func (nsac KubecostNamespaceCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- prometheus.NewDesc("kube_namespace_annotations", "namespace annotations", []string{}, nil)
+	disabledMetrics := nsac.metricsConfig.GetDisabledMetricsMap()
+
+	if _, ok := disabledMetrics["kube_namespace_labels"]; !ok {
+		ch <- prometheus.NewDesc("kube_namespace_annotations", "namespace annotations", []string{}, nil)
+	}
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (nsac KubecostNamespaceCollector) Collect(ch chan<- prometheus.Metric) {
-	namespaces := nsac.KubeClusterCache.GetAllNamespaces()
-	for _, namespace := range namespaces {
-		nsName := namespace.GetName()
+	disabledMetrics := nsac.metricsConfig.GetDisabledMetricsMap()
 
-		labels, values := prom.KubeAnnotationsToLabels(namespace.Annotations)
-		if len(labels) > 0 {
-			m := newNamespaceAnnotationsMetric("kube_namespace_annotations", nsName, labels, values)
-			ch <- m
+	if _, ok := disabledMetrics["kube_namespace_labels"]; !ok {
+		namespaces := nsac.KubeClusterCache.GetAllNamespaces()
+		for _, namespace := range namespaces {
+			nsName := namespace.GetName()
+
+			labels, values := prom.KubeAnnotationsToLabels(namespace.Annotations)
+			if len(labels) > 0 {
+				m := newNamespaceAnnotationsMetric("kube_namespace_annotations", nsName, labels, values)
+				ch <- m
+			}
 		}
 	}
 }
@@ -100,24 +109,33 @@ func (nam NamespaceAnnotationsMetric) Write(m *dto.Metric) error {
 // KubeNamespaceCollector is a prometheus collector that generates namespace sourced metrics
 type KubeNamespaceCollector struct {
 	KubeClusterCache clustercache.ClusterCache
+	metricsConfig    MetricsConfig
 }
 
 // Describe sends the super-set of all possible descriptors of metrics
 // collected by this Collector.
 func (nsac KubeNamespaceCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- prometheus.NewDesc("kube_namespace_labels", "namespace labels", []string{}, nil)
+	disabledMetrics := nsac.metricsConfig.GetDisabledMetricsMap()
+
+	if _, ok := disabledMetrics["kube_namespace_labels"]; !ok {
+		ch <- prometheus.NewDesc("kube_namespace_labels", "namespace labels", []string{}, nil)
+	}
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (nsac KubeNamespaceCollector) Collect(ch chan<- prometheus.Metric) {
-	namespaces := nsac.KubeClusterCache.GetAllNamespaces()
-	for _, namespace := range namespaces {
-		nsName := namespace.GetName()
+	disabledMetrics := nsac.metricsConfig.GetDisabledMetricsMap()
 
-		labels, values := prom.KubeLabelsToLabels(namespace.Labels)
-		if len(labels) > 0 {
-			m := newNamespaceAnnotationsMetric("kube_namespace_labels", nsName, labels, values)
-			ch <- m
+	if _, ok := disabledMetrics["kube_namespace_labels"]; !ok {
+		namespaces := nsac.KubeClusterCache.GetAllNamespaces()
+		for _, namespace := range namespaces {
+			nsName := namespace.GetName()
+
+			labels, values := prom.KubeLabelsToLabels(namespace.Labels)
+			if len(labels) > 0 {
+				m := newNamespaceAnnotationsMetric("kube_namespace_labels", nsName, labels, values)
+				ch <- m
+			}
 		}
 	}
 }

--- a/pkg/metrics/namespacemetrics.go
+++ b/pkg/metrics/namespacemetrics.go
@@ -22,28 +22,32 @@ type KubecostNamespaceCollector struct {
 // collected by this Collector.
 func (nsac KubecostNamespaceCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := nsac.metricsConfig.GetDisabledMetricsMap()
-
-	if _, ok := disabledMetrics["kube_namespace_labels"]; !ok {
-		ch <- prometheus.NewDesc("kube_namespace_annotations", "namespace annotations", []string{}, nil)
+	if _, disabled := disabledMetrics["kube_namespace_annotations"]; disabled {
+		return
 	}
+
+	ch <- prometheus.NewDesc("kube_namespace_annotations", "namespace annotations", []string{}, nil)
+
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (nsac KubecostNamespaceCollector) Collect(ch chan<- prometheus.Metric) {
 	disabledMetrics := nsac.metricsConfig.GetDisabledMetricsMap()
+	if _, disabled := disabledMetrics["kube_namespace_annotations"]; disabled {
+		return
+	}
 
-	if _, ok := disabledMetrics["kube_namespace_labels"]; !ok {
-		namespaces := nsac.KubeClusterCache.GetAllNamespaces()
-		for _, namespace := range namespaces {
-			nsName := namespace.GetName()
+	namespaces := nsac.KubeClusterCache.GetAllNamespaces()
+	for _, namespace := range namespaces {
+		nsName := namespace.GetName()
 
-			labels, values := prom.KubeAnnotationsToLabels(namespace.Annotations)
-			if len(labels) > 0 {
-				m := newNamespaceAnnotationsMetric("kube_namespace_annotations", nsName, labels, values)
-				ch <- m
-			}
+		labels, values := prom.KubeAnnotationsToLabels(namespace.Annotations)
+		if len(labels) > 0 {
+			m := newNamespaceAnnotationsMetric("kube_namespace_annotations", nsName, labels, values)
+			ch <- m
 		}
 	}
+
 }
 
 //--------------------------------------------------------------------------
@@ -116,28 +120,32 @@ type KubeNamespaceCollector struct {
 // collected by this Collector.
 func (nsac KubeNamespaceCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := nsac.metricsConfig.GetDisabledMetricsMap()
-
-	if _, ok := disabledMetrics["kube_namespace_labels"]; !ok {
-		ch <- prometheus.NewDesc("kube_namespace_labels", "namespace labels", []string{}, nil)
+	if _, disabled := disabledMetrics["kube_namespace_labels"]; disabled {
+		return
 	}
+
+	ch <- prometheus.NewDesc("kube_namespace_labels", "namespace labels", []string{}, nil)
+
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (nsac KubeNamespaceCollector) Collect(ch chan<- prometheus.Metric) {
 	disabledMetrics := nsac.metricsConfig.GetDisabledMetricsMap()
+	if _, disabled := disabledMetrics["kube_namespace_labels"]; disabled {
+		return
+	}
 
-	if _, ok := disabledMetrics["kube_namespace_labels"]; !ok {
-		namespaces := nsac.KubeClusterCache.GetAllNamespaces()
-		for _, namespace := range namespaces {
-			nsName := namespace.GetName()
+	namespaces := nsac.KubeClusterCache.GetAllNamespaces()
+	for _, namespace := range namespaces {
+		nsName := namespace.GetName()
 
-			labels, values := prom.KubeLabelsToLabels(namespace.Labels)
-			if len(labels) > 0 {
-				m := newNamespaceAnnotationsMetric("kube_namespace_labels", nsName, labels, values)
-				ch <- m
-			}
+		labels, values := prom.KubeLabelsToLabels(namespace.Labels)
+		if len(labels) > 0 {
+			m := newNamespaceAnnotationsMetric("kube_namespace_labels", nsName, labels, values)
+			ch <- m
 		}
 	}
+
 }
 
 //--------------------------------------------------------------------------

--- a/pkg/metrics/nodemetrics.go
+++ b/pkg/metrics/nodemetrics.go
@@ -30,28 +30,28 @@ type KubeNodeCollector struct {
 func (nsac KubeNodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := nsac.metricsConfig.GetDisabledMetricsMap()
 
-	if _, ok := disabledMetrics["kube_node_status_capacity"]; !ok {
+	if _, disabled := disabledMetrics["kube_node_status_capacity"]; !disabled {
 		ch <- prometheus.NewDesc("kube_node_status_capacity", "Node resource capacity.", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_node_status_capacity_memory_bytes"]; !ok {
+	if _, disabled := disabledMetrics["kube_node_status_capacity_memory_bytes"]; !disabled {
 		ch <- prometheus.NewDesc("kube_node_status_capacity_memory_bytes", "node capacity memory bytes", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_node_status_capacity_cpu_cores"]; !ok {
+	if _, disabled := disabledMetrics["kube_node_status_capacity_cpu_cores"]; !disabled {
 		ch <- prometheus.NewDesc("kube_node_status_capacity_cpu_cores", "node capacity cpu cores", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_node_status_allocatable"]; !ok {
+	if _, disabled := disabledMetrics["kube_node_status_allocatable"]; !disabled {
 		ch <- prometheus.NewDesc("kube_node_status_allocatable", "The allocatable for different resources of a node that are available for scheduling.", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_node_status_allocatable_cpu_cores"]; !ok {
+	if _, disabled := disabledMetrics["kube_node_status_allocatable_cpu_cores"]; !disabled {
 		ch <- prometheus.NewDesc("kube_node_status_allocatable_cpu_cores", "The allocatable cpu cores.", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_node_status_allocatable_memory_bytes"]; !ok {
+	if _, disabled := disabledMetrics["kube_node_status_allocatable_memory_bytes"]; !disabled {
 		ch <- prometheus.NewDesc("kube_node_status_allocatable_memory_bytes", "The allocatable memory in bytes.", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_node_labels"]; !ok {
+	if _, disabled := disabledMetrics["kube_node_labels"]; !disabled {
 		ch <- prometheus.NewDesc("kube_node_labels", "all labels for each node prefixed with label_", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_node_status_condition"]; !ok {
+	if _, disabled := disabledMetrics["kube_node_status_condition"]; !disabled {
 		ch <- prometheus.NewDesc("kube_node_status_condition", "The condition of a cluster node.", []string{}, nil)
 	}
 }
@@ -75,19 +75,19 @@ func (nsac KubeNodeCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 
 			// KSM v1 Emission
-			if _, ok := disabledMetrics["kube_node_status_capacity_cpu_cores"]; !ok {
+			if _, disabled := disabledMetrics["kube_node_status_capacity_cpu_cores"]; !disabled {
 				if resource == "cpu" {
 					ch <- newKubeNodeStatusCapacityCPUCoresMetric("kube_node_status_capacity_cpu_cores", nodeName, value)
 
 				}
 			}
-			if _, ok := disabledMetrics["kube_node_status_capacity_memory_bytes"]; !ok {
+			if _, disabled := disabledMetrics["kube_node_status_capacity_memory_bytes"]; !disabled {
 				if resource == "memory" {
 					ch <- newKubeNodeStatusCapacityMemoryBytesMetric("kube_node_status_capacity_memory_bytes", nodeName, value)
 				}
 			}
 
-			if _, ok := disabledMetrics["kube_node_status_capacity"]; !ok {
+			if _, disabled := disabledMetrics["kube_node_status_capacity"]; !disabled {
 				ch <- newKubeNodeStatusCapacityMetric("kube_node_status_capacity", nodeName, resource, unit, value)
 			}
 		}
@@ -103,30 +103,30 @@ func (nsac KubeNodeCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 
 			// KSM v1 Emission
-			if _, ok := disabledMetrics["kube_node_status_allocatable_cpu_cores"]; !ok {
+			if _, disabled := disabledMetrics["kube_node_status_allocatable_cpu_cores"]; !disabled {
 				if resource == "cpu" {
 					ch <- newKubeNodeStatusAllocatableCPUCoresMetric("kube_node_status_allocatable_cpu_cores", nodeName, value)
 				}
 			}
-			if _, ok := disabledMetrics["kube_node_status_allocatable_memory_bytes"]; !ok {
+			if _, disabled := disabledMetrics["kube_node_status_allocatable_memory_bytes"]; !disabled {
 				if resource == "memory" {
 					ch <- newKubeNodeStatusAllocatableMemoryBytesMetric("kube_node_status_allocatable_memory_bytes", nodeName, value)
 				}
 			}
-			if _, ok := disabledMetrics["kube_node_status_allocatable"]; !ok {
+			if _, disabled := disabledMetrics["kube_node_status_allocatable"]; !disabled {
 				ch <- newKubeNodeStatusAllocatableMetric("kube_node_status_allocatable", nodeName, resource, unit, value)
 			}
 		}
 
 		// node labels
-		if _, ok := disabledMetrics["kube_node_labels"]; !ok {
+		if _, disabled := disabledMetrics["kube_node_labels"]; !disabled {
 			labelNames, labelValues := prom.KubePrependQualifierToLabels(node.GetLabels(), "label_")
 			ch <- newKubeNodeLabelsMetric(nodeName, "kube_node_labels", labelNames, labelValues)
 		}
 
 		// kube_node_status_condition
 		// Collect node conditions and while default to false.
-		if _, ok := disabledMetrics["kube_node_status_condition"]; !ok {
+		if _, disabled := disabledMetrics["kube_node_status_condition"]; !disabled {
 			for _, c := range node.Status.Conditions {
 				conditions := getConditions(c.Status)
 

--- a/pkg/metrics/podlabelmetrics.go
+++ b/pkg/metrics/podlabelmetrics.go
@@ -51,10 +51,10 @@ type KubePodLabelsCollector struct {
 func (kpmc KubePodLabelsCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := kpmc.metricsConfig.GetDisabledMetricsMap()
 
-	if _, ok := disabledMetrics["kube_pod_labels"]; !ok {
+	if _, disabled := disabledMetrics["kube_pod_labels"]; !disabled {
 		ch <- prometheus.NewDesc("kube_pod_labels", "All labels for each pod prefixed with label_", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_pod_owner"]; !ok {
+	if _, disabled := disabledMetrics["kube_pod_owner"]; !disabled {
 		ch <- prometheus.NewDesc("kube_pod_owner", "Information about the Pod's owner", []string{}, nil)
 	}
 }
@@ -70,13 +70,13 @@ func (kpmc KubePodLabelsCollector) Collect(ch chan<- prometheus.Metric) {
 		podUID := string(pod.GetUID())
 
 		// Pod Labels
-		if _, ok := disabledMetrics["kube_pod_labels"]; !ok {
+		if _, disabled := disabledMetrics["kube_pod_labels"]; !disabled {
 			labelNames, labelValues := prom.KubePrependQualifierToLabels(pod.GetLabels(), "label_")
 			ch <- newKubePodLabelsMetric("kube_pod_labels", podNS, podName, podUID, labelNames, labelValues)
 		}
 
 		// Owner References
-		if _, ok := disabledMetrics["kube_pod_owner"]; !ok {
+		if _, disabled := disabledMetrics["kube_pod_owner"]; !disabled {
 			for _, owner := range pod.OwnerReferences {
 				ch <- newKubePodOwnerMetric("kube_pod_owner", podNS, podName, owner.Name, owner.Kind, owner.Controller != nil)
 			}

--- a/pkg/metrics/podlabelmetrics.go
+++ b/pkg/metrics/podlabelmetrics.go
@@ -51,10 +51,10 @@ type KubePodLabelsCollector struct {
 func (kpmc KubePodLabelsCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := kpmc.metricsConfig.GetDisabledMetricsMap()
 
-	if _, ok := disabledMetrics["kube_pod_labels"]; ok {
+	if _, ok := disabledMetrics["kube_pod_labels"]; !ok {
 		ch <- prometheus.NewDesc("kube_pod_labels", "All labels for each pod prefixed with label_", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_pod_owner"]; ok {
+	if _, ok := disabledMetrics["kube_pod_owner"]; !ok {
 		ch <- prometheus.NewDesc("kube_pod_owner", "Information about the Pod's owner", []string{}, nil)
 	}
 }
@@ -70,13 +70,13 @@ func (kpmc KubePodLabelsCollector) Collect(ch chan<- prometheus.Metric) {
 		podUID := string(pod.GetUID())
 
 		// Pod Labels
-		if _, ok := disabledMetrics["kube_pod_labels"]; ok {
+		if _, ok := disabledMetrics["kube_pod_labels"]; !ok {
 			labelNames, labelValues := prom.KubePrependQualifierToLabels(pod.GetLabels(), "label_")
 			ch <- newKubePodLabelsMetric("kube_pod_labels", podNS, podName, podUID, labelNames, labelValues)
 		}
 
 		// Owner References
-		if _, ok := disabledMetrics["kube_pod_owner"]; ok {
+		if _, ok := disabledMetrics["kube_pod_owner"]; !ok {
 			for _, owner := range pod.OwnerReferences {
 				ch <- newKubePodOwnerMetric("kube_pod_owner", podNS, podName, owner.Name, owner.Kind, owner.Controller != nil)
 			}

--- a/pkg/metrics/pvcmetrics.go
+++ b/pkg/metrics/pvcmetrics.go
@@ -21,10 +21,10 @@ type KubePVCCollector struct {
 func (kpvc KubePVCCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := kpvc.metricsConfig.GetDisabledMetricsMap()
 
-	if _, ok := disabledMetrics["kube_persistentvolumeclaim_resource_requests_storage_bytes"]; !ok {
+	if _, disabled := disabledMetrics["kube_persistentvolumeclaim_resource_requests_storage_bytes"]; !disabled {
 		ch <- prometheus.NewDesc("kube_persistentvolumeclaim_resource_requests_storage_bytes", "The pvc storage resource requests in bytes", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_persistentvolumeclaim_info"]; !ok {
+	if _, disabled := disabledMetrics["kube_persistentvolumeclaim_info"]; !disabled {
 		ch <- prometheus.NewDesc("kube_persistentvolumeclaim_info", "The pvc storage resource requests in bytes", []string{}, nil)
 	}
 }
@@ -38,12 +38,12 @@ func (kpvc KubePVCCollector) Collect(ch chan<- prometheus.Metric) {
 		storageClass := getPersistentVolumeClaimClass(pvc)
 		volume := pvc.Spec.VolumeName
 
-		if _, ok := disabledMetrics["kube_persistentvolumeclaim_info"]; !ok {
+		if _, disabled := disabledMetrics["kube_persistentvolumeclaim_info"]; !disabled {
 			ch <- newKubePVCInfoMetric("kube_persistentvolumeclaim_info", pvc.Name, pvc.Namespace, storageClass, volume)
 		}
 
 		if storage, ok := pvc.Spec.Resources.Requests[v1.ResourceStorage]; ok {
-			if _, ok := disabledMetrics["kube_persistentvolumeclaim_resource_requests_storage_bytes"]; !ok {
+			if _, disabled := disabledMetrics["kube_persistentvolumeclaim_resource_requests_storage_bytes"]; !disabled {
 				ch <- newKubePVCResourceRequestsStorageBytesMetric("kube_persistentvolumeclaim_resource_requests_storage_bytes", pvc.Name, pvc.Namespace, float64(storage.Value()))
 			}
 		}

--- a/pkg/metrics/pvcmetrics.go
+++ b/pkg/metrics/pvcmetrics.go
@@ -14,25 +14,38 @@ import (
 // KubePVCCollector is a prometheus collector that generates pvc sourced metrics
 type KubePVCCollector struct {
 	KubeClusterCache clustercache.ClusterCache
+	metricsConfig    MetricsConfig
 }
 
 // Describe sends the super-set of all possible descriptors of metrics collected by this Collector.
 func (kpvc KubePVCCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- prometheus.NewDesc("kube_persistentvolumeclaim_resource_requests_storage_bytes", "The pvc storage resource requests in bytes", []string{}, nil)
-	ch <- prometheus.NewDesc("kube_persistentvolumeclaim_info", "The pvc storage resource requests in bytes", []string{}, nil)
+	disabledMetrics := kpvc.metricsConfig.GetDisabledMetricsMap()
+
+	if _, ok := disabledMetrics["kube_persistentvolumeclaim_resource_requests_storage_bytes"]; !ok {
+		ch <- prometheus.NewDesc("kube_persistentvolumeclaim_resource_requests_storage_bytes", "The pvc storage resource requests in bytes", []string{}, nil)
+	}
+	if _, ok := disabledMetrics["kube_persistentvolumeclaim_info"]; !ok {
+		ch <- prometheus.NewDesc("kube_persistentvolumeclaim_info", "The pvc storage resource requests in bytes", []string{}, nil)
+	}
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (kpvc KubePVCCollector) Collect(ch chan<- prometheus.Metric) {
 	pvcs := kpvc.KubeClusterCache.GetAllPersistentVolumeClaims()
+	disabledMetrics := kpvc.metricsConfig.GetDisabledMetricsMap()
+
 	for _, pvc := range pvcs {
 		storageClass := getPersistentVolumeClaimClass(pvc)
 		volume := pvc.Spec.VolumeName
 
-		ch <- newKubePVCInfoMetric("kube_persistentvolumeclaim_info", pvc.Name, pvc.Namespace, storageClass, volume)
+		if _, ok := disabledMetrics["kube_persistentvolumeclaim_info"]; !ok {
+			ch <- newKubePVCInfoMetric("kube_persistentvolumeclaim_info", pvc.Name, pvc.Namespace, storageClass, volume)
+		}
 
 		if storage, ok := pvc.Spec.Resources.Requests[v1.ResourceStorage]; ok {
-			ch <- newKubePVCResourceRequestsStorageBytesMetric("kube_persistentvolumeclaim_resource_requests_storage_bytes", pvc.Name, pvc.Namespace, float64(storage.Value()))
+			if _, ok := disabledMetrics["kube_persistentvolumeclaim_resource_requests_storage_bytes"]; !ok {
+				ch <- newKubePVCResourceRequestsStorageBytesMetric("kube_persistentvolumeclaim_resource_requests_storage_bytes", pvc.Name, pvc.Namespace, float64(storage.Value()))
+			}
 		}
 	}
 }

--- a/pkg/metrics/pvmetrics.go
+++ b/pkg/metrics/pvmetrics.go
@@ -22,10 +22,10 @@ type KubePVCollector struct {
 func (kpvcb KubePVCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := kpvcb.metricsConfig.GetDisabledMetricsMap()
 
-	if _, ok := disabledMetrics["kube_persistentvolume_capacity_bytes"]; !ok {
+	if _, disabled := disabledMetrics["kube_persistentvolume_capacity_bytes"]; !disabled {
 		ch <- prometheus.NewDesc("kube_persistentvolume_capacity_bytes", "The pv storage capacity in bytes", []string{}, nil)
 	}
-	if _, ok := disabledMetrics["kube_persistentvolume_status_phase"]; !ok {
+	if _, disabled := disabledMetrics["kube_persistentvolume_status_phase"]; !disabled {
 		ch <- prometheus.NewDesc("kube_persistentvolume_status_phase", "The phase indicates if a volume is available, bound to a claim, or released by a claim.", []string{}, nil)
 	}
 }
@@ -36,7 +36,7 @@ func (kpvcb KubePVCollector) Collect(ch chan<- prometheus.Metric) {
 	disabledMetrics := kpvcb.metricsConfig.GetDisabledMetricsMap()
 
 	for _, pv := range pvs {
-		if _, ok := disabledMetrics["kube_persistentvolume_status_phase"]; !ok {
+		if _, disabled := disabledMetrics["kube_persistentvolume_status_phase"]; !disabled {
 			phase := pv.Status.Phase
 			if phase != "" {
 				phases := []struct {
@@ -56,7 +56,7 @@ func (kpvcb KubePVCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 		}
 
-		if _, ok := disabledMetrics["kube_persistentvolume_capacity_bytes"]; !ok {
+		if _, disabled := disabledMetrics["kube_persistentvolume_capacity_bytes"]; !disabled {
 			storage := pv.Spec.Capacity[v1.ResourceStorage]
 			m := newKubePVCapacityBytesMetric("kube_persistentvolume_capacity_bytes", pv.Name, float64(storage.Value()))
 

--- a/pkg/metrics/statefulsetmetrics.go
+++ b/pkg/metrics/statefulsetmetrics.go
@@ -22,29 +22,32 @@ type KubecostStatefulsetCollector struct {
 // collected by this Collector.
 func (sc KubecostStatefulsetCollector) Describe(ch chan<- *prometheus.Desc) {
 	disabledMetrics := sc.metricsConfig.GetDisabledMetricsMap()
-
-	if _, ok := disabledMetrics["statefulSet_match_labels"]; !ok {
-		ch <- prometheus.NewDesc("statefulSet_match_labels", "statfulSet match labels", []string{}, nil)
+	if _, disabled := disabledMetrics["statefulSet_match_labels"]; disabled {
+		return
 	}
+
+	ch <- prometheus.NewDesc("statefulSet_match_labels", "statfulSet match labels", []string{}, nil)
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (sc KubecostStatefulsetCollector) Collect(ch chan<- prometheus.Metric) {
 	disabledMetrics := sc.metricsConfig.GetDisabledMetricsMap()
+	if _, disabled := disabledMetrics["statefulSet_match_labels"]; disabled {
+		return
+	}
 
-	if _, ok := disabledMetrics["statefulSet_match_labels"]; !ok {
-		ds := sc.KubeClusterCache.GetAllStatefulSets()
-		for _, statefulset := range ds {
-			statefulsetName := statefulset.GetName()
-			statefulsetNS := statefulset.GetNamespace()
+	ds := sc.KubeClusterCache.GetAllStatefulSets()
+	for _, statefulset := range ds {
+		statefulsetName := statefulset.GetName()
+		statefulsetNS := statefulset.GetNamespace()
 
-			labels, values := prom.KubeLabelsToLabels(statefulset.Spec.Selector.MatchLabels)
-			if len(labels) > 0 {
-				m := newStatefulsetMatchLabelsMetric(statefulsetName, statefulsetNS, "statefulSet_match_labels", labels, values)
-				ch <- m
-			}
+		labels, values := prom.KubeLabelsToLabels(statefulset.Spec.Selector.MatchLabels)
+		if len(labels) > 0 {
+			m := newStatefulsetMatchLabelsMetric(statefulsetName, statefulsetNS, "statefulSet_match_labels", labels, values)
+			ch <- m
 		}
 	}
+
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?
Adds a metrics configmap and the associated logic for watching/writing contents to a file. Also adds the ability to disable any metric by specifying it in the helm chart (see ). 

Disabling metrics takes the form of the `metricsConfigs.disabledMetrics` field in the helm chart:
```
kubecostProductConfigs:
  ...
  metricsConfigs:
    disabledMetrics:
      - <metric-to-be-disabled>
      - <metric-to-be-disabled>
      etc.
```
This should allow for emission of any metric to be disabled, as this PR adds logic to simply exclude initialization of that metric in the metrics emitter.

## Does this PR rely on any other PRs?

- https://github.com/kubecost/cost-analyzer-helm-chart/pull/1243
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Adds support for disabling emission of specific metrics in the helm chart

## Links to Issues or ZD tickets this PR addresses or fixes

- fixes https://github.com/kubecost/cost-analyzer-helm-chart/issues/1200
- 


## How was this PR tested?
Manually by disabling and reenabling metrics, and examining prometheus.

## Have you made an update to documentation?
No.
